### PR TITLE
perf(scrollback): render streaming markdown blocks off the UI goroutine

### DIFF
--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -70,13 +70,8 @@ type model struct {
 	pendingDecisions *sync.Map // tool call ID → core.ReviewDecision
 
 	// Streaming blocks render their markdown off the UI goroutine so a completed
-	// block never stalls repaint. flushRendering keeps one render in flight at a
-	// time (ordered Printlns); flushMD is the background renderer, kept off the
-	// live-view MDRenderer's mutex and rebuilt on width change. See
-	// model_scrollback.go.
-	flushRendering bool
-	flushMD        *conv.MDRenderer
-	flushMDWidth   int
+	// block never stalls repaint. See flushState and model_scrollback.go.
+	flush flushState
 }
 
 var _ conv.Runtime = (*model)(nil)

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -68,6 +68,15 @@ type model struct {
 	// the UI goroutine at render time — a sync.Map, shared by pointer across
 	// value-receiver copies of the model.
 	pendingDecisions *sync.Map // tool call ID → core.ReviewDecision
+
+	// Streaming blocks render their markdown off the UI goroutine so a completed
+	// block never stalls repaint. flushRendering keeps one render in flight at a
+	// time (ordered Printlns); flushMD is the background renderer, kept off the
+	// live-view MDRenderer's mutex and rebuilt on width change. See
+	// model_scrollback.go.
+	flushRendering bool
+	flushMD        *conv.MDRenderer
+	flushMDWidth   int
 }
 
 var _ conv.Runtime = (*model)(nil)

--- a/internal/app/model_scrollback.go
+++ b/internal/app/model_scrollback.go
@@ -17,14 +17,43 @@ func (m *model) CommitMessages() []tea.Cmd {
 	return m.renderAndCommit(true)
 }
 
-// FlushStreamingBlocks commits the in-flight assistant message's newly-completed
-// blocks to native scrollback, advancing its committed offsets so the live view
-// and the turn-end commit render only the remainder. Both thinking and content
-// commit block-by-block as blank lines (or, for content, closing code fences)
-// land; once content starts — the reliable "reasoning done" signal — thinking's
-// trailing block is flushed too so nothing reasoning-side lingers in the live
-// view. Returns nil when nothing new is committable.
+// blockRenderJob is the immutable snapshot the background render goroutine works
+// from, so it never touches live model state.
+type blockRenderJob struct {
+	msgID            string
+	index            int
+	thinkingSlice    string
+	contentSlice     string
+	thinkingEnd      int // commit offsets, advanced once this render lands
+	contentEnd       int
+	showThinkingIcon bool
+	showBullet       bool
+	width            int
+	md               *conv.MDRenderer
+}
+
+// blocksRenderedMsg carries a finished background render back for
+// handleBlocksRendered to commit to scrollback.
+type blocksRenderedMsg struct {
+	msgID                string
+	index                int
+	thinkingCommittedLen int
+	contentCommittedLen  int
+	thinkingEmitted      bool
+	bulletEmitted        bool
+	printed              string // "" when the blocks rendered empty (blank-only)
+}
+
+// FlushStreamingBlocks starts committing the streaming message's completed
+// blocks to scrollback. The markdown render runs off the UI goroutine
+// (renderBlocksCmd) so it can't stall repaint; one render runs at a time
+// (flushRendering) to keep the Printlns ordered, and offsets advance only when
+// it lands, so the live tail shows each block until its rendered form is in
+// scrollback. Returns nil when a render is in flight or nothing new is ready.
 func (m *model) FlushStreamingBlocks() []tea.Cmd {
+	if m.flushRendering {
+		return nil // a block is already rendering off-thread; wait for it to land
+	}
 	idx := len(m.conv.Messages) - 1
 	if idx < 0 {
 		return nil
@@ -34,40 +63,127 @@ func (m *model) FlushStreamingBlocks() []tea.Cmd {
 		return nil
 	}
 
-	var blocks []string
-
-	// Thinking commits paragraph-by-paragraph as blank lines land; once content
-	// starts, the trailing paragraph is flushed too (it has no terminating blank
-	// line of its own).
+	// Once content starts, flush thinking's trailing paragraph too (it has no
+	// terminating blank line, but reasoning is done).
 	thinkingEnd := conv.CompletedBlockBoundary(msg.Thinking)
 	if len(msg.Content) > 0 {
 		thinkingEnd = len(msg.Thinking)
 	}
+	contentEnd := conv.CompletedBlockBoundary(msg.Content)
+
+	var thinkingSlice, contentSlice string
 	if thinkingEnd > msg.ThinkingCommittedLen {
-		block := conv.RenderCommittedThinkingBlock(msg.Thinking[msg.ThinkingCommittedLen:thinkingEnd], !msg.ThinkingEmitted, m.env.Width)
-		if block != "" {
-			blocks = append(blocks, block)
-			msg.ThinkingEmitted = true
-		}
-		msg.ThinkingCommittedLen = thinkingEnd
+		thinkingSlice = msg.Thinking[msg.ThinkingCommittedLen:thinkingEnd]
+	}
+	if contentEnd > msg.ContentCommittedLen {
+		contentSlice = msg.Content[msg.ContentCommittedLen:contentEnd]
+	}
+	if strings.TrimSpace(thinkingSlice) == "" && strings.TrimSpace(contentSlice) == "" {
+		return nil // no completed block yet (or blank-only — nothing to render)
 	}
 
-	if boundary := conv.CompletedBlockBoundary(msg.Content); boundary > msg.ContentCommittedLen {
-		block := conv.RenderCommittedContentBlock(msg.Content[msg.ContentCommittedLen:boundary], !msg.BulletEmitted, m.conv.MDRenderer)
-		if block != "" {
-			blocks = append(blocks, block)
-			msg.BulletEmitted = true
-		}
-		msg.ContentCommittedLen = boundary
-	}
+	m.flushRendering = true
+	return []tea.Cmd{renderBlocksCmd(blockRenderJob{
+		msgID:            msg.ID,
+		index:            idx,
+		thinkingSlice:    thinkingSlice,
+		contentSlice:     contentSlice,
+		thinkingEnd:      thinkingEnd,
+		contentEnd:       contentEnd,
+		showThinkingIcon: !msg.ThinkingEmitted,
+		showBullet:       !msg.BulletEmitted,
+		width:            m.env.Width,
+		md:               m.flushRenderer(),
+	})}
+}
 
-	if len(blocks) == 0 {
+// renderBlocksCmd renders the job's completed blocks (glamour, off the UI
+// goroutine) and returns them as a blocksRenderedMsg.
+func renderBlocksCmd(job blockRenderJob) tea.Cmd {
+	return func() tea.Msg {
+		// != "" just skips a slice absent this flush; the render helpers
+		// blank-check their input and we gate on a non-empty result.
+		var blocks []string
+		thinkingEmitted := false
+		if job.thinkingSlice != "" {
+			if b := conv.RenderCommittedThinkingBlock(job.thinkingSlice, job.showThinkingIcon, job.width); b != "" {
+				blocks = append(blocks, b)
+				thinkingEmitted = true
+			}
+		}
+		bulletEmitted := false
+		if job.contentSlice != "" {
+			if b := conv.RenderCommittedContentBlock(job.contentSlice, job.showBullet, job.md); b != "" {
+				blocks = append(blocks, b)
+				bulletEmitted = true
+			}
+		}
+		printed := ""
+		if len(blocks) > 0 {
+			// Match RenderMessageAt's leading newline + blank-line separation.
+			printed = "\n" + strings.Join(blocks, "\n\n")
+		}
+		return blocksRenderedMsg{
+			msgID:                job.msgID,
+			index:                job.index,
+			thinkingCommittedLen: job.thinkingEnd,
+			contentCommittedLen:  job.contentEnd,
+			thinkingEmitted:      thinkingEmitted,
+			bulletEmitted:        bulletEmitted,
+			printed:              printed,
+		}
+	}
+}
+
+// handleBlocksRendered lands a background render: advance the row's offsets,
+// print to scrollback, then flush the next completed block.
+func (m *model) handleBlocksRendered(msg blocksRenderedMsg) tea.Cmd {
+	m.flushRendering = false
+
+	// Drop the render if its row was committed whole (turn-end/cancel) or
+	// replaced by a retry (new ID) meanwhile — its content is already handled, so
+	// printing it now would duplicate or reorder scrollback.
+	if msg.index >= len(m.conv.Messages) ||
+		msg.index < m.conv.CommittedCount ||
+		m.conv.Messages[msg.index].ID != msg.msgID ||
+		m.conv.Messages[msg.index].Role != core.RoleAssistant {
 		return nil
 	}
-	// Mirror RenderMessageAt's leading newline + blank-line block separation so
-	// progressively-committed blocks land in scrollback exactly where the
-	// turn-end render would place them.
-	return []tea.Cmd{tea.Println("\n" + strings.Join(blocks, "\n\n"))}
+
+	row := &m.conv.Messages[msg.index]
+	row.ThinkingCommittedLen = msg.thinkingCommittedLen
+	row.ContentCommittedLen = msg.contentCommittedLen
+	if msg.thinkingEmitted {
+		row.ThinkingEmitted = true
+	}
+	if msg.bulletEmitted {
+		row.BulletEmitted = true
+	}
+
+	var cmds []tea.Cmd
+	if msg.printed != "" {
+		cmds = append(cmds, tea.Println(msg.printed))
+	}
+	// Catch a block that completed while this one rendered — Stream.Active means
+	// the row is still uncommitted, so it's safe.
+	if m.conv.Stream.Active {
+		cmds = append(cmds, m.FlushStreamingBlocks()...)
+	}
+	// Sequence, not Batch: this block's print must be queued before the next
+	// render's result, or concurrent Batch could reorder scrollback blocks.
+	return tea.Sequence(cmds...)
+}
+
+// flushRenderer is the background goroutine's own markdown renderer, kept off
+// m.conv.MDRenderer so a slow render can't block the live View on its mutex.
+// Rebuilt on width change; needs no lock since flushRendering means one render
+// uses it at a time.
+func (m *model) flushRenderer() *conv.MDRenderer {
+	if m.flushMD == nil || m.flushMDWidth != m.env.Width {
+		m.flushMD = conv.NewMDRenderer(m.env.Width)
+		m.flushMDWidth = m.env.Width
+	}
+	return m.flushMD
 }
 
 func (m *model) commitAllMessages() []tea.Cmd {

--- a/internal/app/model_scrollback.go
+++ b/internal/app/model_scrollback.go
@@ -17,9 +17,25 @@ func (m *model) CommitMessages() []tea.Cmd {
 	return m.renderAndCommit(true)
 }
 
-// blockRenderJob is the immutable snapshot the background render goroutine works
+// Streaming-flush pipeline. As an assistant message streams in, each of its
+// completed markdown blocks migrates from the live tail (redrawn every frame in
+// the alt-screen) into the terminal's native scrollback, one block at a time:
+//
+//	FlushStreamingBlocks  freezes the newly-completed, not-yet-committed slice of
+//	                      the live message into a flushSnapshot.
+//	renderSnapshotCmd     renders that snapshot with glamour on a background Cmd,
+//	                      so the parse + syntax highlight can't stall repaint.
+//	flushResultMsg        carries the rendered ANSI back to the UI goroutine.
+//	handleFlushResult     Println's it into scrollback and advances the message's
+//	                      commit offsets, so the live tail stops redrawing the
+//	                      prefix now committed and flushes the next block.
+//
+// One render is in flight at a time (flush.rendering) so the Printlns stay
+// ordered; the still-streaming trailing block stays live until it too completes.
+
+// flushSnapshot is the immutable snapshot the background render goroutine works
 // from, so it never touches live model state.
-type blockRenderJob struct {
+type flushSnapshot struct {
 	msgID            string
 	index            int
 	thinkingSlice    string
@@ -32,9 +48,18 @@ type blockRenderJob struct {
 	md               *conv.MDRenderer
 }
 
-// blocksRenderedMsg carries a finished background render back for
-// handleBlocksRendered to commit to scrollback.
-type blocksRenderedMsg struct {
+// flushState is the streaming-block flush subsystem: it renders each completed
+// conversation block (thinking, content) off the UI goroutine and commits the
+// result to scrollback. See FlushStreamingBlocks and model_scrollback.go.
+type flushState struct {
+	rendering bool             // one render in flight at a time, so Printlns stay ordered
+	renderer  *conv.MDRenderer // background renderer, off the live-view MDRenderer's mutex
+	width     int              // width the renderer was built for; rebuild when it changes
+}
+
+// flushResultMsg is the result of rendering a flushSnapshot off-thread, carrying
+// the rendered blocks back for handleFlushResult to commit to scrollback.
+type flushResultMsg struct {
 	msgID                string
 	index                int
 	thinkingCommittedLen int
@@ -44,14 +69,12 @@ type blocksRenderedMsg struct {
 	printed              string // "" when the blocks rendered empty (blank-only)
 }
 
-// FlushStreamingBlocks starts committing the streaming message's completed
-// blocks to scrollback. The markdown render runs off the UI goroutine
-// (renderBlocksCmd) so it can't stall repaint; one render runs at a time
-// (flushRendering) to keep the Printlns ordered, and offsets advance only when
-// it lands, so the live tail shows each block until its rendered form is in
-// scrollback. Returns nil when a render is in flight or nothing new is ready.
+// FlushStreamingBlocks starts one turn of the streaming-flush pipeline above:
+// it freezes the last message's newly-completed blocks into a flushSnapshot and
+// kicks off their background render. Returns nil when a render is already in
+// flight or nothing new is ready to flush.
 func (m *model) FlushStreamingBlocks() []tea.Cmd {
-	if m.flushRendering {
+	if m.flush.rendering {
 		return nil // a block is already rendering off-thread; wait for it to land
 	}
 	idx := len(m.conv.Messages) - 1
@@ -82,8 +105,8 @@ func (m *model) FlushStreamingBlocks() []tea.Cmd {
 		return nil // no completed block yet (or blank-only — nothing to render)
 	}
 
-	m.flushRendering = true
-	return []tea.Cmd{renderBlocksCmd(blockRenderJob{
+	m.flush.rendering = true
+	return []tea.Cmd{renderSnapshotCmd(flushSnapshot{
 		msgID:            msg.ID,
 		index:            idx,
 		thinkingSlice:    thinkingSlice,
@@ -93,27 +116,27 @@ func (m *model) FlushStreamingBlocks() []tea.Cmd {
 		showThinkingIcon: !msg.ThinkingEmitted,
 		showBullet:       !msg.BulletEmitted,
 		width:            m.env.Width,
-		md:               m.flushRenderer(),
+		md:               m.flush.mdRenderer(m.env.Width),
 	})}
 }
 
-// renderBlocksCmd renders the job's completed blocks (glamour, off the UI
-// goroutine) and returns them as a blocksRenderedMsg.
-func renderBlocksCmd(job blockRenderJob) tea.Cmd {
+// renderSnapshotCmd renders the snapshot's completed blocks (glamour, off the UI
+// goroutine) and returns them as a flushResultMsg.
+func renderSnapshotCmd(snap flushSnapshot) tea.Cmd {
 	return func() tea.Msg {
 		// != "" just skips a slice absent this flush; the render helpers
 		// blank-check their input and we gate on a non-empty result.
 		var blocks []string
 		thinkingEmitted := false
-		if job.thinkingSlice != "" {
-			if b := conv.RenderCommittedThinkingBlock(job.thinkingSlice, job.showThinkingIcon, job.width); b != "" {
+		if snap.thinkingSlice != "" {
+			if b := conv.RenderCommittedThinkingBlock(snap.thinkingSlice, snap.showThinkingIcon, snap.width); b != "" {
 				blocks = append(blocks, b)
 				thinkingEmitted = true
 			}
 		}
 		bulletEmitted := false
-		if job.contentSlice != "" {
-			if b := conv.RenderCommittedContentBlock(job.contentSlice, job.showBullet, job.md); b != "" {
+		if snap.contentSlice != "" {
+			if b := conv.RenderCommittedContentBlock(snap.contentSlice, snap.showBullet, snap.md); b != "" {
 				blocks = append(blocks, b)
 				bulletEmitted = true
 			}
@@ -123,11 +146,11 @@ func renderBlocksCmd(job blockRenderJob) tea.Cmd {
 			// Match RenderMessageAt's leading newline + blank-line separation.
 			printed = "\n" + strings.Join(blocks, "\n\n")
 		}
-		return blocksRenderedMsg{
-			msgID:                job.msgID,
-			index:                job.index,
-			thinkingCommittedLen: job.thinkingEnd,
-			contentCommittedLen:  job.contentEnd,
+		return flushResultMsg{
+			msgID:                snap.msgID,
+			index:                snap.index,
+			thinkingCommittedLen: snap.thinkingEnd,
+			contentCommittedLen:  snap.contentEnd,
 			thinkingEmitted:      thinkingEmitted,
 			bulletEmitted:        bulletEmitted,
 			printed:              printed,
@@ -135,10 +158,10 @@ func renderBlocksCmd(job blockRenderJob) tea.Cmd {
 	}
 }
 
-// handleBlocksRendered lands a background render: advance the row's offsets,
+// handleFlushResult lands a background render: advance the row's offsets,
 // print to scrollback, then flush the next completed block.
-func (m *model) handleBlocksRendered(msg blocksRenderedMsg) tea.Cmd {
-	m.flushRendering = false
+func (m *model) handleFlushResult(msg flushResultMsg) tea.Cmd {
+	m.flush.rendering = false
 
 	// Drop the render if its row was committed whole (turn-end/cancel) or
 	// replaced by a retry (new ID) meanwhile — its content is already handled, so
@@ -174,16 +197,16 @@ func (m *model) handleBlocksRendered(msg blocksRenderedMsg) tea.Cmd {
 	return tea.Sequence(cmds...)
 }
 
-// flushRenderer is the background goroutine's own markdown renderer, kept off
+// mdRenderer returns the background goroutine's own markdown renderer, kept off
 // m.conv.MDRenderer so a slow render can't block the live View on its mutex.
-// Rebuilt on width change; needs no lock since flushRendering means one render
+// Rebuilt on width change; needs no lock since flush.rendering means one render
 // uses it at a time.
-func (m *model) flushRenderer() *conv.MDRenderer {
-	if m.flushMD == nil || m.flushMDWidth != m.env.Width {
-		m.flushMD = conv.NewMDRenderer(m.env.Width)
-		m.flushMDWidth = m.env.Width
+func (f *flushState) mdRenderer(width int) *conv.MDRenderer {
+	if f.renderer == nil || f.width != width {
+		f.renderer = conv.NewMDRenderer(width)
+		f.width = width
 	}
-	return m.flushMD
+	return f.renderer
 }
 
 func (m *model) commitAllMessages() []tea.Cmd {

--- a/internal/app/model_scrollback_test.go
+++ b/internal/app/model_scrollback_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
+
 	"github.com/genai-io/san/internal/app/conv"
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/llm"
@@ -13,6 +15,22 @@ func flushTestModel(msg core.ChatMessage) *model {
 	m := &model{env: env{Width: 80}, conv: conv.NewModel(80)}
 	m.conv.Messages = []core.ChatMessage{msg}
 	return m
+}
+
+// applyFlush runs the off-thread render Cmd that FlushStreamingBlocks kicked off
+// and lands its result, mirroring the real render → handleBlocksRendered path so
+// tests can assert the committed offsets the landing advances.
+func applyFlush(t *testing.T, m *model, cmds []tea.Cmd) {
+	t.Helper()
+	if len(cmds) == 0 {
+		t.Fatal("expected a flush render Cmd, got none")
+	}
+	msg := cmds[0]()
+	br, ok := msg.(blocksRenderedMsg)
+	if !ok {
+		t.Fatalf("flush Cmd returned %T, want blocksRenderedMsg", msg)
+	}
+	m.handleBlocksRendered(br)
 }
 
 // The live welcome banner is visible from launch and tracks the model the user
@@ -60,22 +78,25 @@ func TestTakeWelcomeBannerFreezesAndClears(t *testing.T) {
 
 // A completed thinking paragraph (terminated by a blank line) commits to
 // scrollback mid-stream, before any content arrives — reasoning no longer waits
-// for the whole block to finish.
+// for the whole block to finish. The render runs off-thread; the committed
+// offset advances only once it lands.
 func TestFlushStreamingBlocksCommitsThinkingParagraph(t *testing.T) {
 	m := flushTestModel(core.ChatMessage{
 		Role:     core.RoleAssistant,
 		Thinking: "first paragraph of reasoning\n\n",
 	})
 
-	if cmds := m.FlushStreamingBlocks(); len(cmds) == 0 {
-		t.Fatal("a completed thinking paragraph should commit")
-	}
+	applyFlush(t, m, m.FlushStreamingBlocks())
+
 	msg := m.conv.Messages[0]
 	if msg.ThinkingCommittedLen != len(msg.Thinking) {
 		t.Fatalf("ThinkingCommittedLen = %d, want %d", msg.ThinkingCommittedLen, len(msg.Thinking))
 	}
 	if !msg.ThinkingEmitted {
 		t.Fatal("ThinkingEmitted should be set after the first thinking block commits")
+	}
+	if m.flushRendering {
+		t.Fatal("flushRendering should clear once the render has landed")
 	}
 }
 
@@ -104,12 +125,83 @@ func TestFlushStreamingBlocksFlushesTrailingThinkingOnContent(t *testing.T) {
 		Content:  "Here",
 	})
 
-	if cmds := m.FlushStreamingBlocks(); len(cmds) == 0 {
-		t.Fatal("content starting should flush the trailing thinking paragraph")
-	}
+	applyFlush(t, m, m.FlushStreamingBlocks())
+
 	msg := m.conv.Messages[0]
 	if msg.ThinkingCommittedLen != len(msg.Thinking) {
 		t.Fatalf("thinking should be fully committed once content starts, got %d/%d",
 			msg.ThinkingCommittedLen, len(msg.Thinking))
+	}
+}
+
+// Only one block render is in flight at a time: while one is rendering off-
+// thread, a second flush is suppressed so the scrollback Printlns stay ordered.
+func TestFlushStreamingBlocksGatesWhileRendering(t *testing.T) {
+	m := flushTestModel(core.ChatMessage{
+		Role:    core.RoleAssistant,
+		Content: "first block\n\nsecond block\n\n",
+	})
+
+	if cmds := m.FlushStreamingBlocks(); len(cmds) == 0 {
+		t.Fatal("the first completed block should start a render")
+	}
+	if !m.flushRendering {
+		t.Fatal("flushRendering should latch while a render is in flight")
+	}
+	if cmds := m.FlushStreamingBlocks(); cmds != nil {
+		t.Fatal("a second flush must be suppressed while one render is in flight")
+	}
+}
+
+// A render that lands after its row was already committed whole (turn-end or
+// cancel commits the remainder, in-flight block included) is dropped — no
+// duplicate Println, and flushRendering still clears.
+func TestHandleBlocksRenderedDiscardsCommittedRow(t *testing.T) {
+	m := flushTestModel(core.ChatMessage{
+		Role:    core.RoleAssistant,
+		Content: "a block\n\n",
+	})
+
+	cmds := m.FlushStreamingBlocks()
+	if len(cmds) == 0 {
+		t.Fatal("expected a render Cmd")
+	}
+	br, ok := cmds[0]().(blocksRenderedMsg)
+	if !ok {
+		t.Fatal("flush Cmd did not return a blocksRenderedMsg")
+	}
+
+	// The row got committed to scrollback before the render landed.
+	m.conv.CommittedCount = 1
+	if cmd := m.handleBlocksRendered(br); cmd != nil {
+		t.Fatal("a render for an already-committed row must be discarded (no Println)")
+	}
+	if m.flushRendering {
+		t.Fatal("flushRendering must clear even when the render is discarded")
+	}
+}
+
+// A render that lands after its row was dropped and replaced by a retry's fresh
+// row (new message ID) is dropped rather than corrupting the new row's offsets.
+func TestHandleBlocksRenderedDiscardsReplacedRow(t *testing.T) {
+	m := flushTestModel(core.ChatMessage{
+		Role:    core.RoleAssistant,
+		ID:      "old",
+		Content: "a block\n\n",
+	})
+
+	cmds := m.FlushStreamingBlocks()
+	if len(cmds) == 0 {
+		t.Fatal("expected a render Cmd")
+	}
+	br := cmds[0]().(blocksRenderedMsg)
+
+	// Retry dropped the streaming row and appended a fresh one (new ID).
+	m.conv.Messages[0] = core.ChatMessage{Role: core.RoleAssistant, ID: "new", Content: "retried"}
+	if cmd := m.handleBlocksRendered(br); cmd != nil {
+		t.Fatal("a render for a replaced row must be discarded")
+	}
+	if got := m.conv.Messages[0].ContentCommittedLen; got != 0 {
+		t.Fatalf("the fresh row's ContentCommittedLen = %d, want 0 (stale render must not advance it)", got)
 	}
 }

--- a/internal/app/model_scrollback_test.go
+++ b/internal/app/model_scrollback_test.go
@@ -18,19 +18,19 @@ func flushTestModel(msg core.ChatMessage) *model {
 }
 
 // applyFlush runs the off-thread render Cmd that FlushStreamingBlocks kicked off
-// and lands its result, mirroring the real render → handleBlocksRendered path so
-// tests can assert the committed offsets the landing advances.
+// and lands its result, mirroring the real render → handleFlushResult path
+// so tests can assert the committed offsets the landing advances.
 func applyFlush(t *testing.T, m *model, cmds []tea.Cmd) {
 	t.Helper()
 	if len(cmds) == 0 {
 		t.Fatal("expected a flush render Cmd, got none")
 	}
 	msg := cmds[0]()
-	br, ok := msg.(blocksRenderedMsg)
+	br, ok := msg.(flushResultMsg)
 	if !ok {
-		t.Fatalf("flush Cmd returned %T, want blocksRenderedMsg", msg)
+		t.Fatalf("flush Cmd returned %T, want flushResultMsg", msg)
 	}
-	m.handleBlocksRendered(br)
+	m.handleFlushResult(br)
 }
 
 // The live welcome banner is visible from launch and tracks the model the user
@@ -95,8 +95,8 @@ func TestFlushStreamingBlocksCommitsThinkingParagraph(t *testing.T) {
 	if !msg.ThinkingEmitted {
 		t.Fatal("ThinkingEmitted should be set after the first thinking block commits")
 	}
-	if m.flushRendering {
-		t.Fatal("flushRendering should clear once the render has landed")
+	if m.flush.rendering {
+		t.Fatal("flush.rendering should clear once the render has landed")
 	}
 }
 
@@ -145,8 +145,8 @@ func TestFlushStreamingBlocksGatesWhileRendering(t *testing.T) {
 	if cmds := m.FlushStreamingBlocks(); len(cmds) == 0 {
 		t.Fatal("the first completed block should start a render")
 	}
-	if !m.flushRendering {
-		t.Fatal("flushRendering should latch while a render is in flight")
+	if !m.flush.rendering {
+		t.Fatal("flush.rendering should latch while a render is in flight")
 	}
 	if cmds := m.FlushStreamingBlocks(); cmds != nil {
 		t.Fatal("a second flush must be suppressed while one render is in flight")
@@ -155,8 +155,8 @@ func TestFlushStreamingBlocksGatesWhileRendering(t *testing.T) {
 
 // A render that lands after its row was already committed whole (turn-end or
 // cancel commits the remainder, in-flight block included) is dropped — no
-// duplicate Println, and flushRendering still clears.
-func TestHandleBlocksRenderedDiscardsCommittedRow(t *testing.T) {
+// duplicate Println, and flush.rendering still clears.
+func TestHandleFlushResultDiscardsCommittedRow(t *testing.T) {
 	m := flushTestModel(core.ChatMessage{
 		Role:    core.RoleAssistant,
 		Content: "a block\n\n",
@@ -166,24 +166,24 @@ func TestHandleBlocksRenderedDiscardsCommittedRow(t *testing.T) {
 	if len(cmds) == 0 {
 		t.Fatal("expected a render Cmd")
 	}
-	br, ok := cmds[0]().(blocksRenderedMsg)
+	br, ok := cmds[0]().(flushResultMsg)
 	if !ok {
-		t.Fatal("flush Cmd did not return a blocksRenderedMsg")
+		t.Fatal("flush Cmd did not return a flushResultMsg")
 	}
 
 	// The row got committed to scrollback before the render landed.
 	m.conv.CommittedCount = 1
-	if cmd := m.handleBlocksRendered(br); cmd != nil {
+	if cmd := m.handleFlushResult(br); cmd != nil {
 		t.Fatal("a render for an already-committed row must be discarded (no Println)")
 	}
-	if m.flushRendering {
-		t.Fatal("flushRendering must clear even when the render is discarded")
+	if m.flush.rendering {
+		t.Fatal("flush.rendering must clear even when the render is discarded")
 	}
 }
 
 // A render that lands after its row was dropped and replaced by a retry's fresh
 // row (new message ID) is dropped rather than corrupting the new row's offsets.
-func TestHandleBlocksRenderedDiscardsReplacedRow(t *testing.T) {
+func TestHandleFlushResultDiscardsReplacedRow(t *testing.T) {
 	m := flushTestModel(core.ChatMessage{
 		Role:    core.RoleAssistant,
 		ID:      "old",
@@ -194,11 +194,11 @@ func TestHandleBlocksRenderedDiscardsReplacedRow(t *testing.T) {
 	if len(cmds) == 0 {
 		t.Fatal("expected a render Cmd")
 	}
-	br := cmds[0]().(blocksRenderedMsg)
+	br := cmds[0]().(flushResultMsg)
 
 	// Retry dropped the streaming row and appended a fresh one (new ID).
 	m.conv.Messages[0] = core.ChatMessage{Role: core.RoleAssistant, ID: "new", Content: "retried"}
-	if cmd := m.handleBlocksRendered(br); cmd != nil {
+	if cmd := m.handleFlushResult(br); cmd != nil {
 		t.Fatal("a render for a replaced row must be discarded")
 	}
 	if got := m.conv.Messages[0].ContentCommittedLen; got != 0 {

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -193,6 +193,8 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			log.Logger().Warn("async session persist failed", zap.Error(msg.err))
 		}
 		return m, nil
+	case blocksRenderedMsg:
+		return m, m.handleBlocksRendered(msg)
 	case conv.QuestionResponseMsg:
 		return m, m.handleQuestionResponse(msg)
 	case input.SecretPromptResponseMsg:

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -193,8 +193,8 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			log.Logger().Warn("async session persist failed", zap.Error(msg.err))
 		}
 		return m, nil
-	case blocksRenderedMsg:
-		return m, m.handleBlocksRendered(msg)
+	case flushResultMsg:
+		return m, m.handleFlushResult(msg)
 	case conv.QuestionResponseMsg:
 		return m, m.handleQuestionResponse(msg)
 	case input.SecretPromptResponseMsg:


### PR DESCRIPTION
Committing a completed markdown block to scrollback mid-stream ran the glamour
render (parse + syntax highlight) on the UI goroutine, stalling repaint at every
block boundary — so streaming output stuttered.

Render the block on a background `Cmd` instead (the result lands via
`blocksRenderedMsg`). One render runs at a time so scrollback stays ordered, and
a late render whose row was already committed or replaced is dropped.
