### PR TITLE
chore: bump version to 1.20.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to San are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [v1.20.8] - 2026-07-03
+
+### Added
+- Binary self-update and upgrade support ([@hchenxa](https://github.com/hchenxa) in [#263](https://github.com/genai-io/san/pull/263))
+
+### Fixed
+- Keep interactive commands from hanging the TUI ([@yanmxa](https://github.com/yanmxa) in [#264](https://github.com/genai-io/san/pull/264))
+
 ## [v1.20.7] - 2026-06-27
 
 ### Added

--- a/cmd/san/main.go
+++ b/cmd/san/main.go
@@ -31,7 +31,7 @@ import (
 	_ "github.com/genai-io/san/internal/llm/volcengine"
 )
 
-var version = "1.20.7"
+var version = "1.20.8"
 
 // cliOpts holds all CLI flag values in one place.
 var cliOpts struct {


### PR DESCRIPTION
Bump code version to 1.20.8 and update CHANGELOG.