### PR TITLE
fix(bash): keep interactive commands from hanging the TUI

### DIFF
--- a/internal/proc/proc_unix.go
+++ b/internal/proc/proc_unix.go
@@ -21,6 +21,22 @@ func SetProcessGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr.Setpgid = true
 }
 
+// DetachSession configures cmd so the spawned process starts in a new session
+// with no controlling terminal. Programs that try to read from /dev/tty — a
+// password/confirmation prompt, an editor, ssh — then fail fast with ENXIO
+// instead of stealing the parent TUI's terminal and hanging. The session
+// leader is also a new process-group leader (pgid == pid), so TerminateGroup
+// still reaches the whole group; there is no need to also call SetProcessGroup.
+func DetachSession(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setsid = true
+}
+
 // TerminateGroup sends sig to the process group led by cmd. The cmd's
 // in-memory Process handle is used to derive the PGID rather than a raw PID,
 // so this is safe against PID reuse. A missing process (ESRCH) is treated as

--- a/internal/proc/proc_windows.go
+++ b/internal/proc/proc_windows.go
@@ -14,6 +14,11 @@ import (
 // Callers should not assume grandchild cleanup works on Windows.
 func SetProcessGroup(cmd *exec.Cmd) {}
 
+// DetachSession is a no-op on Windows: there is no controlling-terminal /
+// /dev/tty concept to detach from, and session creation is out of scope for
+// this package.
+func DetachSession(cmd *exec.Cmd) {}
+
 // TerminateGroup terminates cmd's direct child process. Windows has no
 // signal-based group termination, so sig is ignored and we call Process.Kill,
 // which maps to TerminateProcess. Because we use the handle the standard

--- a/internal/tool/fs/bash.go
+++ b/internal/tool/fs/bash.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -113,6 +114,14 @@ func (t *BashTool) ExecuteApproved(ctx context.Context, params map[string]any, c
 
 	err := cmd.Run()
 	duration := time.Since(start)
+
+	// A command that backgrounds a child inheriting the output pipe (e.g.
+	// "./server &") exits 0, but WaitDelay then fires because that child keeps
+	// the pipe open. bash itself finished cleanly, so treat it as success
+	// rather than surfacing the "WaitDelay expired" error as a failure.
+	if errors.Is(err, exec.ErrWaitDelay) && cmd.ProcessState != nil && cmd.ProcessState.Success() {
+		err = nil
+	}
 
 	output := stdout.String()
 	errOutput := stderr.String()
@@ -406,12 +415,15 @@ func SetEnvProvider(fn func(context.Context) []string) {
 func bashEnv(ctx context.Context) []string {
 	env := os.Environ()
 	// Nudge common tools onto their non-interactive path so they fail fast
-	// rather than block on a prompt. Appended (not overriding) so a caller that
-	// deliberately set these keeps their value.
-	env = append(env,
-		"GIT_TERMINAL_PROMPT=0",
-		"DEBIAN_FRONTEND=noninteractive",
-	)
+	// rather than block on a prompt. Set each only when the caller hasn't
+	// already: os/exec keeps the last of duplicate keys, so an unconditional
+	// append would silently override a value the user deliberately set.
+	if _, ok := os.LookupEnv("GIT_TERMINAL_PROMPT"); !ok {
+		env = append(env, "GIT_TERMINAL_PROMPT=0")
+	}
+	if _, ok := os.LookupEnv("DEBIAN_FRONTEND"); !ok {
+		env = append(env, "DEBIAN_FRONTEND=noninteractive")
+	}
 	if fn, ok := extraEnvProvider.Load().(func(context.Context) []string); ok && fn != nil {
 		env = append(env, fn(ctx)...)
 	}

--- a/internal/tool/fs/bash.go
+++ b/internal/tool/fs/bash.go
@@ -95,6 +95,18 @@ func (t *BashTool) ExecuteApproved(ctx context.Context, params map[string]any, c
 		cmd.Env = append(cmd.Env, cwdFileEnvVar+"="+trackedFile)
 	}
 
+	// Detach from the controlling terminal so an interactive command grabs no
+	// tty and fails fast instead of hanging the TUI. On timeout/cancel, tear
+	// down the whole process group (not just bash) so a child that grabbed the
+	// terminal — an editor, ssh — can't outlive the deadline; WaitDelay is the
+	// backstop for a grandchild that inherited the output pipe and won't close.
+	proc.DetachSession(cmd)
+	cmd.Cancel = func() error {
+		_ = proc.TerminateGroup(cmd, syscall.SIGKILL)
+		return nil
+	}
+	cmd.WaitDelay = 5 * time.Second
+
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -144,9 +156,10 @@ func (t *BashTool) ExecuteApproved(ctx context.Context, params map[string]any, c
 		// Check if it's a timeout
 		if ctx.Err() == context.DeadlineExceeded {
 			return toolresult.ToolResult{
-				Success:      false,
-				Output:       fullOutput,
-				Error:        "command timed out after " + timeout.String(),
+				Success: false,
+				Output:  fullOutput,
+				Error: "command timed out after " + timeout.String() +
+					" — if it was waiting for interactive input, re-run with a non-interactive flag (e.g. -y, -m, BatchMode=yes) or supply input inline",
 				HookResponse: hookResponse,
 				Metadata: toolresult.ResultMetadata{
 					Title:     t.Name(),
@@ -228,9 +241,11 @@ func (t *BashTool) executeBackground(ctx context.Context, command, description, 
 	cmd.Dir = cwd
 	cmd.Env = bashEnv(ctx)
 
-	// Place the child in its own process group so cancellation can take down
+	// Start the child in its own session: detached from the controlling
+	// terminal (so an interactive command fails fast instead of grabbing the
+	// tty) and the leader of a new process group, so cancellation can take down
 	// any descendants it spawns (Unix). No-op on Windows.
-	proc.SetProcessGroup(cmd)
+	proc.DetachSession(cmd)
 	// Override the default exec.CommandContext cancel, which only kills the
 	// direct child via Process.Kill — without this, context-cancel of the
 	// background task leaves any grandchildren the bash shell spawned alive.
@@ -390,6 +405,13 @@ func SetEnvProvider(fn func(context.Context) []string) {
 
 func bashEnv(ctx context.Context) []string {
 	env := os.Environ()
+	// Nudge common tools onto their non-interactive path so they fail fast
+	// rather than block on a prompt. Appended (not overriding) so a caller that
+	// deliberately set these keeps their value.
+	env = append(env,
+		"GIT_TERMINAL_PROMPT=0",
+		"DEBIAN_FRONTEND=noninteractive",
+	)
 	if fn, ok := extraEnvProvider.Load().(func(context.Context) []string); ok && fn != nil {
 		env = append(env, fn(ctx)...)
 	}

--- a/internal/tool/schema_base.go
+++ b/internal/tool/schema_base.go
@@ -273,6 +273,14 @@ IMPORTANT: Avoid using this tool to run grep, find, cat, head, tail, sed, awk, o
 - Edit files: Use Edit (NOT sed/awk)
 - Write files: Use Write (NOT echo/cat with redirection)
 
+Non-interactive only:
+Commands run with no controlling terminal and no stdin, so anything that waits
+for interactive input — a REPL, an editor, a password/confirmation prompt —
+cannot receive it and will hang until it times out. Pass a non-interactive flag
+or supply input inline instead: use "git commit -m ..." (not a bare "git
+commit"), "npm init -y", "ssh -o BatchMode=yes", "apt-get -y", or feed input via
+a heredoc or a --stdin-style flag.
+
 You may specify an optional timeout in milliseconds (up to 600000ms / 10 minutes). By default, your command will timeout after 120000ms (2 minutes).
 You can use the run_in_background parameter to run the command in the background. You will be notified when it finishes.`,
 	Parameters: map[string]any{


### PR DESCRIPTION
Interactive commands run by the Bash tool (an editor, `ssh`, a password/confirmation prompt) grabbed the parent TUI's controlling terminal and hung until timeout — and the foreground path then only killed `bash`, leaving the child that held the terminal alive past the deadline.

- Start `bash` in a new session (`setsid`) so `/dev/tty` access fails fast instead of stealing the TUI's terminal; on timeout/cancel tear down the whole process group, with a `WaitDelay` backstop for inherited pipes. Foreground now matches the background path.
- Nudge tools onto their non-interactive path via `GIT_TERMINAL_PROMPT=0` and `DEBIAN_FRONTEND=noninteractive`.
- Steer the model: the Bash schema notes commands are non-interactive, and the timeout error suggests a non-interactive flag.