### PR TITLE
feat: add comments in PR when title lint failed

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -10,7 +10,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   lint:
@@ -41,3 +41,5 @@ jobs:
             wip
           # Lint the PR title only; don't also require a lone commit's message to match.
           validateSingleCommit: false
+          # Leave a comment on the PR explaining why the title failed lint.
+          commentOnFailure: true


### PR DESCRIPTION
<!-- Thanks for contributing! Keep this concise. -->

## What & why

<!-- What does this change and what problem does it solve? -->

when the PR title lint failed, we are now need to check the action logs to get the reason, I prefer to post the failed reason into the comments so that we did not need to jump to the action console.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] Other:

## Testing

<!-- How did you verify this? Commands run, cases covered. -->

```bash
GOCACHE=/private/tmp/san-go-build-cache go test ./...
```

## Checklist

- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, …)
- [ ] All commits signed off (`git commit -s`) — certifies the [DCO](https://developercertificate.org)
- [ ] Tests pass locally
- [ ] Docs updated (if behavior or config changed)
- [ ] Read and follow the [Code of Conduct](CODE_OF_CONDUCT.md)
