### PR TITLE
fix: stop status-bar context limit flickering between provider windows

### DIFF
--- a/internal/app/kit/token.go
+++ b/internal/app/kit/token.go
@@ -32,19 +32,18 @@ func GetMaxTokens(store *llm.Store, currentModel *llm.CurrentModelInfo, defaultM
 	return defaultMaxTokens
 }
 
-// GetModelTokenLimits returns the cached token limits for the current model.
+// GetModelTokenLimits returns the cached context window for the current model.
 //
-// It resolves from the current model's own provider/auth cache first. The same
-// model ID can be cached under several providers with different context windows
-// (e.g. gpt-5.5 via Direct API at 400k and via the ChatGPT subscription at
-// 272k); a bare ID scan iterates a map and would return a random one each
-// render, making the status-bar limit flicker. Resolving by the connected
-// provider is deterministic and correct.
+// The same model ID can be cached under several provider/auth keys with
+// different windows (gpt-5.5: 400k via Direct API, 272k via ChatGPT
+// subscription). Scanning the cache map for the ID picks a random one each
+// render — that is what made the status-bar limit flicker. So we resolve in two
+// deterministic steps:
 //
-// It falls back to a cross-provider ID scan when the current provider's cache
-// doesn't report a window — an OpenAI-compatible aggregator may serve a model
-// with no advertised context window while the same model's native provider
-// knows the real one, letting the status bar borrow it instead of showing "--".
+//  1. this model's own provider+auth cache — the correct window. Ignores the 24h
+//     TTL, otherwise an expired cache would fall to step 2 and flicker again.
+//  2. else the largest window for the ID across all caches — covers a model an
+//     aggregator serves with no window while its native provider knows the real one.
 func GetModelTokenLimits(store *llm.Store, currentModel *llm.CurrentModelInfo) (inputLimit, outputLimit int) {
 	if store == nil || currentModel == nil {
 		return 0, 0
@@ -55,12 +54,8 @@ func GetModelTokenLimits(store *llm.Store, currentModel *llm.CurrentModelInfo) (
 			authMethod = conn.AuthMethod
 		}
 	}
-	if models, ok := store.GetCachedModels(currentModel.Provider, authMethod); ok {
-		for _, m := range models {
-			if m.ID == currentModel.ModelID && m.InputTokenLimit > 0 {
-				return m.InputTokenLimit, m.OutputTokenLimit
-			}
-		}
+	if input, output := store.CachedModelLimitsForProvider(currentModel.Provider, authMethod, currentModel.ModelID); input > 0 {
+		return input, output
 	}
 	return store.CachedModelLimits(currentModel.ModelID)
 }

--- a/internal/app/kit/token.go
+++ b/internal/app/kit/token.go
@@ -49,7 +49,13 @@ func GetModelTokenLimits(store *llm.Store, currentModel *llm.CurrentModelInfo) (
 	if store == nil || currentModel == nil {
 		return 0, 0
 	}
-	if models, ok := store.GetCachedModels(currentModel.Provider, currentModel.AuthMethod); ok {
+	authMethod := currentModel.AuthMethod
+	if authMethod == "" {
+		if conn, ok := store.GetConnection(currentModel.Provider); ok {
+			authMethod = conn.AuthMethod
+		}
+	}
+	if models, ok := store.GetCachedModels(currentModel.Provider, authMethod); ok {
 		for _, m := range models {
 			if m.ID == currentModel.ModelID && m.InputTokenLimit > 0 {
 				return m.InputTokenLimit, m.OutputTokenLimit

--- a/internal/app/kit/token_test.go
+++ b/internal/app/kit/token_test.go
@@ -41,3 +41,37 @@ func TestGetModelTokenLimitsPrefersCurrentProvider(t *testing.T) {
 		}
 	}
 }
+
+func TestGetModelTokenLimitsUsesConnectedAuthWhenCurrentAuthMissing(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	store, err := llm.NewStore()
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	if err := store.Connect(llm.OpenAI, llm.AuthSubscription); err != nil {
+		t.Fatalf("Connect(subscription): %v", err)
+	}
+	if err := store.CacheModels(llm.OpenAI, llm.AuthAPIKey, []llm.ModelInfo{
+		{ID: "gpt-5.5", InputTokenLimit: 400000, OutputTokenLimit: 16384},
+	}); err != nil {
+		t.Fatalf("CacheModels(api_key): %v", err)
+	}
+	if err := store.CacheModels(llm.OpenAI, llm.AuthSubscription, []llm.ModelInfo{
+		{ID: "gpt-5.5", InputTokenLimit: 272000, OutputTokenLimit: 16384},
+	}); err != nil {
+		t.Fatalf("CacheModels(subscription): %v", err)
+	}
+
+	current := &llm.CurrentModelInfo{
+		ModelID:  "gpt-5.5",
+		Provider: llm.OpenAI,
+		// Older providers.json files did not persist authMethod on current.
+	}
+
+	for range 30 {
+		if got := GetEffectiveInputLimit(store, current); got != 272000 {
+			t.Fatalf("input limit = %d, want 272000 from connected subscription auth", got)
+		}
+	}
+}

--- a/internal/llm/store.go
+++ b/internal/llm/store.go
@@ -310,6 +310,33 @@ func (s *Store) CachedModelDisplayName(id string) string {
 	return raw
 }
 
+// CachedModelLimitsForProvider returns the token limits for a model ID from a
+// single provider/auth cache, ignoring TTL. Returns (0, 0) when that cache has
+// no entry reporting a context window for the ID.
+//
+// Unlike CachedModelLimits it reads only the one cache keyed by provider+auth,
+// so it is deterministic: it can never flicker between two providers that
+// advertise different windows for the same ID (e.g. gpt-5.5 at 400k via Direct
+// API and 272k via the ChatGPT subscription). It ignores TTL on purpose — the
+// status bar wants the current model's own window even from a stale cache,
+// since context windows rarely change and a stale-but-correct value beats
+// falling back to a random cross-provider one once the cache expires.
+func (s *Store) CachedModelLimitsForProvider(provider Name, authMethod AuthMethod, id string) (inputLimit, outputLimit int) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	cache, ok := s.data.Models[makemodelCacheKey(provider, authMethod)]
+	if !ok {
+		return 0, 0
+	}
+	for _, m := range cache.Models {
+		if m.ID == id && m.InputTokenLimit > 0 {
+			return m.InputTokenLimit, m.OutputTokenLimit
+		}
+	}
+	return 0, 0
+}
+
 // CachedModelLimits returns the token limits for a model ID found in any
 // cached provider list, ignoring TTL. Returns (0, 0) when no cached entry
 // reports a context window for the ID.
@@ -320,21 +347,24 @@ func (s *Store) CachedModelDisplayName(id string) string {
 // with no context length (limit 0), while the model's native provider knows the
 // real window (e.g. DeepSeek V4 Pro at 1M). Resolving the limit from only the
 // current provider's cache would then render "--" even though another cache
-// knows the answer. So we scan all caches and prefer an entry with a real
-// (non-zero) input limit. Scans in place without allocating, since it feeds the
-// status bar on every render.
+// knows the answer. So we scan all caches for the ID. When several report a
+// non-zero window we keep the largest, both because it best reflects the
+// model's real capability and because a fixed choice is deterministic — Go
+// randomizes map iteration order, so returning the first hit would flicker the
+// status bar between providers. Scans in place without allocating, since it
+// feeds the status bar on every render.
 func (s *Store) CachedModelLimits(id string) (inputLimit, outputLimit int) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	for _, cache := range s.data.Models {
 		for _, m := range cache.Models {
-			if m.ID == id && m.InputTokenLimit > 0 {
-				return m.InputTokenLimit, m.OutputTokenLimit
+			if m.ID == id && m.InputTokenLimit > inputLimit {
+				inputLimit, outputLimit = m.InputTokenLimit, m.OutputTokenLimit
 			}
 		}
 	}
-	return 0, 0
+	return inputLimit, outputLimit
 }
 
 // SetCurrentModel sets the current model with provider info

--- a/internal/llm/store_test.go
+++ b/internal/llm/store_test.go
@@ -175,3 +175,79 @@ func TestStore_CachedModelLimitsPrefersKnownWindow(t *testing.T) {
 		t.Fatalf("CachedModelLimits(missing) = (%d, %d), want (0, 0)", in, out)
 	}
 }
+
+// TestStore_CachedModelLimitsPrefersLargestWindow guards the deterministic
+// fallback: when the same ID is cached under two providers that both report a
+// non-zero but different window, CachedModelLimits must always return the same
+// one (the largest) rather than a random map hit that flickers the status bar.
+func TestStore_CachedModelLimitsPrefersLargestWindow(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	store, err := NewStore()
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	if err := store.CacheModels(OpenAI, AuthSubscription, []ModelInfo{
+		{ID: "gpt-5.5", InputTokenLimit: 272_000, OutputTokenLimit: 16_384},
+	}); err != nil {
+		t.Fatalf("CacheModels(subscription) error = %v", err)
+	}
+	if err := store.CacheModels(OpenAI, AuthAPIKey, []ModelInfo{
+		{ID: "gpt-5.5", InputTokenLimit: 400_000, OutputTokenLimit: 16_384},
+	}); err != nil {
+		t.Fatalf("CacheModels(api_key) error = %v", err)
+	}
+
+	for i := range 100 {
+		in, out := store.CachedModelLimits("gpt-5.5")
+		if in != 400_000 || out != 16_384 {
+			t.Fatalf("CachedModelLimits() = (%d, %d), want (400000, 16384) on iteration %d", in, out, i)
+		}
+	}
+}
+
+// TestStore_CachedModelLimitsForProvider verifies the provider-scoped lookup is
+// deterministic and ignores TTL: it must return the current provider's own
+// window (272k for the subscription) even when an api_key cache advertises a
+// different one (400k) and even after the cache has expired — the exact state
+// that made the status-bar limit flicker every render once the 24h TTL lapsed.
+func TestStore_CachedModelLimitsForProvider(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	store, err := NewStore()
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	if err := store.CacheModels(OpenAI, AuthAPIKey, []ModelInfo{
+		{ID: "gpt-5.5", InputTokenLimit: 400_000, OutputTokenLimit: 16_384},
+	}); err != nil {
+		t.Fatalf("CacheModels(api_key) error = %v", err)
+	}
+	if err := store.CacheModels(OpenAI, AuthSubscription, []ModelInfo{
+		{ID: "gpt-5.5", InputTokenLimit: 272_000, OutputTokenLimit: 16_384},
+	}); err != nil {
+		t.Fatalf("CacheModels(subscription) error = %v", err)
+	}
+
+	// Backdate the subscription cache well past the TTL to reproduce the bug.
+	key := makemodelCacheKey(OpenAI, AuthSubscription)
+	cache := store.data.Models[key]
+	cache.CachedAt = cache.CachedAt.Add(-2 * modelCacheTTL)
+	store.data.Models[key] = cache
+
+	if in, ok := store.GetCachedModels(OpenAI, AuthSubscription); ok {
+		t.Fatalf("expected subscription cache to be expired, got %v", in)
+	}
+
+	for i := range 100 {
+		in, out := store.CachedModelLimitsForProvider(OpenAI, AuthSubscription, "gpt-5.5")
+		if in != 272_000 || out != 16_384 {
+			t.Fatalf("CachedModelLimitsForProvider() = (%d, %d), want (272000, 16384) on iteration %d", in, out, i)
+		}
+	}
+
+	// An unknown provider/auth pair reports no window.
+	if in, out := store.CachedModelLimitsForProvider(OpenAI, AuthMethod("none"), "gpt-5.5"); in != 0 || out != 0 {
+		t.Fatalf("CachedModelLimitsForProvider(none) = (%d, %d), want (0, 0)", in, out)
+	}
+}


### PR DESCRIPTION
The status-bar \`ctx used/limit\` flickered between two values (e.g. 400.0k and 272.0k) when the same model ID is cached under two provider/auth keys with different context windows — gpt-5.5 at 400k via Direct API and 272k via the ChatGPT subscription.

Two causes, fixed here:

- The provider+auth-keyed limit lookup was gated by the 24h model-cache TTL. Once that cache expired, every render fell through to a cross-provider map scan that returns a random non-zero limit each time. Now the current model's own provider+auth window is resolved ignoring TTL — a stale-but-correct value beats a random cross-provider one.
- The cross-provider fallback itself was non-deterministic (first non-zero hit in a randomized map order). It now prefers the largest known window, so it never flickers.

Also backfills the auth method from the live connection when \`CurrentModelInfo.AuthMethod\` is empty (older \`providers.json\` files didn't persist it).