### PR TITLE
feat: surface auto-review activity in the UI

### DIFF
--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -201,7 +201,8 @@ func (m *model) buildAgentParams() agent.BuildParams {
 			}
 			// Defense in depth: the judge may never approve a floored action,
 			// even if one somehow reaches it.
-			if setting.BypassImmuneReason(name, args) != "" {
+			if r := setting.BypassImmuneReason(name, args); r != "" {
+				m.recordDecision(ctx, false, r)
 				return agent.PermReviewResult{}
 			}
 			ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -215,6 +216,7 @@ func (m *model) buildAgentParams() agent.BuildParams {
 				zap.String("reason", verdict.Reason),
 				zap.Error(err))
 			if err != nil || !verdict.Allow {
+				m.recordDecision(ctx, false, escalationReason(verdict.Reason, err))
 				return agent.PermReviewResult{} // fail closed → escalate to human
 			}
 			if rec != nil {
@@ -228,7 +230,10 @@ func (m *model) buildAgentParams() agent.BuildParams {
 			// the session. Safe to write here: the agent goroutine is the only
 			// mutator (the human-approval writer runs only while it is parked).
 			m.env.SessionPermissions.AllowPattern(setting.BuildRule(name, args))
-			m.reviewerApprovals.Add(1)
+			// Tally it and stash the decision so the renderer can draw it inline
+			// under the tool call the judge just let through (the status-bar count
+			// alone doesn't say what was approved or why).
+			m.recordDecision(ctx, true, verdict.Reason)
 			return agent.PermReviewResult{Allow: true, Reason: "auto-review: " + verdict.Reason}
 		},
 	}
@@ -250,6 +255,50 @@ func (m *model) resolveReviewerModel(ref string) (llm.Provider, string) {
 		return m.env.LLMProvider, m.env.GetModelID()
 	}
 	return m.env.LLMProvider, ref
+}
+
+// recordDecision tallies one auto-review decision for the status-bar count and
+// stashes it for the renderer, keyed by the tool call ID carried in ctx and
+// consumed (load + delete) in TakeDecision — so the handoff map only ever
+// holds calls whose result has not arrived yet. The approved flag
+// picks the counter, so the count and the inline annotations can never drift.
+// The count is bumped even when ctx carries no tool call ID; only the stash
+// needs one.
+func (m *model) recordDecision(ctx context.Context, approved bool, reason string) {
+	if approved {
+		m.reviewerApprovals.Add(1)
+	} else {
+		m.reviewerEscalations.Add(1)
+	}
+	if id := core.ToolCallIDFromContext(ctx); id != "" {
+		m.pendingDecisions.Store(id, core.ReviewDecision{Approved: approved, Reason: reason})
+	}
+}
+
+// TakeDecision consumes the decision stashed for a tool call (load + delete),
+// so it stamps exactly one rendered result and the handoff map holds only
+// in-flight calls. Returns nil when the call was not auto-reviewed. Mirrors the
+// tool side-effect handoff (Tool.PopSideEffect), consumed at the same point in
+// OnToolResult.
+func (m *model) TakeDecision(callID string) *core.ReviewDecision {
+	// No empty-callID guard: recordDecision never stores under an empty key, so
+	// LoadAndDelete("") already misses and returns nil.
+	v, ok := m.pendingDecisions.LoadAndDelete(callID)
+	if !ok {
+		return nil
+	}
+	decision := v.(core.ReviewDecision)
+	return &decision
+}
+
+// escalationReason is the one-line explanation shown when the judge sends a
+// gray-zone call back to the user: the judge's own reason, or a generic note
+// when it could not reach a decision (error / timeout / unparseable reply).
+func escalationReason(judgeReason string, err error) string {
+	if err != nil || judgeReason == "" {
+		return "auto-review unavailable — asking you"
+	}
+	return judgeReason
 }
 
 // marshalPermInput serializes the tool args for a permission audit record.

--- a/internal/app/conv/conversation.go
+++ b/internal/app/conv/conversation.go
@@ -97,7 +97,7 @@ func (m *ConversationModel) AppendErrorToLast(err error) {
 	}
 }
 
-func (m *ConversationModel) AppendCancelledToolResults(calls []core.ToolCall, contentFn func(core.ToolCall) string) {
+func (m *ConversationModel) AppendCancelledToolResults(calls []core.ToolCall, contentFn func(core.ToolCall) string, decisionFn func(callID string) *core.ReviewDecision) {
 	for _, tc := range calls {
 		m.Append(core.ChatMessage{
 			Role: core.RoleUser,
@@ -107,6 +107,10 @@ func (m *ConversationModel) AppendCancelledToolResults(calls []core.ToolCall, co
 				Content:    contentFn(tc),
 				IsError:    true,
 			},
+			// Consume the stashed auto-review decision so an interrupted judged
+			// call still shows its annotation and its handoff entry is released
+			// (this synthetic result never reaches the applyPostTool path).
+			Decision: decisionFn(tc.ID),
 		})
 	}
 }

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -88,6 +88,13 @@ var (
 	agentLabelStyle = lipgloss.NewStyle().
 			Foreground(kit.CurrentTheme.Success)
 
+	// Auto-review decision labels: green when the judge auto-approved a
+	// gray-zone tool call, amber when it escalated the call back to the user.
+	decisionApprovedStyle = lipgloss.NewStyle().
+				Foreground(kit.CurrentTheme.Success)
+	decisionEscalatedStyle = lipgloss.NewStyle().
+				Foreground(kit.CurrentTheme.Warning)
+
 	trackerPendingStyle = lipgloss.NewStyle().
 				Foreground(kit.CurrentTheme.Muted)
 
@@ -382,6 +389,27 @@ func RenderSystemMessage(content string) string {
 	return systemMsgStyle.Render(content) + "\n"
 }
 
+// renderDecision renders the auto-review outcome as a one-line annotation
+// between a tool call and its result: a "↳" arrow plus the decision — green
+// "auto-approved" when the judge let it through, amber "escalated" when it
+// handed the call back to the user — and the judge's one-sentence reason dimmed
+// after it. Returns "" when the call was not judged. The "  ↳" indent aligns the
+// arrow with the "⎿" result trailer on the line below.
+func renderDecision(v *core.ReviewDecision) string {
+	if v == nil {
+		return ""
+	}
+	label, style := "escalated", decisionEscalatedStyle
+	if v.Approved {
+		label, style = "auto-approved", decisionApprovedStyle
+	}
+	line := style.Render("  ↳ " + label)
+	if v.Reason != "" {
+		line += toolResultStyle.Render(" · " + v.Reason)
+	}
+	return line + "\n"
+}
+
 // ToolCallsParams holds the parameters for rendering tool calls.
 type ToolCallsParams struct {
 	ToolCalls         []core.ToolCall
@@ -411,6 +439,9 @@ type ToolResultData struct {
 	Interactive bool
 	Expanded    bool
 	ToolInput   string
+	// Decision is the auto-review decision for this call (nil if it was not
+	// judged), drawn as a colored line between the call and its result.
+	Decision *core.ReviewDecision
 }
 
 // RenderToolCalls renders the tool calls section of an assistant core.
@@ -471,6 +502,9 @@ func RenderToolCalls(params ToolCallsParams) string {
 		if resultData, ok := params.ResultMap[tc.ID]; ok {
 			resultData.ToolInput = tc.Input
 			resultData.Interactive = params.Interactive
+			// Decision sits between the call and its result, mirroring the
+			// order things happened: judged → ran → produced this output.
+			sb.WriteString(renderDecision(resultData.Decision))
 			sb.WriteString(RenderToolResultInline(resultData, params.MDRenderer))
 		} else if tool.IsAgentToolName(tc.Name) {
 			limit := maxCompactAgentToolLines

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -574,3 +574,28 @@ func Test_renderTaskOutputResultInlineShowsErrorText(t *testing.T) {
 		t.Fatalf("expected TaskOutput error text, got %q", rendered)
 	}
 }
+
+func TestRenderDecision(t *testing.T) {
+	// No decision → no annotation line at all.
+	if got := renderDecision(nil); got != "" {
+		t.Errorf("nil decision should render nothing, got %q", got)
+	}
+
+	approved := stripANSI(renderDecision(&core.ReviewDecision{Approved: true, Reason: "read-only ls, no side effects"}))
+	for _, want := range []string{"↳", "auto-approved", "read-only ls, no side effects"} {
+		if !strings.Contains(approved, want) {
+			t.Errorf("approved decision missing %q: %q", want, approved)
+		}
+	}
+
+	escalated := stripANSI(renderDecision(&core.ReviewDecision{Approved: false, Reason: "writes outside the project"}))
+	if !strings.Contains(escalated, "escalated") {
+		t.Errorf("escalated decision should say so: %q", escalated)
+	}
+
+	// A blank reason drops the separator rather than leaving a dangling "·".
+	bare := stripANSI(renderDecision(&core.ReviewDecision{Approved: true}))
+	if strings.Contains(bare, "·") {
+		t.Errorf("blank reason should not render a separator: %q", bare)
+	}
+}

--- a/internal/app/conv/runtime.go
+++ b/internal/app/conv/runtime.go
@@ -24,6 +24,9 @@ type Runtime interface {
 	OnTokenUsage(resp *core.InferResponse)
 	OnAgentMessage(msg core.Message) tea.Cmd
 	OnToolResult(tr core.ToolResult) *core.ToolResult
+	// TakeDecision consumes the auto-review decision stashed for a tool
+	// call (nil if it was not auto-reviewed), to stamp onto its rendered result.
+	TakeDecision(callID string) *core.ReviewDecision
 	OnTurnEnd(result core.Result) tea.Cmd
 	OnAgentStop(err error) tea.Cmd
 	OnPermGateRequest(req *PermGateRequest) tea.Cmd

--- a/internal/app/conv/status_bar.go
+++ b/internal/app/conv/status_bar.go
@@ -217,26 +217,27 @@ func fitStatusSegments(segments []statusSegment, maxWidth, sepWidth int) []strin
 
 // OperationModeParams holds the parameters needed for rendering mode status.
 type OperationModeParams struct {
-	Mode             setting.OperationMode
-	InputTokens      int
-	InputLimit       int
-	ModelName        string
-	StatusMessage    string
-	ConversationCost llm.Money
-	Compressions     int  // session compact count, drives the "compacted ×N" badge
-	ShowContextBar   bool // render the visual [██████░░░░] 71% bar (opt-in)
-	Width            int
-	ThinkingEffort   string
-	ShowThinking     bool
-	QueueCount       int
-	ReviewApprovals  int // auto-review approvals this session, shown next to the mode
+	Mode              setting.OperationMode
+	InputTokens       int
+	InputLimit        int
+	ModelName         string
+	StatusMessage     string
+	ConversationCost  llm.Money
+	Compressions      int  // session compact count, drives the "compacted ×N" badge
+	ShowContextBar    bool // render the visual [██████░░░░] 71% bar (opt-in)
+	Width             int
+	ThinkingEffort    string
+	ShowThinking      bool
+	QueueCount        int
+	ReviewApprovals   int // auto-review approvals this session, shown next to the mode
+	ReviewEscalations int // auto-review escalations to the user this session
 }
 
 // RenderModeStatus renders the combined mode status line.
 func RenderModeStatus(params OperationModeParams) string {
 	var leftParts []string
 
-	if modeStatus := RenderOperationModeIndicator(params.Mode, params.ReviewApprovals); modeStatus != "" {
+	if modeStatus := RenderOperationModeIndicator(params.Mode, params.ReviewApprovals, params.ReviewEscalations); modeStatus != "" {
 		leftParts = append(leftParts, modeStatus)
 	}
 
@@ -341,7 +342,7 @@ func compactStatusHint(percent float64) string {
 }
 
 // RenderOperationModeIndicator returns the mode status indicator for auto-accept, auto-review, or bypass mode.
-func RenderOperationModeIndicator(mode setting.OperationMode, reviewApprovals int) string {
+func RenderOperationModeIndicator(mode setting.OperationMode, reviewApprovals, reviewEscalations int) string {
 	var icon, label string
 	var clr kit.AdaptiveColor
 
@@ -362,8 +363,13 @@ func RenderOperationModeIndicator(mode setting.OperationMode, reviewApprovals in
 		return ""
 	}
 
-	if mode == setting.ModeAutoReview && reviewApprovals > 0 {
-		label += fmt.Sprintf(" · %d approved", reviewApprovals)
+	if mode == setting.ModeAutoReview {
+		if reviewApprovals > 0 {
+			label += fmt.Sprintf(" · %d approved", reviewApprovals)
+		}
+		if reviewEscalations > 0 {
+			label += fmt.Sprintf(" · %d escalated", reviewEscalations)
+		}
 	}
 
 	style := lipgloss.NewStyle().Foreground(clr)

--- a/internal/app/conv/status_bar_test.go
+++ b/internal/app/conv/status_bar_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"charm.land/lipgloss/v2"
+
+	"github.com/genai-io/san/internal/setting"
 )
 
 func TestClassifyContextTier_Boundaries(t *testing.T) {
@@ -218,5 +220,42 @@ func TestFitStatusSegments_AccountsForSeparatorWidth(t *testing.T) {
 	}
 	if got := fitStatusSegments(segments, 12, 3); len(got) != 1 || got[0] != "aaaaa" {
 		t.Errorf("separator should push the second segment out at width 12; got %q", got)
+	}
+}
+
+func TestRenderOperationModeIndicator_AutoReviewCounts(t *testing.T) {
+	cases := []struct {
+		name        string
+		approvals   int
+		escalations int
+		wantApprove bool
+		wantEscal   bool
+	}{
+		{"fresh session hides both", 0, 0, false, false},
+		{"approvals only", 3, 0, true, false},
+		{"escalations only", 0, 2, false, true},
+		{"both", 3, 2, true, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out := stripANSI(RenderOperationModeIndicator(setting.ModeAutoReview, c.approvals, c.escalations))
+			if !strings.Contains(out, "auto review on") {
+				t.Fatalf("missing base label: %q", out)
+			}
+			if got := strings.Contains(out, "approved"); got != c.wantApprove {
+				t.Errorf("approved shown=%v, want %v (out=%q)", got, c.wantApprove, out)
+			}
+			if got := strings.Contains(out, "escalated"); got != c.wantEscal {
+				t.Errorf("escalated shown=%v, want %v (out=%q)", got, c.wantEscal, out)
+			}
+		})
+	}
+}
+
+func TestRenderOperationModeIndicator_CountsOnlyInAutoReview(t *testing.T) {
+	// Approvals/escalations are an auto-review concept; other modes never show them.
+	out := stripANSI(RenderOperationModeIndicator(setting.ModeAutoAccept, 5, 4))
+	if strings.Contains(out, "approved") || strings.Contains(out, "escalated") {
+		t.Errorf("accept-edits mode must not show review counts: %q", out)
 	}
 }

--- a/internal/app/conv/update.go
+++ b/internal/app/conv/update.go
@@ -268,6 +268,10 @@ func applyPostTool(rt Runtime, m *Model, ev core.Event) tea.Cmd {
 	m.Append(core.ChatMessage{
 		Role:       core.RoleUser,
 		ToolResult: result,
+		// Stamp the auto-review decision (if this call was judged) onto the
+		// result message so it renders inline under the tool call. Consumed
+		// here — the handoff map keeps only in-flight calls.
+		Decision: rt.TakeDecision(tr.ToolCallID),
 	})
 	return nil
 }

--- a/internal/app/conv/view.go
+++ b/internal/app/conv/view.go
@@ -107,6 +107,7 @@ func PrecomputeInlinedResults(messages []core.ChatMessage) inlinedToolResults {
 				Content:  next.ToolResult.Content,
 				IsError:  next.ToolResult.IsError,
 				Expanded: next.Expanded,
+				Decision: next.Decision,
 			}
 		}
 	}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -22,6 +22,7 @@
 package app
 
 import (
+	"sync"
 	"sync/atomic"
 
 	"charm.land/bubbles/v2/textarea"
@@ -54,10 +55,19 @@ type model struct {
 	// model_scrollback.go (takeWelcomeBanner).
 	welcomePending bool
 
-	// reviewerApprovals counts auto-review approvals this session for the status
-	// bar. A pointer so value-receiver copies of the model share one counter
-	// across the agent and UI goroutines.
-	reviewerApprovals *atomic.Int64
+	// reviewerApprovals / reviewerEscalations count auto-review outcomes this
+	// session for the status bar: gray-zone tool calls the judge auto-approved
+	// vs. handed back to the user. Pointers so value-receiver copies of the
+	// model share one counter across the agent and UI goroutines.
+	reviewerApprovals   *atomic.Int64
+	reviewerEscalations *atomic.Int64
+
+	// pendingDecisions maps a tool call ID to the auto-review judge's decision,
+	// so the renderer can draw it inline under that tool call. Written on the
+	// agent goroutine (in PermissionReview, before the tool runs) and read on
+	// the UI goroutine at render time — a sync.Map, shared by pointer across
+	// value-receiver copies of the model.
+	pendingDecisions *sync.Map // tool call ID → core.ReviewDecision
 }
 
 var _ conv.Runtime = (*model)(nil)

--- a/internal/app/model_lifecycle.go
+++ b/internal/app/model_lifecycle.go
@@ -7,6 +7,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 
 	"github.com/genai-io/san/internal/app/conv"
@@ -60,13 +61,15 @@ func newBaseModel() model {
 			LoadDisabled:    svc.Setting.GetDisabledToolsAt,
 			UpdateDisabled:  svc.Setting.UpdateDisabledToolsAt,
 		}),
-		conv:              conv.NewModel(defaultWidth),
-		agentEventHub:     hub.New(),
-		mainEvents:        make(chan hub.Event, 64),
-		systemInput:       trigger.New(),
-		env:               environment,
-		services:          svc,
-		reviewerApprovals: new(atomic.Int64),
+		conv:                conv.NewModel(defaultWidth),
+		agentEventHub:       hub.New(),
+		mainEvents:          make(chan hub.Event, 64),
+		systemInput:         trigger.New(),
+		env:                 environment,
+		services:            svc,
+		reviewerApprovals:   new(atomic.Int64),
+		reviewerEscalations: new(atomic.Int64),
+		pendingDecisions:    new(sync.Map),
 	}
 }
 

--- a/internal/app/update_input_effects.go
+++ b/internal/app/update_input_effects.go
@@ -58,7 +58,7 @@ func (m *model) cancelPendingToolCalls() {
 			return "Stopped waiting for background task output because the user sent a new message. The background task may still be running."
 		}
 		return "Tool execution interrupted because the user sent a new message."
-	})
+	}, m.TakeDecision)
 }
 
 func (m *model) pasteImageFromClipboard() (tea.Cmd, bool) {

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -259,20 +259,25 @@ func (m model) renderModeStatus() string {
 	if m.reviewerApprovals != nil {
 		reviewApprovals = int(m.reviewerApprovals.Load())
 	}
+	reviewEscalations := 0
+	if m.reviewerEscalations != nil {
+		reviewEscalations = int(m.reviewerEscalations.Load())
+	}
 	return conv.RenderModeStatus(conv.OperationModeParams{
-		Mode:             m.env.OperationMode,
-		InputTokens:      m.env.InputTokens,
-		InputLimit:       kit.GetEffectiveInputLimit(m.services.LLM.Store(), m.env.CurrentModel),
-		ModelName:        modelName,
-		StatusMessage:    m.userInput.Provider.StatusMessage,
-		ConversationCost: m.env.ConversationCost,
-		Compressions:     m.env.Compressions,
-		ShowContextBar:   m.env.ShowContextBar,
-		Width:            m.env.Width,
-		ThinkingEffort:   thinkingEffort,
-		ShowThinking:     showThinking,
-		QueueCount:       m.userInput.Queue.Len(),
-		ReviewApprovals:  reviewApprovals,
+		Mode:              m.env.OperationMode,
+		InputTokens:       m.env.InputTokens,
+		InputLimit:        kit.GetEffectiveInputLimit(m.services.LLM.Store(), m.env.CurrentModel),
+		ModelName:         modelName,
+		StatusMessage:     m.userInput.Provider.StatusMessage,
+		ConversationCost:  m.env.ConversationCost,
+		Compressions:      m.env.Compressions,
+		ShowContextBar:    m.env.ShowContextBar,
+		Width:             m.env.Width,
+		ThinkingEffort:    thinkingEffort,
+		ShowThinking:      showThinking,
+		QueueCount:        m.userInput.Queue.Len(),
+		ReviewApprovals:   reviewApprovals,
+		ReviewEscalations: reviewEscalations,
 	})
 }
 

--- a/internal/core/message.go
+++ b/internal/core/message.go
@@ -76,6 +76,15 @@ type Message struct {
 	Signal            Signal          `json:"-"`
 }
 
+// ReviewDecision is the auto-review judge's display-only outcome for one
+// gray-zone tool call: whether it was auto-approved (vs. escalated to the user)
+// and the judge's one-sentence reason. Rendered inline under the tool call it
+// annotates; never persisted or sent to the provider.
+type ReviewDecision struct {
+	Approved bool
+	Reason   string
+}
+
 // ChatMessage is the TUI view-model for one conversation entry: the same
 // content as Message plus transient display state (the expand/collapse
 // toggles). The app layer renders ChatMessages and converts them back to
@@ -100,6 +109,12 @@ type ChatMessage struct {
 	ToolResult        *ToolResult
 	ToolCallsExpanded bool // UI: the assistant's tool-call block is expanded
 	Expanded          bool // UI: the tool-result block is expanded
+
+	// Decision is the auto-review judge's decision for the tool call this message
+	// carries the result of — set only on a RoleUser/ToolResult message whose
+	// call was judged, so the renderer can draw the decision inline under the
+	// tool call. Display-only: dropped by ToMessage, never persisted.
+	Decision *ReviewDecision
 
 	// Streaming-commit progress. While an assistant message streams, completed
 	// markdown blocks are flushed to native scrollback (tea.Println) as they


### PR DESCRIPTION
Auto-review approvals were silent apart from a cumulative "approved" count. This adds visibility into what the judge is doing.

- **Status bar:** now shows `auto review on · N approved · M escalated`, each part only when `> 0`. `escalated` counts gray-zone calls the judge handed back to the user (escalate verdict, error/timeout, or bypass-immune floor).
- **Per-approval hint:** each auto-approval prints a lightweight line to scrollback next to the tool call it let through — `⏵ auto-approved Bash · <reason>`.

The hint fires mid-stream, where appending to the message list would break the streaming assistant tail (the codebase already defers notices while `Stream.Active`). So it's delivered via a dedicated `AgentToUI` channel and `tea.Println`-ed straight to native scrollback, never touching `Messages` — the same pattern `FlushStreamingBlocks` uses. Trade-off: the hint isn't re-rendered on a compact reprint, but the approval is already recorded in the transcript audit.