### PR TITLE
feat(desktop): add opt-in full-screen conversation surface

### DIFF
--- a/docs/concepts/rendering.md
+++ b/docs/concepts/rendering.md
@@ -13,10 +13,94 @@ becomes state; this doc covers how state becomes characters on screen.
 > the alt-screen region. The "rendering pipeline" below is entirely
 > string composition; the terminal does the actual drawing.
 
+## Rendering modes: how a TUI can own a terminal
+
+A terminal program has three ways to put content on screen, and the
+choice decides who owns the history — the terminal, or the app:
+
+| Mode | Who owns the screen | History lives in | Scrolling |
+| --- | --- | --- | --- |
+| **Plain streaming** — write lines to stdout, no managed region | nobody | terminal | terminal |
+| **Inline** — manage the bottom N lines, push finished output above | app owns the bottom strip, terminal owns everything above | terminal | terminal |
+| **Alt-screen** — switch to the alternate buffer and own every cell | app | app | app |
+
+**San's native mode is inline**, and it is what the rest of this document
+describes. Bubble Tea manages only the bottom strip (the live tail plus
+the input area); every finished message is pushed above it with
+`tea.Println`, which is `insertAbove` — it scrolls the terminal and
+writes the lines into the terminal's own scrollback.
+
+That choice buys a lot, and all of it comes from the terminal rather
+than from code San has to write:
+
+- **The transcript is real terminal output.** Native scroll, native
+  search (⌘F), native selection and copy, and it survives the session —
+  quit San and the conversation is still in the buffer, next to the
+  `git status` you ran before it.
+- **Cheap repaints.** Only the bottom strip is redrawn per frame, no
+  matter how long the conversation is. Committed messages are never
+  rendered again.
+- **It composes with the terminal.** Output interleaves normally with
+  anything else that prints, and tmux/iTerm features work as usual.
+
+What inline gives up is the flip side of the same property: **once a
+line is committed, San can never touch it again.**
+
+- A resize cannot re-wrap it — glamour wrapped it at the old width, and
+  the terminal can only re-flow, not re-render.
+- A theme switch cannot re-color it.
+- Nothing in-app can scroll, fold, or search it, because it is not the
+  app's memory any more.
+- The live region is capped at the terminal height. A long streaming
+  reply is truncated to its last lines (`tailLines`) until it commits.
+
+### The desktop surface
+
+The desktop ([`internal/app/desktop`](../../internal/app/desktop)) is
+the alt-screen mode, offered as an **opt-in second surface** rather than
+a replacement — Ctrl-G toggles it. San takes the whole screen and draws
+the transcript into a viewport it controls, so the history is the app's
+data again:
+
+- **The whole conversation scrolls in-app** (pgup/pgdown/home/end),
+  independent of the terminal's scrollback position.
+- **Nothing is truncated.** A reply taller than the screen is scrollable
+  while it streams, instead of showing only its tail.
+- **Committed output stays re-renderable** — it is redrawn from
+  `m.conv.Messages` every time, so width and theme changes apply to all
+  of it, not just the tail.
+- **It is a frame, not a strip.** A stable full-screen rectangle is what
+  a multi-pane layout would need; the surface is built around a `Pane`
+  list for that reason, with the transcript as the first one.
+
+The cost is symmetrical: on the alt-screen there is no native scrollback
+to write to, so nothing the desktop draws survives in the terminal, and
+the transcript must be re-rendered by San instead of by the terminal.
+Neither mode dominates, which is why both exist.
+
+### How the two coexist
+
+They share every renderer — the desktop calls `RenderMessageRange`,
+`RenderActiveContent`, and `renderFooter`, the same functions the inline
+view calls, so the two surfaces read identically. What they cannot share
+is the terminal write: `insertAbove` scrolls and inserts rows into
+whichever buffer is current, so a `tea.Println` issued while the
+alt-screen is up would land inside the desktop's frame and be lost from
+the history below.
+
+One invariant handles that: **while the desktop owns the screen, the
+commit pipeline runs untouched but its terminal writes wait in the
+queue** (`scrollbackSuspended`). Commit offsets and `CommittedCount`
+advance exactly as they would inline, so nothing diverges; the queued
+chunks replay in order when the inline view comes back. The one thing
+the desktop renders differently is the *streaming* message: the inline
+view skips the prefix it already flushed to scrollback, and the desktop
+— which is covering that scrollback — draws the message whole.
+
 ## Mental model: two surfaces
 
-The terminal window has **two surfaces** during a session, and every
-rendered string ends up on exactly one of them:
+Within the inline mode, the terminal window has **two surfaces** during
+a session, and every rendered string ends up on exactly one of them:
 
 ```
 m.conv.Messages = [ msg0, msg1, msg2, msg3 | msg4, msg5 ]
@@ -393,3 +477,5 @@ in [`internal/app/update_resize.go`](../../internal/app/update_resize.go):
 | `MDRenderer` lifecycle | [`internal/app/conv/model.go`](../../internal/app/conv/model.go) |
 | Scrollback commit | [`internal/app/model_scrollback.go`](../../internal/app/model_scrollback.go) |
 | Resize + reflow | [`internal/app/update_resize.go`](../../internal/app/update_resize.go) |
+| Desktop surface wiring (toggle, keys, transcript) | [`internal/app/desktop_surface.go`](../../internal/app/desktop_surface.go) |
+| Desktop window manager | [`internal/app/desktop/desktop.go`](../../internal/app/desktop/desktop.go) |

--- a/docs/concepts/rendering.zh.md
+++ b/docs/concepts/rendering.zh.md
@@ -12,9 +12,81 @@
 > 把它写到 alt-screen 区域之上。下面的"渲染管线"全程都是字符串组装；
 > 真正的"画"是终端干的。
 
+## 渲染模式：一个 TUI 可以怎样占用终端
+
+终端程序把内容显示到屏幕上只有三种方式，选哪种决定了**历史归谁所有**
+——归终端，还是归应用：
+
+| 模式 | 屏幕归谁 | 历史存在哪 | 谁负责滚动 |
+| --- | --- | --- | --- |
+| **纯流式输出**——直接往 stdout 写行，不管理任何区域 | 没人 | 终端 | 终端 |
+| **Inline**——只管理底部 N 行，写完的内容推到上方 | 应用管底部条，上方归终端 | 终端 | 终端 |
+| **Alt-screen**——切到备用缓冲区，接管每一个字符格 | 应用 | 应用 | 应用 |
+
+**San 原生用的是 inline**，本文后面讲的也都是它。Bubble Tea 只管理底部
+那一条（活跃尾巴 + 输入区）；每条写完的消息都用 `tea.Println` 推到上面
+去，也就是 `insertAbove`——它滚动终端，把这些行写进**终端自己的**
+scrollback。
+
+这个选择换来了很多东西，而且全是终端白送的，不用 San 自己写：
+
+- **transcript 就是真正的终端输出。** 原生滚动、原生搜索（⌘F）、原生
+  选中复制，而且会话结束后还在——退出 San，对话仍然躺在缓冲区里，就在
+  你之前跑的那条 `git status` 旁边。
+- **重绘很便宜。** 不管对话多长，每帧只重画底部那一条；已 commit 的
+  消息永远不会被再渲染一次。
+- **和终端天然共存。** 输出能和其它程序的输出正常交错，tmux/iTerm 的
+  各种功能照常可用。
+
+inline 放弃的东西，正是同一个性质的反面：**一行内容一旦 commit，San
+就再也碰不到它了。**
+
+- resize 无法重新折行——glamour 是按旧宽度排的版，终端只能 re-flow，
+  没法重新渲染。
+- 切主题无法给它重新上色。
+- 应用内没法滚动、折叠或搜索它，因为它已经不属于应用的内存了。
+- 活跃区受终端高度限制。一条很长的流式回复在 commit 之前只能显示末尾
+  几行（`tailLines` 截断）。
+
+### desktop 表面
+
+desktop（[`internal/app/desktop`](../../internal/app/desktop)）就是
+alt-screen 模式，但它是**可选的第二块表面**，不是替代品——Ctrl-G 切换。
+San 接管整个屏幕，把 transcript 画进自己控制的 viewport，于是历史重新
+变回应用的数据：
+
+- **整段对话在应用内滚动**（pgup/pgdown/home/end），和终端 scrollback
+  的位置互不相干。
+- **不再被截断。** 比屏幕还高的回复在流式过程中就能滚动查看，而不是
+  只看得到尾巴。
+- **已 commit 的输出仍然可被重新渲染**——每次都是从 `m.conv.Messages`
+  重画的，所以宽度和主题变化对全部内容生效，不只是尾巴。
+- **它是一个"框"，不是一条"带"。** 稳定的全屏矩形正是多面板布局需要的
+  东西；这个表面因此是围绕一组 `Pane` 建的，transcript 只是第一个。
+
+代价是对称的：alt-screen 上没有原生 scrollback 可写，所以 desktop 画的
+东西不会留在终端里，而且 transcript 得由 San 自己重渲染，不能靠终端。
+两种模式谁也压不倒谁，所以两个都留着。
+
+### 两者如何共存
+
+它们共用全部渲染函数——desktop 调的是 `RenderMessageRange`、
+`RenderActiveContent`、`renderFooter`，和 inline 视图调的一模一样，所以
+两块表面看起来完全一致。唯一不能共用的是**往终端的那次写入**：
+`insertAbove` 会往当前缓冲区滚动并插入行，因此 alt-screen 打开时发出的
+`tea.Println` 会落进 desktop 的画面里，同时从下面的历史里丢失。
+
+一条不变式解决了这件事：**desktop 占屏期间，commit 管线照常运行，只是
+它往终端的写入在队列里等着**（`scrollbackSuspended`）。commit 偏移量和
+`CommittedCount` 的推进和 inline 时完全一样，所以状态不会分叉；排队的
+分块会在回到 inline 视图时按序补写。desktop 唯一渲染得不一样的是**正在
+流式输出的那条消息**：inline 视图会跳过它已经 flush 到 scrollback 的
+前缀，而 desktop 正盖着那段 scrollback，所以它把整条消息完整画出来。
+
 ## 心智模型：两块表面
 
-会话期间终端窗口有**两块表面**，每条渲染出的字符串都恰好落到其中一块：
+在 inline 模式内部，会话期间终端窗口有**两块表面**，每条渲染出的字符串
+都恰好落到其中一块：
 
 ```
 m.conv.Messages = [ msg0, msg1, msg2, msg3 | msg4, msg5 ]
@@ -376,3 +448,5 @@ CommittedCount = 3                           // 追上
 | `MDRenderer` 生命周期 | [`internal/app/conv/model.go`](../../internal/app/conv/model.go) |
 | Scrollback commit | [`internal/app/model_scrollback.go`](../../internal/app/model_scrollback.go) |
 | Resize + reflow | [`internal/app/update_resize.go`](../../internal/app/update_resize.go) |
+| desktop 表面接线（切换、按键、transcript） | [`internal/app/desktop_surface.go`](../../internal/app/desktop_surface.go) |
+| desktop 窗口管理 | [`internal/app/desktop/desktop.go`](../../internal/app/desktop/desktop.go) |

--- a/docs/reference/package-map.md
+++ b/docs/reference/package-map.md
@@ -17,6 +17,7 @@ the assignment changes.
 | --- | --- | --- |
 | `internal/app` | `app` | Bubble Tea root model, service composition, event routing, session restore, app lifecycle. |
 | `internal/app/conv` | `app` | Conversation rendering state and agent outbox observation. |
+| `internal/app/desktop` | `app` | Alt-screen full-screen surface: scrollable transcript viewport above the input strip. |
 | `internal/app/input` | `app` | Text input, selectors, approvals, user-input flow. |
 | `internal/app/trigger` | `app` | System triggers such as cron and async hook polling. |
 | `internal/broker` | `feature` | Routes messages between agents: addresses keyed by agent id, for main↔subagent messages and completions. |

--- a/internal/app/desktop/desktop.go
+++ b/internal/app/desktop/desktop.go
@@ -1,0 +1,107 @@
+// Package desktop implements San's full-screen surface: an alt-screen reader
+// that shows the same conversation transcript and input strip as the inline
+// view, but owns the whole screen so the entire history scrolls inside the
+// managed frame — where the inline view instead hands finished output to the
+// terminal's native scrollback and can no longer touch it.
+//
+// It is deliberately chrome-light: one scrollable content viewport above the
+// footer (the app's input bar). Nothing here renders conversation content: the
+// app supplies a Pane, the manager gives it a width and scrolls the result. The
+// package holds no reference to the root model and imports no bubbletea — it is
+// a plain view component, driven entirely from internal/app/desktop_surface.go.
+package desktop
+
+import (
+	"strings"
+
+	"charm.land/bubbles/v2/viewport"
+	"charm.land/lipgloss/v2"
+)
+
+// Pane is the content the app supplies each frame — today the conversation
+// transcript, rendered at the surface width. Sig is a cheap change signature
+// that gates the expensive rebuild: same signature, same size, no re-render.
+// A second window is a second Pane, not a change to this file.
+type Pane struct {
+	ID     string
+	Sig    string
+	Render func(w, h int) string
+}
+
+// Manager owns the alt-screen reader: a single scrollable content viewport plus
+// the footer. It is a value held by the root model.
+type Manager struct {
+	w, h   int
+	vp     viewport.Model
+	footer string
+	sig    string
+	cw, ch int
+	ready  bool
+}
+
+func New() Manager { return Manager{vp: viewport.New()} }
+
+func (mgr *Manager) Resize(w, h int) { mgr.w, mgr.h = w, h }
+
+// SetFooter sets the bottom strip (the input bar), drawn below the transcript.
+// Call it before SetContent: the footer's height is what's left for the
+// transcript.
+func (mgr *Manager) SetFooter(s string) { mgr.footer = s }
+
+// ContentHeight reports how many rows the transcript occupies, which is also the
+// row the footer starts on — the app needs it to place the terminal cursor
+// inside the composer. Valid after SetContent.
+func (mgr *Manager) ContentHeight() int { return mgr.ch }
+
+// SetContent syncs the scrollable transcript, rebuilding only when the signature
+// or the content size changes — so a markdown re-render happens on real change,
+// not every frame. The reader stays pinned to the bottom when it was already
+// there, so streaming output keeps the latest line in view; once the reader has
+// scrolled up, new content no longer yanks it back down.
+func (mgr *Manager) SetContent(p Pane) {
+	h := max(mgr.h-footerLines(mgr.footer), 1)
+	if mgr.ready && mgr.sig == p.Sig && mgr.cw == mgr.w && mgr.ch == h {
+		return
+	}
+	atBottom := !mgr.ready || mgr.vp.AtBottom()
+	mgr.sig, mgr.cw, mgr.ch, mgr.ready = p.Sig, mgr.w, h, true
+	mgr.vp.SetWidth(mgr.w)
+	mgr.vp.SetHeight(h)
+	mgr.vp.SetContent(p.Render(mgr.w, h))
+	if atBottom {
+		mgr.vp.GotoBottom()
+	}
+}
+
+// Render composes the scrollable transcript above the footer — the full-screen
+// counterpart of the inline view. The result is exactly the surface height, so
+// it fills the alt-screen without pushing rows off it.
+func (mgr *Manager) Render() string {
+	if mgr.w < 1 || mgr.h < 1 {
+		return ""
+	}
+	if footerLines(mgr.footer) > 0 {
+		return lipgloss.JoinVertical(lipgloss.Left, mgr.vp.View(), mgr.footer)
+	}
+	return mgr.vp.View()
+}
+
+// Scrolling is exposed as explicit methods rather than by forwarding keys into
+// the viewport's own Update: its default keymap claims bare letters (f, b, j, k,
+// space) and ctrl+u/ctrl+d, which belong to the composer and to the app's own
+// shortcuts. The app decides which keys the reader gets; see handleDesktopKey.
+
+func (mgr *Manager) PageUp()   { mgr.vp.ScrollUp(mgr.vp.Height()) }
+func (mgr *Manager) PageDown() { mgr.vp.ScrollDown(mgr.vp.Height()) }
+func (mgr *Manager) GotoTop()  { mgr.vp.GotoTop() }
+
+// GotoBottom jumps to the latest output and re-pins the reader, so streaming
+// resumes following the tail.
+func (mgr *Manager) GotoBottom() { mgr.vp.GotoBottom() }
+
+func footerLines(s string) int {
+	if s == "" {
+		return 0
+	}
+	return strings.Count(s, "\n") + 1
+}

--- a/internal/app/desktop/desktop_test.go
+++ b/internal/app/desktop/desktop_test.go
@@ -1,0 +1,103 @@
+package desktop
+
+import (
+	"strings"
+	"testing"
+)
+
+func newSurface(w, h int, footer string) Manager {
+	mgr := New()
+	mgr.Resize(w, h)
+	mgr.SetFooter(footer)
+	return mgr
+}
+
+func pane(sig, body string) Pane {
+	return Pane{ID: "conversation", Sig: sig, Render: func(int, int) string { return body }}
+}
+
+// The frame is exactly the surface height, so it fills the alt-screen without
+// pushing rows off it, and the footer starts on the row ContentHeight reports —
+// which is what the app uses to place the terminal cursor.
+func TestRenderFillsSurfaceHeight(t *testing.T) {
+	footer := "───\n❭ prompt\n───"
+	mgr := newSurface(40, 12, footer)
+	mgr.SetContent(pane("a", "one\ntwo"))
+
+	frame := mgr.Render()
+	if got := strings.Count(frame, "\n") + 1; got != 12 {
+		t.Fatalf("frame height = %d, want 12", got)
+	}
+	if got := mgr.ContentHeight(); got != 12-3 {
+		t.Fatalf("ContentHeight = %d, want %d", got, 12-3)
+	}
+	lines := strings.Split(frame, "\n")
+	if !strings.HasPrefix(lines[mgr.ContentHeight()], "───") {
+		t.Fatalf("footer does not start at row %d: %q", mgr.ContentHeight(), lines[mgr.ContentHeight()])
+	}
+}
+
+// The signature gates the expensive rebuild: same signature, no re-render.
+func TestSetContentRebuildsOnlyOnChange(t *testing.T) {
+	mgr := newSurface(40, 12, "───")
+	renders := 0
+	build := func(sig string) Pane {
+		return Pane{ID: "conversation", Sig: sig, Render: func(int, int) string {
+			renders++
+			return "body"
+		}}
+	}
+
+	mgr.SetContent(build("a"))
+	mgr.SetContent(build("a"))
+	if renders != 1 {
+		t.Fatalf("renders = %d after an unchanged signature, want 1", renders)
+	}
+
+	mgr.SetContent(build("b"))
+	if renders != 2 {
+		t.Fatalf("renders = %d after a changed signature, want 2", renders)
+	}
+
+	// A resize invalidates too — the content has to re-wrap.
+	mgr.Resize(60, 12)
+	mgr.SetContent(build("b"))
+	if renders != 3 {
+		t.Fatalf("renders = %d after a resize, want 3", renders)
+	}
+}
+
+// A reader parked at the bottom keeps following streaming output; one that has
+// scrolled up stays put, and GotoBottom re-pins it.
+func TestScrollPinning(t *testing.T) {
+	tall := strings.Repeat("line\n", 200)
+	mgr := newSurface(40, 12, "───")
+	mgr.SetContent(pane("a", tall))
+
+	bottom := mgr.Render()
+	mgr.SetContent(pane("b", tall+"more\n"))
+	if mgr.Render() == bottom {
+		t.Fatal("pinned reader did not follow new content")
+	}
+
+	mgr.PageUp()
+	scrolled := mgr.Render()
+	mgr.SetContent(pane("c", tall+"more\nand more\n"))
+	if mgr.Render() != scrolled {
+		t.Fatal("scrolled-up reader was yanked to the bottom by new content")
+	}
+
+	mgr.GotoBottom()
+	if mgr.Render() == scrolled {
+		t.Fatal("GotoBottom did not re-pin the reader")
+	}
+}
+
+// A surface with no size yet renders nothing rather than a stray frame.
+func TestRenderWithoutSizeIsEmpty(t *testing.T) {
+	mgr := New()
+	mgr.SetFooter("───")
+	if got := mgr.Render(); got != "" {
+		t.Fatalf("Render() = %q, want empty", got)
+	}
+}

--- a/internal/app/desktop_surface.go
+++ b/internal/app/desktop_surface.go
@@ -1,0 +1,302 @@
+// Desktop surface wiring: the seam between the root model and the alt-screen
+// reader in internal/app/desktop. The desktop shows the same transcript and the
+// same input strip as the inline view — reusing the very same render functions —
+// but full-screen and scrollable, so the whole history stays inside the managed
+// frame instead of being handed to the terminal's native scrollback.
+//
+// Everything the surface needs lives here: the Surface enum, its model state,
+// the toggle, the repaint heartbeat, the per-frame content snapshot, and key
+// routing. The inline path is left alone; the only thing the desktop asks of it
+// is that scrollback writes wait until the screen is handed back (see
+// scrollbackSuspended).
+package app
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/genai-io/san/internal/app/conv"
+	"github.com/genai-io/san/internal/app/desktop"
+	"github.com/genai-io/san/internal/core"
+)
+
+// Surface selects which presentation the root model renders.
+type Surface int
+
+const (
+	// SurfaceInline is the default: the live tail renders inline and finished
+	// output is committed to the terminal's native scrollback.
+	SurfaceInline Surface = iota
+	// SurfaceDesktop is the opt-in full-screen reader: the same content, but San
+	// owns the whole screen and the full history scrolls within it.
+	SurfaceDesktop
+)
+
+// desktopSurface is all the state the full-screen surface needs, in one struct
+// so the root model carries a single field and every desktop concern stays in
+// this file.
+type desktopSurface struct {
+	manager desktop.Manager
+
+	// ticking guards the repaint heartbeat to a single chain, so repeated
+	// toggles don't stack heartbeats.
+	ticking bool
+
+	// md is the surface's own markdown renderer, kept off m.conv.MDRenderer so a
+	// full-transcript render never contends with the live view. Rebuilt on width
+	// change.
+	md      *conv.MDRenderer
+	mdWidth int
+
+	// history caches the rendered committed prefix, keyed by everything that can
+	// change it. Without it every streamed chunk would re-run glamour over the
+	// entire conversation, since the desktop — unlike the inline view — has to
+	// draw the history itself.
+	history    string
+	historyKey string
+
+	// inputRow is where renderFooter placed the composer within the footer strip,
+	// carried over so the view can put the terminal cursor there.
+	inputRow int
+}
+
+func newDesktopSurface() desktopSurface {
+	return desktopSurface{manager: desktop.New()}
+}
+
+// desktopTickInterval paces the repaint heartbeat: the surface redraws on its
+// own so spinners and elapsed timers keep moving between agent events.
+const desktopTickInterval = 80 * time.Millisecond
+
+type desktopTickMsg struct{}
+
+// desktopFlushMsg is posted by exitDesktop and handled one loop iteration later,
+// after the inline view has repainted and the renderer has left the alt-screen —
+// so the held scrollback writes land in the normal buffer, not on the alt-screen
+// that is about to be discarded.
+type desktopFlushMsg struct{}
+
+func desktopTick() tea.Cmd {
+	return tea.Tick(desktopTickInterval, func(time.Time) tea.Msg { return desktopTickMsg{} })
+}
+
+// desktopActive reports whether the desktop is both selected and owns the frame.
+// An overlay (slash-command picker, approval/question modal) is an inline-surface
+// panel, so while one is up the app falls back to the inline view and the desktop
+// resumes when it closes. View and the key router share this predicate, keeping
+// the app's rule that the panel owning the keyboard is the one drawn on screen.
+func (m *model) desktopActive() bool {
+	if m.env.Surface != SurfaceDesktop {
+		return false
+	}
+	_, hasOverlay := m.activeOverlay()
+	return !hasOverlay
+}
+
+// scrollbackSuspended reports whether writes to the terminal's native scrollback
+// must wait. Bubble Tea's insertAbove scrolls and inserts rows into whichever
+// buffer is current, so a tea.Println issued while the alt-screen is up would
+// land in the desktop's frame and be lost from the history below it.
+//
+// Only the terminal write waits — the commit pipeline itself runs untouched, so
+// commit offsets, CommittedCount, and the rendered blocks are identical on both
+// surfaces. The queue replays in order once the inline view is back, which is
+// why this stays true for the whole desktop session, including the moments an
+// overlay borrows the frame.
+func (m *model) scrollbackSuspended() bool {
+	return m.env.Surface == SurfaceDesktop
+}
+
+// enterDesktop switches to the desktop and starts the repaint heartbeat — one
+// chain only; it lapses in Update once we go back inline. The first frame needs
+// no priming here: View syncs the surface on the paint that follows this Update.
+func (m *model) enterDesktop() tea.Cmd {
+	m.env.Surface = SurfaceDesktop
+	if m.desktop.ticking {
+		return nil
+	}
+	m.desktop.ticking = true
+	return desktopTick()
+}
+
+// exitDesktop returns to the inline surface and schedules the backlog flush.
+func (m *model) exitDesktop() tea.Cmd {
+	m.env.Surface = SurfaceInline
+	return func() tea.Msg { return desktopFlushMsg{} }
+}
+
+// onDesktopTick keeps the heartbeat alive while the surface is selected. Each
+// tick is just a repaint trigger — View does the work.
+func (m *model) onDesktopTick() tea.Cmd {
+	if m.env.Surface == SurfaceDesktop {
+		return desktopTick()
+	}
+	m.desktop.ticking = false
+	return nil
+}
+
+// onDesktopFlush releases everything scrollbackSuspended held back, now that the
+// inline view has repainted: the print queue restarts where it left off, and any
+// message that finished during the desktop session is committed behind it.
+func (m *model) onDesktopFlush() tea.Cmd {
+	return tea.Sequence(
+		m.resumeScrollbackPrints(),
+		tea.Batch(m.CommitMessages()...),
+	)
+}
+
+// desktopView renders the full-screen frame.
+func (m *model) desktopView() tea.View {
+	m.syncDesktop()
+	v := tea.NewView(m.desktop.manager.Render())
+	// San owns the whole screen here; the native scrollback below is left intact
+	// and reappears untouched on exit. No mouse tracking: capturing the mouse
+	// would disable the terminal's own text selection and copy.
+	v.AltScreen = true
+	v.Cursor = m.inputCursor(m.desktop.manager.ContentHeight() + m.desktop.inputRow)
+	return v
+}
+
+// syncDesktop reconciles the surface's size, transcript, and input strip with the
+// live model. Cheap to call every frame: the transcript sits behind a signature
+// inside the manager, so the heavy render runs only on real change.
+func (m *model) syncDesktop() {
+	separator := conv.SeparatorStyle.Render(strings.Repeat("─", m.env.Width))
+	footer, inputRow := m.renderFooter(separator)
+	m.desktop.inputRow = inputRow
+
+	m.desktop.manager.Resize(m.env.Width, m.env.Height)
+	m.desktop.manager.SetFooter(footer)
+	m.desktop.manager.SetContent(desktop.Pane{
+		ID:     "conversation",
+		Sig:    m.desktopSig(),
+		Render: func(w, _ int) string { return m.renderTranscriptAt(w) },
+	})
+}
+
+// desktopSig is the manager's rebuild key: it has to move whenever the rendered
+// transcript would differ. Width is tracked by the manager itself.
+func (m *model) desktopSig() string {
+	lastContent, lastThinking := 0, 0
+	if n := len(m.conv.Messages); n > 0 {
+		lastContent = len(m.conv.Messages[n-1].Content)
+		lastThinking = len(m.conv.Messages[n-1].Thinking)
+	}
+	// The spinner frame is part of the key: between chunks — while a tool runs —
+	// nothing else moves, and without it the live tail's spinner and elapsed
+	// timers would freeze on screen.
+	blink := 0
+	if m.needsSpinner() {
+		blink = m.conv.Spinner.Frame()
+	}
+	return fmt.Sprintf("%d|%d|%d|%d|%d|%d",
+		len(m.conv.Messages), m.conv.CommittedCount,
+		lastContent, lastThinking, m.expandedCommittedCount(), blink)
+}
+
+// renderTranscriptAt renders the whole conversation at the given width, reusing
+// the inline renderers so both surfaces read identically. The split mirrors the
+// inline view: the committed prefix is rendered statically (it is what inline
+// hands to native scrollback), while the active tail goes through
+// RenderActiveContent + renderChatSection — the same path that drives the live
+// spinner and running-tool rows above the inline input.
+func (m *model) renderTranscriptAt(width int) string {
+	params := m.desktopParams(width)
+
+	parts := make([]string, 0, 2)
+	if history := m.desktopHistory(params, width); strings.TrimSpace(history) != "" {
+		parts = append(parts, history)
+	}
+	live := m.renderChatSection(conv.RenderActiveContent(params), m.renderTrackerList())
+	if strings.TrimSpace(live) != "" {
+		parts = append(parts, live)
+	}
+	return strings.Join(parts, "\n")
+}
+
+// desktopParams builds the render context for the surface: the inline width and
+// renderer are swapped for the surface's own, and the streaming message's commit
+// offsets are cleared.
+//
+// Those offsets exist so the inline view skips the prefix already flushed to
+// native scrollback (see FlushStreamingBlocks). The desktop covers that
+// scrollback, so honouring them would open a hole in the middle of the message
+// the user is watching. Only the uncommitted tail can carry offsets, so the copy
+// is a couple of messages, and it is a copy precisely so the inline surface's own
+// bookkeeping stays untouched.
+func (m *model) desktopParams(width int) conv.RenderContext {
+	if m.desktop.md == nil || m.desktop.mdWidth != width {
+		m.desktop.md = conv.NewMDRenderer(width)
+		m.desktop.mdWidth = width
+		m.desktop.historyKey = "" // rebuild the cache through the new renderer
+	}
+
+	params := m.messageRenderParams()
+	params.Width = width
+	params.MDRenderer = m.desktop.md
+
+	if n := len(params.Messages); n > params.CommittedCount {
+		whole := make([]core.ChatMessage, n)
+		copy(whole, params.Messages)
+		for i := params.CommittedCount; i < n; i++ {
+			whole[i].ResetStreamCommit()
+		}
+		params.Messages = whole
+	}
+	return params
+}
+
+// desktopHistory renders messages [0, CommittedCount) — the part the inline
+// surface freezes into native scrollback — and caches it, since only a new
+// commit, a resize, or an expand/collapse toggle can change it.
+func (m *model) desktopHistory(params conv.RenderContext, width int) string {
+	key := fmt.Sprintf("%d|%d|%d", width, params.CommittedCount, m.expandedCommittedCount())
+	if m.desktop.historyKey == key {
+		return m.desktop.history
+	}
+	m.desktop.historyKey = key
+	m.desktop.history = conv.RenderMessageRange(params, 0, params.CommittedCount, false)
+	return m.desktop.history
+}
+
+// expandedCommittedCount fingerprints the expand/collapse state of the committed
+// range. Ctrl-O is the one thing that re-renders an already-committed message,
+// and every toggle it offers — one row, or all of them — moves this count.
+func (m *model) expandedCommittedCount() int {
+	n := 0
+	for i := 0; i < m.conv.CommittedCount && i < len(m.conv.Messages); i++ {
+		if m.conv.Messages[i].ToolCallsExpanded {
+			n++
+		}
+		if m.conv.Messages[i].Expanded {
+			n++
+		}
+	}
+	return n
+}
+
+// handleDesktopKey claims the keys the reader needs and nothing else: the exit
+// toggle and scrolling. Everything else — typing, Enter, Ctrl-C, Ctrl-O, history
+// — falls through to the normal chain, so the app behaves the same on both
+// surfaces. It is routed after the suggestion/queue overlays, which already own
+// pgup/pgdown/home/end while they are visible.
+func (m *model) handleDesktopKey(msg tea.KeyMsg) (tea.Cmd, bool) {
+	switch msg.String() {
+	case "ctrl+g":
+		return m.exitDesktop(), true
+	case "pgup":
+		m.desktop.manager.PageUp()
+	case "pgdown":
+		m.desktop.manager.PageDown()
+	case "home":
+		m.desktop.manager.GotoTop()
+	case "end":
+		m.desktop.manager.GotoBottom()
+	default:
+		return nil, false
+	}
+	return nil, true
+}

--- a/internal/app/desktop_surface_test.go
+++ b/internal/app/desktop_surface_test.go
@@ -1,0 +1,128 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/genai-io/san/internal/app/conv"
+	"github.com/genai-io/san/internal/app/input"
+	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/hook"
+	"github.com/genai-io/san/internal/subagent"
+	"github.com/genai-io/san/internal/todo"
+	"github.com/genai-io/san/internal/tool/perm"
+)
+
+func desktopTestModel() *model {
+	m := &model{
+		env:       env{Width: 100, Height: 24, Ready: true},
+		conv:      conv.NewModel(100),
+		desktop:   newDesktopSurface(),
+		userInput: input.New("", 100, nil, input.SelectorDeps{}),
+		services: services{
+			Subagent: subagent.NewRegistry(),
+			Tracker:  todo.NewStore(),
+			Hook:     hook.DefaultEngine(), // the footer's status line reads it
+		},
+	}
+	return m
+}
+
+// The desktop covers the terminal's native scrollback, so a message whose
+// completed blocks were already flushed there has to be drawn whole — honouring
+// the inline commit offsets would leave a hole in the middle of the reply the
+// user is watching. The inline path keeps skipping the flushed prefix.
+func TestDesktopRendersStreamingMessageWhole(t *testing.T) {
+	m := desktopTestModel()
+	m.conv.Stream.Active = true
+	m.conv.Messages = []core.ChatMessage{{
+		Role:    core.RoleAssistant,
+		Content: "FLUSHED_PREFIX\n\nLIVE_TAIL",
+		// The prefix is already in native scrollback (see FlushStreamingBlocks).
+		ContentCommittedLen: len("FLUSHED_PREFIX\n\n"),
+		BulletEmitted:       true,
+	}}
+
+	transcript := m.renderTranscriptAt(m.env.Width)
+	if !strings.Contains(transcript, "FLUSHED_PREFIX") {
+		t.Error("desktop transcript dropped the already-flushed prefix")
+	}
+	if !strings.Contains(transcript, "LIVE_TAIL") {
+		t.Error("desktop transcript dropped the live tail")
+	}
+
+	// The inline live tail still skips the prefix — the desktop's copy must not
+	// have rewritten the model's own commit bookkeeping.
+	if got := m.conv.Messages[0].ContentCommittedLen; got != len("FLUSHED_PREFIX\n\n") {
+		t.Errorf("inline commit offset = %d, want %d", got, len("FLUSHED_PREFIX\n\n"))
+	}
+	inline := conv.RenderActiveContent(m.messageRenderParams())
+	if strings.Contains(inline, "FLUSHED_PREFIX") {
+		t.Error("inline live tail redrew the prefix that is already in scrollback")
+	}
+}
+
+// While the desktop owns the screen the commit pipeline runs untouched — only
+// the terminal write waits, so nothing diverges between the two surfaces and
+// nothing is lost. Leaving replays the queue.
+func TestDesktopHoldsScrollbackWritesAndReplaysOnExit(t *testing.T) {
+	m := desktopTestModel()
+	m.enterDesktop()
+	if !m.scrollbackSuspended() {
+		t.Fatal("entering the desktop did not suspend scrollback writes")
+	}
+
+	m.conv.Messages = []core.ChatMessage{{Role: core.RoleAssistant, Content: "committed while full-screen"}}
+	if cmds := m.CommitMessages(); len(cmds) != 1 {
+		t.Fatalf("commit commands = %d, want 1 — the pipeline must keep running", len(cmds))
+	}
+	if m.conv.CommittedCount != 1 {
+		t.Fatalf("CommittedCount = %d, want 1 — commit bookkeeping must not diverge", m.conv.CommittedCount)
+	}
+	if len(m.flush.pendingPrints) != 1 {
+		t.Fatalf("queued prints = %d, want 1 — the write should be held, not dropped", len(m.flush.pendingPrints))
+	}
+
+	// The ready message is a no-op while the alt-screen is up: nothing is
+	// prepared for insertAbove and the chunk stays queued.
+	if _, cmd := m.Update(scrollbackPrintReadyMsg{id: m.flush.pendingPrints[0].id}); cmd != nil {
+		t.Fatal("a scrollback print was dispatched while the desktop owned the screen")
+	}
+	if m.flush.pendingPrints[0].current != "" {
+		t.Fatal("the held chunk was prepared for insertAbove anyway")
+	}
+
+	m.exitDesktop()
+	if m.scrollbackSuspended() {
+		t.Fatal("leaving the desktop did not resume scrollback writes")
+	}
+	if cmd := m.resumeScrollbackPrints(); cmd == nil {
+		t.Fatal("the held queue head was not re-posted on exit")
+	}
+}
+
+// An overlay is an inline-surface panel: while one is up the app falls back to
+// the inline view so the panel that owns the keyboard is the one on screen.
+func TestOverlayTakesTheFrameBackFromTheDesktop(t *testing.T) {
+	m := desktopTestModel()
+	m.enterDesktop()
+	if !m.desktopActive() {
+		t.Fatal("desktop should own the frame with no overlay up")
+	}
+
+	m.userInput.Approval.Show(&perm.PermissionRequest{ToolName: "Bash"}, m.env.Width, m.env.Height)
+
+	if _, ok := m.activeOverlay(); !ok {
+		t.Fatal("test setup: expected an active overlay")
+	}
+	if m.desktopActive() {
+		t.Error("desktop kept the frame while a modal owned the keyboard")
+	}
+	// The surface is still selected — it resumes once the modal closes.
+	if m.env.Surface != SurfaceDesktop {
+		t.Error("the overlay deselected the desktop surface instead of borrowing the frame")
+	}
+	if !m.scrollbackSuspended() {
+		t.Error("scrollback writes resumed mid-session while the desktop was still selected")
+	}
+}

--- a/internal/app/env.go
+++ b/internal/app/env.go
@@ -21,6 +21,9 @@ type env struct {
 	Height        int
 	Ready         bool
 	InitialPrompt string
+	// Surface selects the active presentation: the default inline scrollback
+	// view, or the opt-in full-screen desktop. See desktop_surface.go.
+	Surface Surface
 
 	// ── Provider (mutable — changes via SwitchProvider) ─────────
 	LLMProvider  llm.Provider

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -55,6 +55,7 @@ type model struct {
 	selfLearnStarts chan struct{}        // fork goroutine → Update loop: a review started (start the spinner)
 	systemInput     trigger.Model        // Source 3: system events (cron/hooks/watcher)
 	conv            conv.Model           // Agent Outbox: conversation + output rendering
+	desktop         desktopSurface       // Opt-in full-screen surface (ctrl+g); see desktop_surface.go
 	env             env                  // Shared app state: provider, session, permission, plan, config
 	services        services             // Domain service singletons, injected at construction
 	learnedStores   *learnedStoreContext // live cwd/settings source for /evolve inventories

--- a/internal/app/model_lifecycle.go
+++ b/internal/app/model_lifecycle.go
@@ -76,6 +76,7 @@ func newBaseModel() model {
 			},
 		}),
 		conv:                conv.NewModel(defaultWidth),
+		desktop:             newDesktopSurface(),
 		mainNotices:         make(chan mainNotice, 64),
 		selfLearnStarts:     make(chan struct{}, 8),
 		systemInput:         trigger.New(),

--- a/internal/app/model_scrollback.go
+++ b/internal/app/model_scrollback.go
@@ -293,6 +293,16 @@ func (f *flushState) queueScrollbackPrint(content string) tea.Cmd {
 	return printScrollback(pending.id)
 }
 
+// resumeScrollbackPrints restarts the queue after writes were held back (see
+// scrollbackSuspended): the ready message for the head was dropped while the
+// alt-screen was up, so it needs re-posting. Nothing pending, nothing to do.
+func (m *model) resumeScrollbackPrints() tea.Cmd {
+	if len(m.flush.pendingPrints) == 0 {
+		return nil
+	}
+	return printScrollback(m.flush.pendingPrints[0].id)
+}
+
 // finishScrollbackPrint completes only the in-flight queue head. A stale or
 // out-of-order done message is ignored; the next chunk or queued print cannot
 // start until the current Println has been processed.

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -115,6 +115,10 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case tea.WindowSizeMsg:
 		return m, m.handleWindowResize(msg)
+	case desktopTickMsg:
+		return m, m.onDesktopTick()
+	case desktopFlushMsg:
+		return m, m.onDesktopFlush()
 	case spinner.TickMsg:
 		// The /autopilot Mission dialog runs its own spinner while awaiting a
 		// reply. Ticks carry a per-spinner id, so a foreign tick returns a nil
@@ -287,6 +291,11 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case flushResultMsg:
 		return m, m.handleFlushResult(msg)
 	case scrollbackPrintReadyMsg:
+		if m.scrollbackSuspended() {
+			// The desktop owns the screen; this chunk waits in the queue and
+			// resumeScrollbackPrints re-posts it on the way back (desktop_surface.go).
+			return m, nil
+		}
 		// Bubble Tea's renderer barrier flushes the latest managed View before
 		// insertAbove. Sequence ensures completion is observed only after this
 		// chunk has been inserted.

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -55,6 +55,16 @@ func (m *model) routeKeypress(msg tea.KeyMsg) (tea.Cmd, bool) {
 		return c, ok
 	}
 
+	// The desktop surface claims only its own keys (exit + scrolling) and is
+	// routed here, below the overlays that already own pgup/pgdown/home/end while
+	// they are visible. Everything else falls through, so both surfaces share the
+	// same keyboard.
+	if m.desktopActive() {
+		if c, ok := m.handleDesktopKey(msg); ok {
+			return c, true
+		}
+	}
+
 	return m.handleTextareaShortcut(msg)
 }
 
@@ -91,6 +101,9 @@ func (m *model) handleTextareaShortcut(msg tea.KeyMsg) (tea.Cmd, bool) {
 	case "alt+t", "alt+T":
 		m.conv.ShowTasks = !m.conv.ShowTasks
 		return nil, true
+
+	case "ctrl+g":
+		return m.enterDesktop(), true
 
 	case "ctrl+o":
 		return m.handleCtrlO(), true

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -31,6 +31,9 @@ func (m *model) View() tea.View {
 	if frame, ok := m.scrollbackFrameForPrint(); ok {
 		return frame
 	}
+	if m.desktopActive() {
+		return m.desktopView() // full-screen surface; see desktop_surface.go
+	}
 	content, cursor := m.viewString()
 	v := tea.NewView(content)
 	v.Cursor = cursor


### PR DESCRIPTION
Add an opt-in full-screen "desktop" surface — an alt-screen reader — alongside the default inline scrollback view. Ctrl-G toggles it.

## Why a second surface

A terminal program has three ways to put content on screen, and the choice decides who owns the history:

| Mode | Who owns the screen | History lives in | Scrolling |
| --- | --- | --- | --- |
| **Plain streaming** — write lines to stdout | nobody | terminal | terminal |
| **Inline** — manage the bottom N lines, push finished output above | app owns the bottom strip | terminal | terminal |
| **Alt-screen** — own every cell | app | app | app |

**San is inline today.** Bubble Tea manages the bottom strip; finished messages go above it via `tea.Println` (`insertAbove`) and become ordinary terminal scrollback. That buys native scroll, native search, native selection/copy, output that survives the session, and repaints that cost the same no matter how long the conversation is.

The flip side is that **a committed line can never be touched again**: a resize can't re-wrap it, a theme switch can't re-color it, nothing in-app can scroll or fold it, and the live region is capped at the terminal height — a long streaming reply shows only its tail until it commits.

The desktop is the alt-screen mode, offered as a second surface rather than a replacement:

- the whole conversation scrolls in-app (pgup/pgdown/home/end), independent of the terminal
- nothing is truncated — a reply taller than the screen is scrollable while it streams
- committed output stays re-renderable, so width and theme changes apply to all of it
- it's a stable full-screen frame, which is what a multi-pane layout would need

Neither mode dominates, which is why both stay. Full write-up in `docs/concepts/rendering.md`.

## Keeping it out of the inline path

- `internal/app/desktop` is a plain view component: a scrollable transcript viewport above the footer. It holds no reference to the root model and imports no bubbletea. The app hands it a `Pane`, it scrolls the result — a second window is a second Pane.
- `internal/app/desktop_surface.go` is the only seam: Surface enum, toggle, repaint heartbeat, content snapshot, key routing. Existing files gain single-line hooks (40 lines across 7 files); no inline renderer changes behavior.
- Both surfaces call the same render functions, so they read identically.
- The desktop claims only `ctrl+g` and the paging keys, routed below the overlays that already own pgup/pgdown/home/end. Everything else — typing, Enter, Ctrl-C, Ctrl-O, history — falls through unchanged.

## The one thing they can't share

`insertAbove` scrolls and inserts rows into whichever buffer is current, so a `tea.Println` issued while the alt-screen is up would land inside the desktop's frame and be lost from the history below.

So: **while the desktop owns the screen the commit pipeline runs untouched, but its terminal writes wait in the queue.** Commit offsets and `CommittedCount` advance exactly as they would inline — nothing diverges — and the queued chunks replay in order when the inline view returns.

Two consequences worth naming:

- The desktop draws the *streaming* message whole, ignoring the commit offsets that let the inline view skip its already-flushed prefix — that prefix sits in the scrollback the desktop is covering, so honouring them would open a hole mid-reply.
- Quitting from the desktop leaves the held writes unflushed, so that stretch of conversation isn't in the terminal's scrollback afterwards. It is in the session transcript, and exiting to inline first replays everything.

An overlay (slash-command picker, approval/question modal) takes the frame back for as long as it is up, so the panel that owns the keyboard is always the one drawn on screen.
