### PR TITLE
refactor: shorten the auto-review reason; scope per-frame result precompute

### DIFF
--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -392,7 +392,7 @@ func RenderSystemMessage(content string) string {
 // renderDecision renders the auto-review outcome as a one-line annotation
 // between a tool call and its result: a "↳" arrow plus the decision — green
 // "auto-approved" when the judge let it through, amber "escalated" when it
-// handed the call back to the user — and the judge's one-sentence reason dimmed
+// handed the call back to the user — and the judge's (few-word) reason dimmed
 // after it. Returns "" when the call was not judged. The "  ↳" indent aligns the
 // arrow with the "⎿" result trailer on the line below.
 func renderDecision(v *core.ReviewDecision) string {

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -325,11 +325,38 @@ func TestRenderActiveContentShowsRunningStateForPendingWebFetch(t *testing.T) {
 		SpinnerView:  "⋯",
 		Width:        100,
 	}
-	params.InlinedResults = PrecomputeInlinedResults(params.Messages)
+	params.InlinedResults = PrecomputeInlinedResults(params.Messages, 0)
 
 	rendered := stripANSI(RenderActiveContent(params))
 	if !strings.Contains(rendered, "⋯ WebFetch(https://github.com/features/copilot/plans)") {
 		t.Fatalf("RenderActiveContent() = %q, want pending WebFetch spinner", rendered)
+	}
+}
+
+func TestPrecomputeInlinedResultsFromScopesToActiveRange(t *testing.T) {
+	// assistant(0) with a tool call, then its result(1), then a fresh
+	// assistant(2) with a call and its result(3).
+	msgs := []core.ChatMessage{
+		{Role: core.RoleAssistant, ToolCalls: []core.ToolCall{{ID: "a", Name: "Bash"}}},
+		{Role: core.RoleUser, ToolResult: &core.ToolResult{ToolCallID: "a", ToolName: "Bash"}},
+		{Role: core.RoleAssistant, ToolCalls: []core.ToolCall{{ID: "b", Name: "Bash"}}},
+		{Role: core.RoleUser, ToolResult: &core.ToolResult{ToolCallID: "b", ToolName: "Bash"}},
+	}
+
+	// from=0 inlines both results with their owners.
+	all := PrecomputeInlinedResults(msgs, 0)
+	if !all.IsResultInlined(1) || !all.IsResultInlined(3) {
+		t.Fatalf("from=0 should inline both results, got %+v", all.resultOwner)
+	}
+
+	// from=2 (first turn committed) scans only the active tail: result(3)
+	// still inlines under assistant(2); the committed result(1) is skipped.
+	active := PrecomputeInlinedResults(msgs, 2)
+	if active.IsResultInlined(1) {
+		t.Errorf("from=2 should not scan the committed result at index 1")
+	}
+	if !active.IsResultInlined(3) || active.ownerOf(3) != 2 {
+		t.Errorf("from=2 should still inline the active result at index 3 under assistant 2")
 	}
 }
 

--- a/internal/app/conv/view.go
+++ b/internal/app/conv/view.go
@@ -67,16 +67,25 @@ type inlinedToolResults struct {
 	resultsForAssistant map[int]map[string]ToolResultData
 }
 
-// PrecomputeInlinedResults walks `messages` once and returns the
-// inlining map. Exported because the model builds it inside
-// messageRenderParams; everything else in this package reads
-// RenderContext.InlinedResults.
-func PrecomputeInlinedResults(messages []core.ChatMessage) inlinedToolResults {
+// PrecomputeInlinedResults walks `messages[from:]` once and returns the
+// inlining map. `from` is the caller's CommittedCount: the render only ever
+// draws [from:] (committed messages live in native scrollback), so scanning the
+// whole conversation every frame is pure waste that grows with session length.
+// Absolute indices are preserved — the maps key by position in the full slice,
+// and a result at index ≥ from is always owned by an assistant at index ≥ from
+// (an assistant commits together with its tool results), so nothing is missed.
+// Exported because the model builds it inside messageRenderParams; everything
+// else in this package reads RenderContext.InlinedResults.
+func PrecomputeInlinedResults(messages []core.ChatMessage, from int) inlinedToolResults {
 	p := inlinedToolResults{
 		resultOwner:         make(map[int]int),
 		resultsForAssistant: make(map[int]map[string]ToolResultData),
 	}
-	for i, msg := range messages {
+	if from < 0 {
+		from = 0
+	}
+	for i := from; i < len(messages); i++ {
+		msg := messages[i]
 		if msg.Role != core.RoleAssistant || len(msg.ToolCalls) == 0 {
 			continue
 		}

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -302,7 +302,7 @@ func (m model) messageRenderParams() conv.RenderContext {
 		// Conversation state
 		Messages:       m.conv.Messages,
 		CommittedCount: m.conv.CommittedCount,
-		InlinedResults: conv.PrecomputeInlinedResults(m.conv.Messages),
+		InlinedResults: conv.PrecomputeInlinedResults(m.conv.Messages, m.conv.CommittedCount),
 
 		// Streaming + tool execution
 		StreamActive: m.conv.Stream.Active,

--- a/internal/reviewer/reviewer.go
+++ b/internal/reviewer/reviewer.go
@@ -137,7 +137,7 @@ func parseBashPromptReply(content string) (BashPromptReply, error) {
 const permissionTask = `Decide whether to auto-approve the following tool call, or escalate it to the user.
 
 Respond with ONLY a JSON object:
-{"decision": "allow" | "escalate", "reason": "<one short sentence>"}`
+{"decision": "allow" | "escalate", "reason": "<a few words>"}`
 
 // bashPromptTask is the per-call instruction for answering an interactive prompt
 // a running, already-approved command raised.


### PR DESCRIPTION
Two changes (two commits), both following up on the auto-review feature (#274):

1. **Shorter decision reason** — ask the judge for `a few words` instead of `one short sentence`, so the inline decision annotation stays a short one-liner.
2. **Perf: scope inlined-result precompute** — `messageRenderParams` rebuilt the tool-result inlining map over the *entire* conversation every frame (O(N) per frame, growing with session length). Only `[CommittedCount:]` is ever drawn, so scan just the active range. General render-path win, surfaced while investigating streaming smoothness.