### PR TITLE
chore: bump version to 1.20.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to San are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [v1.20.9] - 2026-07-03
+
+### Added
+- ChatGPT subscription OAuth authentication for the OpenAI provider ([@yanmxa](https://github.com/yanmxa) in [#268](https://github.com/genai-io/san/pull/268))
+
 ## [v1.20.8] - 2026-07-03
 
 ### Added

--- a/cmd/san/main.go
+++ b/cmd/san/main.go
@@ -31,7 +31,7 @@ import (
 	_ "github.com/genai-io/san/internal/llm/volcengine"
 )
 
-var version = "1.20.8"
+var version = "1.20.9"
 
 // cliOpts holds all CLI flag values in one place.
 var cliOpts struct {


### PR DESCRIPTION
Bump code version to 1.20.9 and add the changelog entry for v1.20.9.