### PR TITLE
feat: autopilot follow-ups — Suggest steer, hands-free start, mission lifecycle

### DIFF
--- a/docs/guides/autopilot.md
+++ b/docs/guides/autopilot.md
@@ -1,0 +1,148 @@
+# Autopilot
+
+## Overview
+
+Autopilot is San's autonomy system, designed to minimize human intervention: a
+copilot model cruises the session, keeping routine work moving and handing
+control back only when something genuinely needs you. It acts through a set of
+independently enabled **steers** — proposing or rewriting input, approving
+gray-zone tool calls, answering a command's interactive prompts, answering
+`AskUserQuestion`, and continuing finished turns toward a mission. Only
+gray-zone permission judging is on by default.
+
+Enter AutoPilot mode with `shift+tab` (cycle until the amber
+`⏵⏵ autopilot on`), and configure it with the `/autopilot` panel. A resumed
+session (`san -r <id>`) comes back in the mode it was saved in.
+
+## The six steers
+
+Steers are à-la-carte toggles, ordered by increasing autonomy. None fire unless
+AutoPilot mode is engaged.
+
+| Steer | Default | What it does |
+|---|---|---|
+| **Suggest** | off | Fills the input hint (ghost text) with the copilot's proposed next step — toward the mission when one is set, the generic prediction otherwise. `tab` accepts, `enter` sends. It suggests; it never acts. With Suggest *off*, AutoPilot suppresses the hint entirely so the copilot doesn't nudge. |
+| **Start** | off | Owns the turn's input: rewrites each message you send into a clearer, mission-aligned instruction, and — when you enter AutoPilot with a mission set and an empty composer — kicks off the mission by deriving and submitting the first step itself. |
+| **Permission** | **on** | Auto-approves gray-zone tool calls the static rules couldn't resolve, judging reversibility, blast radius, and data exfiltration. Fails closed: any error escalates to you. |
+| **Bash** | off | Answers an already-approved command's interactive prompt (`Continue? [Y/n]`) when the answer just continues the approved action; skips anything that would widen scope. |
+| **Question** | off | Answers `AskUserQuestion` for you when the mission makes the choice clear and low-risk; defers to you otherwise. Option labels are validated verbatim — a partial or invented answer becomes a defer. |
+| **End** | off | After a finished turn, decides whether to continue toward the mission and types the next instruction itself. Bounded by **Continue at most N times** (default 20); the counter resets on every human turn. |
+
+## Mission
+
+The mission is what the copilot drives toward this session — briefed
+conversationally in the `/autopilot` panel's Mission dialog (`enter` sends,
+`ctrl+r` clears, `esc` saves back). The steering steers (Suggest, Start,
+Question, End) read it; the safety steers (Permission, Bash) deliberately never
+see it, so an action's risk is judged independently of intent.
+
+When the End steer decides the mission is **fully accomplished**, it retires
+it: the mission is cleared and the steers reset to the passive baseline
+(Permission + Bash) — AutoPilot stays on, you take the wheel back with the
+auto-approve safety net intact.
+
+## Demo: a hands-free scaffold
+
+A two-minute run that exercises the full loop — mission kick-off, gray-zone
+approval, auto-continuation, and completion — without touching anything outside
+a scratch directory.
+
+**1. Start San in an empty directory:**
+
+```bash
+mkdir /tmp/autopilot-demo && cd /tmp/autopilot-demo && san
+```
+
+**2. Configure the copilot** — run `/autopilot`:
+
+- Toggle **Start** and **End** on (Permission is already on).
+- Open **Mission** and brief it:
+
+  > Scaffold a `notes/` directory: `todo.md` with a 3-item checklist, `done.md`
+  > empty, and `README.md` explaining the layout. Work one file per turn. When
+  > all three exist, verify with `ls notes/` — then the mission is complete.
+
+- `esc` back, then **Save**.
+
+**3. Engage** — press `shift+tab` until the mode line shows
+`⏵⏵ autopilot on`. That's the last key you need to press: with Start on, a
+mission set, and an empty composer, the copilot derives the opening step and
+submits it itself.
+
+**4. Watch the run.** Expect a transcript like:
+
+```
+❭ Create notes/todo.md with a 3-item checklist.
+  ↖ autopilot · 1/20
+● Write(notes/todo.md)
+  ⎿  Write → 5 lines
+❭ Create an empty notes/done.md.
+  ↖ autopilot · 2/20
+...
+● Bash(ls notes/)
+  ↳ auto-approved · read-only directory listing
+  ⎿  Bash → 3 lines
+  ✓ autopilot · mission complete
+```
+
+Every `❭` in the run carries the green `↖ autopilot` mark — the copilot typed
+them all, opening step included; you never touched the composer. The `ls` is a
+gray-zone call the Permission steer approved inline. On `✓ mission complete` the mission is cleared and the steers drop back
+to the passive baseline — open `/autopilot` to confirm — while AutoPilot stays
+engaged.
+
+To see the gentler end of the spectrum, rerun with only **Suggest** on: the
+copilot proposes each step as ghost text in the composer and you accept with
+`tab` + `enter`.
+
+## Reading the transcript
+
+| Mark | Meaning |
+|---|---|
+| green `↖ autopilot · 2/5` | the `❭` line above was typed by the copilot (continuation 2 of 5) |
+| green `↖ autopilot · refined` | the `❭` line above is your message, rewritten by the Start steer |
+| green `↳ auto-approved · <reason>` | the permission judge let the tool call above through |
+| amber `↳ escalated · <reason>` | the judge sent the call back to you |
+| green `⏵ autopilot · answered for you` | the copilot answered an `AskUserQuestion` |
+| amber `↩ autopilot · this question is yours` | it deferred the question to you |
+| amber `↩ autopilot · over to you` | it stopped and handed control back (a decide error rides after it) |
+| green `✓ autopilot · mission complete` | the mission is done and retired |
+
+While a decision is in flight the mode line reads `⏵⏵ autopilot · thinking…`;
+approvals tally there too (`· 3 approved · 1 escalated`).
+
+## Configuration
+
+The panel edits the live session config and saves it to `settings.json` as the
+default seed for new sessions. The session's config and mode also persist with
+the transcript and restore on `/resume`.
+
+```jsonc
+{
+  "autoPilot": {
+    "model": "anthropic/claude-haiku-4-5", // steer decisions; empty = session model
+    "systemPrompt": "…",                   // "how it drives" — shared by all steers
+    "systemPromptFile": "~/prompts/pilot.md", // used when systemPrompt is empty
+    "mission": "…",                        // usually set via the panel, per session
+    "maxContinuations": 20,
+    "steers": {
+      "suggest": true,
+      "turnStart": true,   // the Start steer
+      "permission": true,  // omit for the default (on); false escalates everything
+      "bashPrompt": true,  // the Bash steer
+      "question": true,
+      "turnEnd": true      // the End steer
+    }
+  }
+}
+```
+
+Named presets: the panel's **▲ Export / ▼ Import** save and load whole configs
+under `~/.san/autopilot/<name>.json`.
+
+## Relationship to other features
+
+- [Permission model](../concepts/permission-model.md) — the static rules whose
+  gray zone the Permission steer judges; hard-blocked actions never reach it.
+- The judge component lives in `internal/reviewer` (`reviewer.Judge`); the
+  steers and panel live in `internal/app` / `internal/app/input`.

--- a/docs/guides/autopilot.zh.md
+++ b/docs/guides/autopilot.zh.md
@@ -1,0 +1,139 @@
+# Autopilot(副驾)
+
+## 概览
+
+Autopilot 是 San 的自动驾驶系统,旨在最大限度减少人工介入:由一个 copilot
+模型对会话进行巡航,让例行工作持续推进,只在真正需要人的时刻交还控制权。
+它通过一组可独立启用的介入点(**steer**)行动 —— 提议或改写输入、放行灰区
+工具调用、回答命令的交互问询、回答 `AskUserQuestion`,以及在回合结束后朝
+mission 继续推进。默认仅开启灰区权限判定。
+
+用 `shift+tab` 切换到 AutoPilot 模式(循环到琥珀色的 `⏵⏵ autopilot on`),
+用 `/autopilot` 面板配置。恢复会话(`san -r <id>`)会回到保存时所在的模式。
+
+## 六个 steer
+
+Steer 是按需组合的开关,按自主程度从低到高排列。AutoPilot 模式未开启时,
+任何 steer 都不会触发。
+
+| Steer | 默认 | 作用 |
+|---|---|---|
+| **Suggest** | 关 | 把副驾提议的下一步填进输入提示(幽灵文本)—— 有 mission 时朝 mission 提议,没有则退回通用预测。`tab` 接受、`enter` 发送。只建议、不代发。Suggest *关闭*时,AutoPilot 会整体压掉提示,避免副驾怂恿你。 |
+| **Start** | 关 | 负责回合的输入:把你发的每条消息改写成更清晰、贴合 mission 的指令;当你带着 mission、输入框为空进入 AutoPilot 时,自己从 mission 推出第一步并提交,免去开场那一句。 |
+| **Permission** | **开** | 自动放行静态规则解不了的灰区工具调用,按可逆性、影响面、数据外泄三轴判断。失败即收紧:任何错误都升级给你。 |
+| **Bash** | 关 | 回答已批准命令的交互问询(`Continue? [Y/n]`),仅当回答只是让已批准的动作继续;会扩大范围的一律跳过。 |
+| **Question** | 关 | 当 mission 使选择明确且低风险时替你回答 `AskUserQuestion`,否则留给你。选项标签逐字校验 —— 部分或凭空的回答一律转为留给你。 |
+| **End** | 关 | 回合结束后判断是否朝 mission 续跑,并自己敲出下一条指令。受 **Continue at most N times** 约束(默认 20);计数在每次人类回合重置。 |
+
+## Mission(任务)
+
+Mission 是副驾本会话要开往的目标 —— 在 `/autopilot` 面板的 Mission 对话框里
+口头交代(`enter` 发送、`ctrl+r` 清空、`esc` 存回)。推进类 steer(Suggest、
+Start、Question、End)读它;安全类 steer(Permission、Bash)刻意对它不可见,
+使动作风险的判断独立于意图。
+
+当 End steer 判定 mission **已完全达成**,会将其退役:清空 mission、steer 归位
+到被动基线(Permission + Bash)—— AutoPilot 保持开启,你重新接手,自动放行的
+安全网仍在。
+
+## Demo:一次免人工的脚手架搭建
+
+两分钟跑通完整闭环 —— mission 起步、灰区放行、自动续跑、任务完成 ——
+全程不触碰临时目录以外的任何东西。
+
+**1. 在空目录启动 San:**
+
+```bash
+mkdir /tmp/autopilot-demo && cd /tmp/autopilot-demo && san
+```
+
+**2. 配置 copilot** —— 运行 `/autopilot`:
+
+- 打开 **Start** 和 **End**(Permission 默认已开)。
+- 打开 **Mission**,交代任务:
+
+  > 搭建一个 `notes/` 目录:`todo.md` 放一个 3 项的清单、`done.md` 留空、
+  > `README.md` 说明目录结构。每回合处理一个文件。三个文件齐了之后用
+  > `ls notes/` 验证 —— 然后任务即完成。
+
+- `esc` 返回,然后 **Save**。
+
+**3. 启动巡航** —— 按 `shift+tab` 直到模式行显示 `⏵⏵ autopilot on`。
+这是你需要按的最后一个键:Start 开启、mission 已设、输入框为空时,
+copilot 会自己推出第一步并提交。
+
+**4. 观察运行。** 预期的转录大致是:
+
+```
+❭ Create notes/todo.md with a 3-item checklist.
+  ↖ autopilot · 1/20
+● Write(notes/todo.md)
+  ⎿  Write → 5 lines
+❭ Create an empty notes/done.md.
+  ↖ autopilot · 2/20
+...
+● Bash(ls notes/)
+  ↳ auto-approved · read-only directory listing
+  ⎿  Bash → 3 lines
+  ✓ autopilot · mission complete
+```
+
+整个运行里的每个 `❭` 都带绿色 `↖ autopilot` 标记 —— 包括开场那条,全部由
+copilot 敲入,你没有碰过输入框。那条 `ls` 是灰区调用,由 Permission steer
+就地放行。出现
+`✓ mission complete` 时,mission 被清空、steer 归位到被动基线(打开
+`/autopilot` 可确认),而 AutoPilot 保持开启。
+
+想体验最轻的一档,只开 **Suggest** 重跑一遍:copilot 把每一步以幽灵文本
+提议在输入框里,你用 `tab` + `enter` 接受发送。
+
+## 读懂转录里的标记
+
+| 标记 | 含义 |
+|---|---|
+| 绿 `↖ autopilot · 2/5` | 上方那条 `❭` 是副驾敲的(第 2 / 共 5 次续跑) |
+| 绿 `↖ autopilot · refined` | 上方那条 `❭` 是你的消息,被 Start steer 改写过 |
+| 绿 `↳ auto-approved · <理由>` | 判官放行了上方的工具调用 |
+| 琥珀 `↳ escalated · <理由>` | 判官把调用退回给你 |
+| 绿 `⏵ autopilot · answered for you` | 副驾替你回答了 `AskUserQuestion` |
+| 琥珀 `↩ autopilot · this question is yours` | 它把问题留给了你 |
+| 琥珀 `↩ autopilot · over to you` | 它停手并交还控制权(判定出错时错误原因缀在后面) |
+| 绿 `✓ autopilot · mission complete` | mission 完成并退役 |
+
+判定进行中,模式行显示 `⏵⏵ autopilot · thinking…`;放行计数也在那里
+(`· 3 approved · 1 escalated`)。
+
+## 配置
+
+面板编辑的是本会话的实时配置,保存后写入 `settings.json` 作为新会话的默认种子。
+会话自身的配置与模式也随转录持久化,`/resume` 时恢复。
+
+```jsonc
+{
+  "autoPilot": {
+    "model": "anthropic/claude-haiku-4-5", // steer 判定用的模型;留空用会话模型
+    "systemPrompt": "…",                   // “怎么开” —— 全部 steer 共用
+    "systemPromptFile": "~/prompts/pilot.md", // systemPrompt 为空时生效
+    "mission": "…",                        // 通常在面板里按会话设置
+    "maxContinuations": 20,
+    "steers": {
+      "suggest": true,
+      "turnStart": true,   // Start steer
+      "permission": true,  // 省略即默认开;false 则一律升级给你
+      "bashPrompt": true,  // Bash steer
+      "question": true,
+      "turnEnd": true      // End steer
+    }
+  }
+}
+```
+
+命名预设:面板的 **▲ Export / ▼ Import** 把整份配置存取于
+`~/.san/autopilot/<name>.json`。
+
+## 关联
+
+- [权限模型](../concepts/permission-model.md) —— Permission steer 判定的灰区
+  来自这套静态规则;被硬性拦截的动作永远到不了判官面前。
+- 判官组件在 `internal/reviewer`(`reviewer.Judge`);steer 与面板在
+  `internal/app` / `internal/app/input`。

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -9,6 +9,7 @@ Task-oriented how-tos. For conceptual background see
 | [`getting-started`](getting-started.md) | Install, build, and run San for the first time. |
 | [`inspector`](inspector.md) | Replay session transcripts with `san inspector`. |
 | [`explore-mode`](explore-mode.md) | Use the read-only Explore subagent for fan-out search. |
+| [`autopilot`](autopilot.md) | Configure the autopilot copilot: steers, mission, and the `/autopilot` panel. |
 | [`writing-a-skill`](writing-a-skill.md) | Author a Skill. |
 | [`writing-a-subagent`](writing-a-subagent.md) | Author a custom subagent. |
 | [`writing-a-plugin`](writing-a-plugin.md) | Bundle skills / agents / hooks / commands into a plugin. |

--- a/internal/app/autopilot.go
+++ b/internal/app/autopilot.go
@@ -231,6 +231,37 @@ func (m *model) autopilotContinueCmd(result core.Result) tea.Cmd {
 		m.conv.AddNotice(autopilotHandback("")) // spent the budget; the ↖ N/N above says why
 		return nil
 	}
+	return m.autopilotDecideCmd(result, false)
+}
+
+// autopilotKickCmd opens the mission when the human hasn't: on entering AutoPilot
+// with the TurnStart steer on, a mission set, and the agent idle, it derives the
+// first step from the mission (the same decision as TurnEnd, just an empty-ish
+// transcript) and submits it — so briefing a mission and switching autopilot on
+// is enough to start, with no opening turn to type. Returns nil when any
+// precondition is unmet, the human is mid-compose (don't clobber input), or a
+// decision is already in flight (don't stack on rapid mode cycling).
+func (m *model) autopilotKickCmd() tea.Cmd {
+	ar := m.env.AutoPilot
+	if !m.autopilotEngaged() || !ar.Steers.TurnStart || m.autopilotDeciding {
+		return nil
+	}
+	if m.conv.Stream.Active || strings.TrimSpace(m.userInput.FullValue()) != "" {
+		return nil
+	}
+	if m.autopilotContinuations >= ar.ResolvedMaxContinuations() {
+		return nil
+	}
+	return m.autopilotDecideCmd(core.Result{}, true)
+}
+
+// autopilotDecideCmd is the shared tail of the TurnEnd continuation and the Start
+// kick: it resolves the mission/model, renders the recent transcript, marks the
+// mode line "thinking…", and fires the async continue/done decision. The callers
+// own their distinct gates (steer toggle, budget notice, mid-compose check);
+// this owns the one decision pipeline so the two can't drift apart.
+func (m *model) autopilotDecideCmd(result core.Result, kick bool) tea.Cmd {
+	ar := m.env.AutoPilot
 	mission := strings.TrimSpace(ar.Mission)
 	if mission == "" {
 		return nil // no mission to steer toward
@@ -244,41 +275,7 @@ func (m *model) autopilotContinueCmd(result core.Result) tea.Cmd {
 	m.autopilotDeciding = true // shown on the mode indicator, not a transcript line
 	return autopilotAsync(func(ctx context.Context) tea.Msg {
 		cont, done, instruction, err := autopilotDecideContinue(ctx, provider, modelID, systemPrompt, mission, transcript)
-		return autopilotDecisionMsg{result: result, cont: cont, done: done, instruction: instruction, err: err}
-	})
-}
-
-// autopilotKickCmd opens the mission when the human hasn't: on entering AutoPilot
-// with the TurnStart steer on, a mission set, and the agent idle, it derives the
-// first step from the mission (the same decision as TurnEnd, just an empty-ish
-// transcript) and submits it — so briefing a mission and switching autopilot on
-// is enough to start, with no opening turn to type. Returns nil when any
-// precondition is unmet, or when the human is mid-compose (don't clobber input).
-func (m *model) autopilotKickCmd() tea.Cmd {
-	ar := m.env.AutoPilot
-	if !m.autopilotEngaged() || !ar.Steers.TurnStart {
-		return nil
-	}
-	if m.conv.Stream.Active || strings.TrimSpace(m.userInput.FullValue()) != "" {
-		return nil
-	}
-	if m.autopilotContinuations >= ar.ResolvedMaxContinuations() {
-		return nil
-	}
-	mission := strings.TrimSpace(ar.Mission)
-	if mission == "" {
-		return nil
-	}
-	provider, modelID := m.resolveReviewerModel(ar.Model)
-	if provider == nil {
-		return nil
-	}
-	transcript := autopilotRecentTranscript(m.conv.Messages, 3000)
-	systemPrompt := m.autopilotSystemPrompt()
-	m.autopilotDeciding = true // shown on the mode indicator, not a transcript line
-	return autopilotAsync(func(ctx context.Context) tea.Msg {
-		cont, done, instruction, err := autopilotDecideContinue(ctx, provider, modelID, systemPrompt, mission, transcript)
-		return autopilotDecisionMsg{kick: true, cont: cont, done: done, instruction: instruction, err: err}
+		return autopilotDecisionMsg{result: result, kick: kick, cont: cont, done: done, instruction: instruction, err: err}
 	})
 }
 
@@ -339,10 +336,20 @@ func autopilotDecideContinue(ctx context.Context, provider llm.Provider, modelID
 // prior turn) fires no idle hooks and stays quiet when it finds nothing to open.
 func (m *model) handleAutopilotDecision(msg autopilotDecisionMsg) tea.Cmd {
 	m.autopilotDeciding = false // the "thinking…" indicator clears here
-	// The human may have started a turn, or cycled out of AutoPilot, while the
-	// decision was in flight; if so, stand down entirely.
-	if m.conv.Stream.Active || !m.autopilotEngaged() {
+	// A turn is already in flight (a new stream, or a compaction mid-apply) — the
+	// running turn owns the lifecycle, so drop this stale decision silently.
+	if m.conv.Stream.Active || m.conv.Compact.Active {
 		return nil
+	}
+	// The human took over while we were deciding — left AutoPilot, or started
+	// typing their own next message. Don't act (and never clobber their draft);
+	// hand the finished turn back to them by firing the idle hooks OnTurnEnd
+	// deferred to us (a kick had no prior turn, so it has none to fire).
+	if !m.autopilotEngaged() || strings.TrimSpace(m.userInput.FullValue()) != "" {
+		if msg.kick {
+			return nil
+		}
+		return m.fireIdleHooksCmd(msg.result)
 	}
 	if msg.err == nil && msg.cont && msg.instruction != "" {
 		m.autopilotContinuations++
@@ -377,14 +384,16 @@ func (m *model) handleAutopilotDecision(msg autopilotDecisionMsg) tea.Cmd {
 }
 
 // retireAutopilotMission winds down a finished mission without leaving AutoPilot:
-// it clears the mission and resets the steers to the passive baseline (permission
-// + bash judging), so the copilot stops actively driving — no more continue,
-// rewrite, or auto-answer — and just keeps auto-approving while the human takes
-// over. Session-scoped: the saved settings.json config (the user's template) is
-// left untouched.
+// it clears the mission and turns off the driving steers (Suggest, TurnStart,
+// Question, TurnEnd), so the copilot stops actively driving — no more suggest,
+// rewrite, auto-answer, or continue — while the passive safety steers stay
+// exactly as the user configured them (a Bash steer they left off is NOT flipped
+// on, an explicit permission:false is NOT overridden). Session-scoped: the saved
+// settings.json config (the user's template) is left untouched.
 func (m *model) retireAutopilotMission() {
 	m.env.AutoPilot.Mission = ""
-	m.env.AutoPilot.Steers = setting.SteerSettings{BashPrompt: true} // Permission nil = on
+	s := &m.env.AutoPilot.Steers
+	s.Suggest, s.TurnStart, s.Question, s.TurnEnd = false, false, false, false
 	m.rebuildAutopilotReviewer()
 }
 
@@ -522,7 +531,8 @@ Return ONLY the rewritten message, with no preamble, quotes, or explanation. If 
 // TurnStart steer are on, returning (cmd, true) to rewrite it asynchronously
 // before sending. It returns (nil, false) — proceed normally — for the re-submit
 // of an already rewritten message, copilot continuations, slash commands, and
-// empty input.
+// empty input. While a rewrite is already in flight it swallows the submission
+// (nil, true) so a second Enter can't launch a second rewrite / double-submit.
 func (m *model) autopilotRewriteCmd(userMessage string) (tea.Cmd, bool) {
 	if m.autopilotRewrote {
 		m.autopilotRewrote = false // this IS the rewritten re-submit
@@ -531,6 +541,9 @@ func (m *model) autopilotRewriteCmd(userMessage string) (tea.Cmd, bool) {
 	ar := m.env.AutoPilot
 	if !m.autopilotEngaged() || !ar.Steers.TurnStart || m.autopilotContinuing {
 		return nil, false
+	}
+	if m.autopilotRewriting {
+		return nil, true // a rewrite is in flight; it will submit — swallow this Enter
 	}
 	userMessage = strings.TrimSpace(userMessage)
 	if userMessage == "" || strings.HasPrefix(userMessage, "/") {
@@ -542,6 +555,7 @@ func (m *model) autopilotRewriteCmd(userMessage string) (tea.Cmd, bool) {
 	}
 	mission := strings.TrimSpace(ar.Mission)
 	systemPrompt := m.autopilotSystemPrompt()
+	m.autopilotRewriting = true
 	m.autopilotDeciding = true // rewrite in flight — "thinking…" on the mode line
 	return autopilotAsync(func(ctx context.Context) tea.Msg {
 		return autopilotRewriteMsg{original: userMessage, rewritten: autopilotRewriteInput(ctx, provider, modelID, systemPrompt, mission, userMessage)}
@@ -567,6 +581,7 @@ func autopilotRewriteInput(ctx context.Context, provider llm.Provider, modelID, 
 // user left AutoPilot while the rewrite ran.
 func (m *model) handleAutopilotRewrite(msg autopilotRewriteMsg) tea.Cmd {
 	m.autopilotDeciding = false
+	m.autopilotRewriting = false
 	text := msg.rewritten
 	if text == "" {
 		text = msg.original
@@ -599,6 +614,12 @@ func (m *model) handleAutopilotQuestion(msg autopilotQuestionMsg) tea.Cmd {
 	// Drop if the question is no longer pending (human answered, or agent stopped
 	// and drained it).
 	if m.conv.Modal.PendingQuestion != msg.req || m.conv.Modal.PendingQuestionReply == nil {
+		return nil
+	}
+	// The human may have left AutoPilot (or turned the Question steer off) while
+	// the answer inference ran — precisely to answer it themselves. If so, leave
+	// the modal up for them.
+	if !m.autopilotEngaged() || !m.env.AutoPilot.Steers.Question {
 		return nil
 	}
 	if !msg.answer || len(msg.answers) == 0 {

--- a/internal/app/autopilot.go
+++ b/internal/app/autopilot.go
@@ -96,11 +96,10 @@ var (
 	autopilotDoneMark = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Success)
 )
 
-// autopilotHint formats a concise copilot notice: an amber "⏵ autopilot" mark
-// (the same brand as the mode indicator) plus a dimmed detail. It states only
-// what the copilot did — never the instruction itself, which reads back as the
-// submitted message — so the transcript looks like a human driving the session,
-// echoing the terse inline review-decision hints rather than a verbose insert.
+// autopilotHint formats a plain amber "⏵ autopilot · <detail>" notice — the
+// neutral copilot mark (same brand as the mode indicator). Used for the one-off
+// "start failed" message; the handback / action / mission-done notices below
+// carry their own arrow + colour.
 func autopilotHint(detail string) string {
 	return autopilotHintMark.Render("⏵ autopilot") + autopilotHintDim.Render(" · "+detail)
 }

--- a/internal/app/autopilot.go
+++ b/internal/app/autopilot.go
@@ -93,6 +93,7 @@ func (m *model) autopilotEngaged() bool {
 var (
 	autopilotHintMark = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Warning)
 	autopilotHintDim  = lipgloss.NewStyle().Foreground(kit.CurrentTheme.TextDim)
+	autopilotDoneMark = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Success)
 )
 
 // autopilotHint formats a concise copilot notice: an amber "⏵ autopilot" mark
@@ -104,15 +105,31 @@ func autopilotHint(detail string) string {
 	return autopilotHintMark.Render("⏵ autopilot") + autopilotHintDim.Render(" · "+detail)
 }
 
-// settleAutopilotHint resolves the pending "thinking…" notice into its outcome
-// on the same line — falling back to a fresh notice if that line already
-// flushed to scrollback — so the copilot's deliberation and its decision read
-// as one line instead of two.
-func (m *model) settleAutopilotHint(detail string) {
-	hint := autopilotHint(detail)
-	if !m.conv.SetLastNotice(hint) {
-		m.conv.AddNotice(hint)
+// autopilotHandback is the notice shown when the copilot returns control to the
+// human — it stops mid-mission (needs a decision, or spent its continuation
+// budget), so the arrow curves back to the user rather than driving forward.
+// A non-empty detail (e.g. the decide error) rides dimmed after it.
+func autopilotHandback(detail string) string {
+	s := autopilotHintMark.Render("↩ autopilot") + autopilotHintDim.Render(" · over to you")
+	if detail != "" {
+		s += autopilotHintDim.Render(" · " + detail)
 	}
+	return s
+}
+
+// autopilotAction is the green notice for something the copilot handled itself
+// (answered a question for you) — green = it kept the session moving, matching
+// the ↖ continuation mark and the auto-approved decision hint.
+func autopilotAction(detail string) string {
+	return autopilotDoneMark.Render("⏵ autopilot") + autopilotHintDim.Render(" · "+detail)
+}
+
+// autopilotMissionDone is the green notice shown when the copilot judges the
+// mission fully accomplished — a success terminal, distinct from the amber
+// handback. AutoPilot stays on (retireAutopilotMission drops to the passive
+// baseline), so the human keeps the auto-approve safety net.
+func autopilotMissionDone() string {
+	return autopilotDoneMark.Render("✓ autopilot") + autopilotHintDim.Render(" · mission complete")
 }
 
 // marshalAutoPilot encodes the live config for session persistence, returning
@@ -182,7 +199,9 @@ func (m *model) missionReply(ctx context.Context, history []input.MissionMessage
 // to the UI goroutine.
 type autopilotDecisionMsg struct {
 	result      core.Result
+	kick        bool // opened the mission (no prior turn) vs continued a finished one
 	cont        bool
+	done        bool
 	instruction string
 	err         error
 }
@@ -190,10 +209,14 @@ type autopilotDecisionMsg struct {
 const continueDecisionTask = `The agent just finished a turn and is about to hand control back to the human. Decide whether to keep it going toward the mission.
 
 Reply with ONLY a JSON object:
-{"continue": true|false, "instruction": "the next thing to tell the agent"}
+{"continue": true|false, "done": true|false, "instruction": "the next thing to tell the agent"}
 
-Set continue=true only if the mission is clearly not yet complete AND there is a concrete, safe next step you can direct. The instruction is a short, direct imperative — exactly what you'd type to the agent as the next message.
-Set continue=false (with instruction "") if the mission looks complete, if you are unsure, if it needs a human decision, or if the agent is blocked or asking for input. When in doubt, stop.`
+- continue=true (with a short, direct instruction — exactly what you'd type to the agent next) only if the mission is clearly not yet complete AND there is a concrete, safe next step you can direct.
+- done=true (continue=false, instruction "") only if the mission is fully accomplished — nothing meaningful is left to do.
+- continue=false, done=false (instruction "") if you are stopping but the mission is NOT complete: you are unsure, it needs a human decision, or the agent is blocked or asking for input.
+When in doubt, stop (continue=false, done=false).
+
+Judge what is already accomplished from the whole session transcript below, not the last turn alone — do not re-issue a step the transcript shows is already done.`
 
 // autopilotContinueCmd asks the copilot whether to auto-continue the finished
 // turn. It returns nil (letting the turn go idle normally) when AutoPilot mode
@@ -205,7 +228,7 @@ func (m *model) autopilotContinueCmd(result core.Result) tea.Cmd {
 		return nil
 	}
 	if m.autopilotContinuations >= ar.ResolvedMaxContinuations() {
-		m.conv.AddNotice(autopilotHint(fmt.Sprintf("budget reached (%d) · handing back", ar.ResolvedMaxContinuations())))
+		m.conv.AddNotice(autopilotHandback("")) // spent the budget; the ↖ N/N above says why
 		return nil
 	}
 	mission := strings.TrimSpace(ar.Mission)
@@ -216,50 +239,153 @@ func (m *model) autopilotContinueCmd(result core.Result) tea.Cmd {
 	if provider == nil {
 		return nil
 	}
-	last := core.LastAssistantChatContent(m.conv.Messages)
+	transcript := autopilotRecentTranscript(m.conv.Messages, 3000)
 	systemPrompt := m.autopilotSystemPrompt()
-	m.conv.AddNotice(autopilotHint("thinking…"))
+	m.autopilotDeciding = true // shown on the mode indicator, not a transcript line
 	return autopilotAsync(func(ctx context.Context) tea.Msg {
-		cont, instruction, err := autopilotDecideContinue(ctx, provider, modelID, systemPrompt, mission, last)
-		return autopilotDecisionMsg{result: result, cont: cont, instruction: instruction, err: err}
+		cont, done, instruction, err := autopilotDecideContinue(ctx, provider, modelID, systemPrompt, mission, transcript)
+		return autopilotDecisionMsg{result: result, cont: cont, done: done, instruction: instruction, err: err}
 	})
 }
 
-func autopilotDecideContinue(ctx context.Context, provider llm.Provider, modelID, systemPrompt, mission, lastTurn string) (bool, string, error) {
-	user := continueDecisionTask + "\n\nMission:\n" + mission + "\n\nThe agent's last turn ended with:\n" + kit.TruncateText(lastTurn, 2000)
+// autopilotKickCmd opens the mission when the human hasn't: on entering AutoPilot
+// with the TurnStart steer on, a mission set, and the agent idle, it derives the
+// first step from the mission (the same decision as TurnEnd, just an empty-ish
+// transcript) and submits it — so briefing a mission and switching autopilot on
+// is enough to start, with no opening turn to type. Returns nil when any
+// precondition is unmet, or when the human is mid-compose (don't clobber input).
+func (m *model) autopilotKickCmd() tea.Cmd {
+	ar := m.env.AutoPilot
+	if !m.autopilotEngaged() || !ar.Steers.TurnStart {
+		return nil
+	}
+	if m.conv.Stream.Active || strings.TrimSpace(m.userInput.FullValue()) != "" {
+		return nil
+	}
+	if m.autopilotContinuations >= ar.ResolvedMaxContinuations() {
+		return nil
+	}
+	mission := strings.TrimSpace(ar.Mission)
+	if mission == "" {
+		return nil
+	}
+	provider, modelID := m.resolveReviewerModel(ar.Model)
+	if provider == nil {
+		return nil
+	}
+	transcript := autopilotRecentTranscript(m.conv.Messages, 3000)
+	systemPrompt := m.autopilotSystemPrompt()
+	m.autopilotDeciding = true // shown on the mode indicator, not a transcript line
+	return autopilotAsync(func(ctx context.Context) tea.Msg {
+		cont, done, instruction, err := autopilotDecideContinue(ctx, provider, modelID, systemPrompt, mission, transcript)
+		return autopilotDecisionMsg{kick: true, cont: cont, done: done, instruction: instruction, err: err}
+	})
+}
+
+// autopilotRecentTranscript renders the recent human/agent turns as a compact
+// "you:/agent:" transcript for the turn-end decision, so the copilot judges
+// mission progress across the whole run — not from the last turn alone (which
+// can't tell it an earlier step is already done). Walks back from the newest
+// message within a character budget, then returns the kept turns oldest-first;
+// tool-result and compact-summary rows are skipped.
+func autopilotRecentTranscript(messages []core.ChatMessage, budget int) string {
+	var lines []string
+	used := 0
+	for i := len(messages) - 1; i >= 0 && used < budget; i-- {
+		msg := messages[i]
+		var label string
+		switch {
+		case msg.Role == core.RoleUser && msg.ToolResult == nil && !core.IsCompactSummary(msg.Content):
+			label = "you"
+		case msg.Role == core.RoleAssistant:
+			label = "agent"
+		default:
+			continue
+		}
+		text := strings.TrimSpace(msg.Content)
+		if text == "" {
+			continue
+		}
+		line := label + ": " + kit.TruncateText(text, 600)
+		lines = append(lines, line)
+		used += len(line)
+	}
+	for i, j := 0, len(lines)-1; i < j; i, j = i+1, j-1 {
+		lines[i], lines[j] = lines[j], lines[i] // oldest-first, so it reads top-to-bottom
+	}
+	return strings.Join(lines, "\n")
+}
+
+func autopilotDecideContinue(ctx context.Context, provider llm.Provider, modelID, systemPrompt, mission, transcript string) (cont, done bool, instruction string, err error) {
+	user := continueDecisionTask + "\n\nMission:\n" + mission + "\n\nSession so far (recent turns, oldest first):\n" + transcript
 	content, err := autopilotComplete(ctx, provider, modelID, systemPrompt, user, 400)
 	if err != nil {
-		return false, "", err
+		return false, false, "", err
 	}
 	var out struct {
 		Continue    bool   `json:"continue"`
+		Done        bool   `json:"done"`
 		Instruction string `json:"instruction"`
 	}
 	if err := json.Unmarshal([]byte(reviewer.ExtractJSONObject(content)), &out); err != nil {
-		return false, "", err
+		return false, false, "", err
 	}
-	return out.Continue, strings.TrimSpace(out.Instruction), nil
+	return out.Continue, out.Done, strings.TrimSpace(out.Instruction), nil
 }
 
-// handleAutopilotDecision acts on the copilot's turn-end verdict: on continue it
-// "types" the instruction into the composer and submits it (visible, budgeted);
-// on stop it fires the idle hooks OnTurnEnd deferred while the decision ran.
+// handleAutopilotDecision acts on the copilot's turn-end or kick verdict: on
+// continue it "types" the instruction into the composer and submits it (visible,
+// budgeted); on done it retires the mission; otherwise it hands back. A kick (no
+// prior turn) fires no idle hooks and stays quiet when it finds nothing to open.
 func (m *model) handleAutopilotDecision(msg autopilotDecisionMsg) tea.Cmd {
-	// The human may have started a turn while the decision was in flight; if so,
-	// stand down entirely.
-	if m.conv.Stream.Active {
+	m.autopilotDeciding = false // the "thinking…" indicator clears here
+	// The human may have started a turn, or cycled out of AutoPilot, while the
+	// decision was in flight; if so, stand down entirely.
+	if m.conv.Stream.Active || !m.autopilotEngaged() {
 		return nil
 	}
 	if msg.err == nil && msg.cont && msg.instruction != "" {
 		m.autopilotContinuations++
 		m.autopilotContinuing = true
-		m.settleAutopilotHint(fmt.Sprintf("continuing (%d/%d)",
-			m.autopilotContinuations, m.env.AutoPilot.ResolvedMaxContinuations()))
 		m.userInput.Textarea.SetValue(msg.instruction) // visible: the copilot "types" it, then it reads back as the submitted message
 		return m.handleSubmit()
 	}
-	m.settleAutopilotHint("handing back")
+	if msg.err == nil && msg.done {
+		m.conv.AddNotice(autopilotMissionDone())
+		m.retireAutopilotMission()
+		if msg.kick {
+			return nil
+		}
+		return m.fireIdleHooksCmd(msg.result)
+	}
+	// Stopped without completing: hand back, surfacing a decide error so a
+	// misconfigured model doesn't read as a silent "chose to stop". A kick that
+	// found nothing to open stays quiet — it never took over, so there's nothing
+	// to hand back — but a kick that *errored* says so.
+	if msg.kick {
+		if msg.err != nil {
+			m.conv.AddNotice(autopilotHint("start failed · " + kit.TruncateText(msg.err.Error(), 120)))
+		}
+		return nil
+	}
+	detail := ""
+	if msg.err != nil {
+		detail = kit.TruncateText(msg.err.Error(), 120)
+	}
+	m.conv.AddNotice(autopilotHandback(detail))
 	return m.fireIdleHooksCmd(msg.result)
+}
+
+// retireAutopilotMission winds down a finished mission without leaving AutoPilot:
+// it clears the mission and resets the steers to the passive baseline (permission
+// + bash judging), so the copilot stops actively driving — no more continue,
+// rewrite, or auto-answer — and just keeps auto-approving while the human takes
+// over. Session-scoped: the saved settings.json config (the user's template) is
+// left untouched.
+func (m *model) retireAutopilotMission() {
+	m.env.AutoPilot.Mission = ""
+	m.env.AutoPilot.Steers = setting.SteerSettings{BashPrompt: true} // Permission nil = on
+	m.rebuildAutopilotReviewer()
 }
 
 // autopilotComplete runs one single-user-message completion and returns the
@@ -416,6 +542,7 @@ func (m *model) autopilotRewriteCmd(userMessage string) (tea.Cmd, bool) {
 	}
 	mission := strings.TrimSpace(ar.Mission)
 	systemPrompt := m.autopilotSystemPrompt()
+	m.autopilotDeciding = true // rewrite in flight — "thinking…" on the mode line
 	return autopilotAsync(func(ctx context.Context) tea.Msg {
 		return autopilotRewriteMsg{original: userMessage, rewritten: autopilotRewriteInput(ctx, provider, modelID, systemPrompt, mission, userMessage)}
 	}), true
@@ -433,15 +560,18 @@ func autopilotRewriteInput(ctx context.Context, provider llm.Provider, modelID, 
 	return out
 }
 
-// handleAutopilotRewrite re-submits the (possibly) rewritten message.
+// handleAutopilotRewrite re-submits the (possibly) rewritten message. When the
+// rewrite changed the text, the re-submitted message wears the "↖ autopilot ·
+// refined" annotation (via autopilotRefined → dispatchSubmission) instead of a
+// separate notice. The message must never be lost, so this submits even if the
+// user left AutoPilot while the rewrite ran.
 func (m *model) handleAutopilotRewrite(msg autopilotRewriteMsg) tea.Cmd {
+	m.autopilotDeciding = false
 	text := msg.rewritten
 	if text == "" {
 		text = msg.original
 	}
-	if text != msg.original {
-		m.conv.AddNotice(autopilotHint("refined your request"))
-	}
+	m.autopilotRefined = text != msg.original
 	m.autopilotRewrote = true
 	m.userInput.Textarea.SetValue(text)
 	return m.handleSubmit()
@@ -472,11 +602,11 @@ func (m *model) handleAutopilotQuestion(msg autopilotQuestionMsg) tea.Cmd {
 		return nil
 	}
 	if !msg.answer || len(msg.answers) == 0 {
-		m.conv.AddNotice(autopilotHint("left this question for you"))
+		m.conv.AddNotice(autopilotHandback("this question is yours"))
 		return nil
 	}
 	m.conv.Modal.Question.Hide()
-	m.conv.AddNotice(autopilotHint("answered for you"))
+	m.conv.AddNotice(autopilotAction("answered for you"))
 	return m.handleQuestionResponse(conv.QuestionResponseMsg{
 		Request:  msg.req,
 		Response: &tool.QuestionResponse{RequestID: msg.req.ID, Answers: msg.answers},

--- a/internal/app/conv/conversation.go
+++ b/internal/app/conv/conversation.go
@@ -49,20 +49,6 @@ func (m *ConversationModel) AddNotice(content string) {
 	m.Messages = append(m.Messages, core.ChatMessage{Role: core.RoleNotice, Content: content})
 }
 
-// SetLastNotice rewrites the trailing notice in place when it's still in the
-// live tail (not yet flushed to scrollback), returning true. It returns false —
-// so the caller can AddNotice instead — when the last message isn't an
-// uncommitted notice. This lets a transient "…thinking" notice resolve into its
-// outcome on the same line rather than stacking a second line beneath it.
-func (m *ConversationModel) SetLastNotice(content string) bool {
-	idx := len(m.Messages) - 1
-	if idx < 0 || idx < m.CommittedCount || m.Messages[idx].Role != core.RoleNotice {
-		return false
-	}
-	m.Messages[idx].Content = content
-	return true
-}
-
 func (m *ConversationModel) AppendToLast(text, thinking string) {
 	if len(m.Messages) == 0 {
 		return

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -96,6 +96,12 @@ var (
 	decisionEscalatedStyle = lipgloss.NewStyle().
 				Foreground(kit.CurrentTheme.Warning)
 
+	// The autopilot continuation header: green like an auto-approved decision —
+	// the copilot drove this turn forward — with a downward arrow that points at
+	// the "❭" line right below it.
+	autopilotStepStyle = lipgloss.NewStyle().
+				Foreground(kit.CurrentTheme.Success)
+
 	trackerPendingStyle = lipgloss.NewStyle().
 				Foreground(kit.CurrentTheme.Muted)
 
@@ -114,6 +120,16 @@ var (
 				Background(kit.CurrentTheme.Primary).
 				Bold(true)
 )
+
+// RenderAutopilotMark is the "↖ autopilot · <note>" annotation a copilot-produced
+// turn wears — a continuation ("2/5") or a rewrite ("refined") — drawn tight
+// below its "❭" line: the up-left arrow points back at the instruction to say
+// the copilot, not the human, typed it (mirroring how a permission decision
+// hangs under the call it judged).
+func RenderAutopilotMark(note string) string {
+	return autopilotStepStyle.Render("  ↖ autopilot") +
+		toolResultStyle.Render(" · "+note) + "\n"
+}
 
 // RenderUserMessage renders a user message with prompt and optional images.
 func RenderUserMessage(content, displayContent string, images []core.Image, mdRenderer *MDRenderer, width int) string {

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -354,7 +354,7 @@ func RenderAssistantMessage(params AssistantParams) string {
 	}
 
 	if interrupted {
-		sb.WriteString("  " + ThinkingStyle.Render("⏸ interrupted by user") + "\n")
+		sb.WriteString("  " + ThinkingStyle.Render("↩ cancelled") + "\n")
 	}
 
 	return sb.String()

--- a/internal/app/conv/status_bar.go
+++ b/internal/app/conv/status_bar.go
@@ -365,11 +365,10 @@ func RenderOperationModeIndicator(mode setting.OperationMode, reviewApprovals, r
 	}
 
 	if mode == setting.ModeAutoPilot {
-		switch {
-		case autopilotThinking:
+		if autopilotThinking {
 			// The copilot is deciding — surface it here instead of a transcript line.
 			label = " autopilot · thinking…"
-		default:
+		} else {
 			if reviewApprovals > 0 {
 				label += fmt.Sprintf(" · %d approved", reviewApprovals)
 			}

--- a/internal/app/conv/status_bar.go
+++ b/internal/app/conv/status_bar.go
@@ -229,15 +229,16 @@ type OperationModeParams struct {
 	ThinkingEffort    string
 	ShowThinking      bool
 	QueueCount        int
-	ReviewApprovals   int // auto-review approvals this session, shown next to the mode
-	ReviewEscalations int // auto-review escalations to the user this session
+	ReviewApprovals   int  // auto-review approvals this session, shown next to the mode
+	ReviewEscalations int  // auto-review escalations to the user this session
+	AutopilotThinking bool // the copilot is mid-decision — show "thinking…" on the mode indicator
 }
 
 // RenderModeStatus renders the combined mode status line.
 func RenderModeStatus(params OperationModeParams) string {
 	var leftParts []string
 
-	if modeStatus := RenderOperationModeIndicator(params.Mode, params.ReviewApprovals, params.ReviewEscalations); modeStatus != "" {
+	if modeStatus := RenderOperationModeIndicator(params.Mode, params.ReviewApprovals, params.ReviewEscalations, params.AutopilotThinking); modeStatus != "" {
 		leftParts = append(leftParts, modeStatus)
 	}
 
@@ -342,7 +343,7 @@ func compactStatusHint(percent float64) string {
 }
 
 // RenderOperationModeIndicator returns the mode status indicator for auto-accept, auto-review, or bypass mode.
-func RenderOperationModeIndicator(mode setting.OperationMode, reviewApprovals, reviewEscalations int) string {
+func RenderOperationModeIndicator(mode setting.OperationMode, reviewApprovals, reviewEscalations int, autopilotThinking bool) string {
 	var icon, label string
 	var clr kit.AdaptiveColor
 
@@ -364,11 +365,17 @@ func RenderOperationModeIndicator(mode setting.OperationMode, reviewApprovals, r
 	}
 
 	if mode == setting.ModeAutoPilot {
-		if reviewApprovals > 0 {
-			label += fmt.Sprintf(" · %d approved", reviewApprovals)
-		}
-		if reviewEscalations > 0 {
-			label += fmt.Sprintf(" · %d escalated", reviewEscalations)
+		switch {
+		case autopilotThinking:
+			// The copilot is deciding — surface it here instead of a transcript line.
+			label = " autopilot · thinking…"
+		default:
+			if reviewApprovals > 0 {
+				label += fmt.Sprintf(" · %d approved", reviewApprovals)
+			}
+			if reviewEscalations > 0 {
+				label += fmt.Sprintf(" · %d escalated", reviewEscalations)
+			}
 		}
 	}
 

--- a/internal/app/conv/status_bar_test.go
+++ b/internal/app/conv/status_bar_test.go
@@ -238,7 +238,7 @@ func TestRenderOperationModeIndicator_AutoPilotCounts(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			out := stripANSI(RenderOperationModeIndicator(setting.ModeAutoPilot, c.approvals, c.escalations))
+			out := stripANSI(RenderOperationModeIndicator(setting.ModeAutoPilot, c.approvals, c.escalations, false))
 			if !strings.Contains(out, "autopilot on") {
 				t.Fatalf("missing base label: %q", out)
 			}
@@ -254,8 +254,20 @@ func TestRenderOperationModeIndicator_AutoPilotCounts(t *testing.T) {
 
 func TestRenderOperationModeIndicator_CountsOnlyInAutoPilot(t *testing.T) {
 	// Approvals/escalations are an auto-review concept; other modes never show them.
-	out := stripANSI(RenderOperationModeIndicator(setting.ModeAutoAccept, 5, 4))
+	out := stripANSI(RenderOperationModeIndicator(setting.ModeAutoAccept, 5, 4, false))
 	if strings.Contains(out, "approved") || strings.Contains(out, "escalated") {
 		t.Errorf("accept-edits mode must not show review counts: %q", out)
+	}
+}
+
+func TestRenderOperationModeIndicator_Thinking(t *testing.T) {
+	// While the copilot decides, the indicator shows "thinking…" and drops the
+	// "on"/counts so the transient state lives here, not in a transcript line.
+	out := stripANSI(RenderOperationModeIndicator(setting.ModeAutoPilot, 3, 1, true))
+	if !strings.Contains(out, "thinking…") {
+		t.Fatalf("missing thinking label: %q", out)
+	}
+	if strings.Contains(out, "approved") || strings.Contains(out, "escalated") {
+		t.Errorf("thinking must suppress the counts: %q", out)
 	}
 }

--- a/internal/app/conv/view.go
+++ b/internal/app/conv/view.go
@@ -156,6 +156,12 @@ func RenderMessageAt(p RenderContext, idx int, isStreaming bool) string {
 	msg := p.Messages[idx]
 	var sb strings.Builder
 
+	// A copilot-produced turn (continuation or rewrite) wears a "↖ autopilot ·
+	// <note>" annotation hugging its "❭" line from below (no blank between) so
+	// the up-left arrow points back at the instruction; the normal blank line
+	// above still separates it from the turn before.
+	autopilotDriven := msg.Role == core.RoleUser && msg.ToolResult == nil && msg.AutopilotNote != ""
+
 	if msg.ToolResult == nil {
 		sb.WriteString("\n")
 	}
@@ -178,6 +184,9 @@ func RenderMessageAt(p RenderContext, idx int, isStreaming bool) string {
 			sb.WriteString(RenderSystemMessage(msg.DisplayContent))
 		default:
 			sb.WriteString(RenderUserMessage(msg.Content, msg.DisplayContent, msg.Images, p.MDRenderer, p.Width))
+			if autopilotDriven {
+				sb.WriteString(RenderAutopilotMark(msg.AutopilotNote))
+			}
 		}
 	case core.RoleNotice:
 		sb.WriteString(RenderSystemMessage(msg.Content))

--- a/internal/app/env.go
+++ b/internal/app/env.go
@@ -265,15 +265,15 @@ func (m *env) SessionMode() string {
 	}
 }
 
-// parseSessionMode is SessionMode's inverse, mapping a persisted session mode
-// back to the OperationMode a resumed session restores into. Unknown or empty
-// strings map to Normal; bypass is never persisted (SessionMode folds it into
-// "normal"), so a resumed session can't silently regain bypass.
+// parseSessionMode maps a persisted session mode back to the OperationMode a
+// resumed session restores into, reusing the canonical string parser but folding
+// everything except the two elevated cycle modes to Normal — so a resumed (or
+// hand-edited) session can never silently regain bypass / dont-ask.
 func parseSessionMode(mode string) setting.OperationMode {
-	switch mode {
-	case "auto-accept":
+	switch setting.OperationModeFromString(mode) {
+	case setting.ModeAutoAccept:
 		return setting.ModeAutoAccept
-	case "auto-pilot":
+	case setting.ModeAutoPilot:
 		return setting.ModeAutoPilot
 	default:
 		return setting.ModeNormal

--- a/internal/app/env.go
+++ b/internal/app/env.go
@@ -265,6 +265,21 @@ func (m *env) SessionMode() string {
 	}
 }
 
+// parseSessionMode is SessionMode's inverse, mapping a persisted session mode
+// back to the OperationMode a resumed session restores into. Unknown or empty
+// strings map to Normal; bypass is never persisted (SessionMode folds it into
+// "normal"), so a resumed session can't silently regain bypass.
+func parseSessionMode(mode string) setting.OperationMode {
+	switch mode {
+	case "auto-accept":
+		return setting.ModeAutoAccept
+	case "auto-pilot":
+		return setting.ModeAutoPilot
+	default:
+		return setting.ModeNormal
+	}
+}
+
 // ResetContextDisplay zeroes the bottom-right context-window readout (latest
 // input/output tokens). Called per-compaction: the live context shrinks to the
 // summary, so the bar/label restart from empty until the next infer. The

--- a/internal/app/input/autopilot_mission.go
+++ b/internal/app/input/autopilot_mission.go
@@ -85,6 +85,9 @@ func (p *AutopilotSelector) handleMissionKey(msg tea.KeyMsg) tea.Cmd {
 	case "alt+enter", "shift+enter":
 		p.mission.input.InsertString("\n")
 		return nil
+	case "ctrl+r":
+		p.clearMission()
+		return nil
 	default:
 		var cmd tea.Cmd
 		p.mission.input, cmd = p.mission.input.Update(msg)
@@ -118,6 +121,17 @@ func (p *AutopilotSelector) sendMission() tea.Cmd {
 		return MissionReplyMsg{Text: reply, Err: err}
 	}
 	return tea.Batch(p.mission.spinner.Tick, request)
+}
+
+// clearMission wipes the whole briefing — the accumulated turns and the composer
+// — so the mission resets to empty instead of only ever growing; commitMission
+// then persists the cleared ("") mission.
+func (p *AutopilotSelector) clearMission() {
+	p.mission.log = nil
+	p.mission.thinking = false
+	p.mission.input.Reset()
+	p.mission.status = "mission cleared"
+	p.commitMission()
 }
 
 // commitMission folds the user turns into the persisted mission directive.
@@ -157,7 +171,7 @@ func (p *AutopilotSelector) UpdateSpinner(msg tea.Msg) tea.Cmd {
 }
 
 func (p *AutopilotSelector) missionHint() string {
-	return kit.HintLine(keycap("enter")+" send", keycap("alt+enter")+" newline", keycap("esc")+" back")
+	return kit.HintLine(keycap("enter")+" send", keycap("alt+enter")+" newline", keycap("ctrl+r")+" clear", keycap("esc")+" back")
 }
 
 func (p *AutopilotSelector) renderMission(width int) string {

--- a/internal/app/input/autopilot_panel.go
+++ b/internal/app/input/autopilot_panel.go
@@ -307,11 +307,12 @@ func (p *AutopilotSelector) rows() []apRow {
 		{kind: apRowEntry, label: "System Prompt", desc: "how it drives", open: apSystemPrompt, summary: systemPromptSummary},
 		{kind: apRowSpacer},
 		{kind: apRowSection, label: "Steer"},
-		{kind: apRowSteer, label: "Turn Start", desc: "rewrite each input", get: getTurnStart, toggle: toggleTurnStart},
+		{kind: apRowSteer, label: "Suggest", desc: "propose the next step", get: getSuggest, toggle: toggleSuggest},
+		{kind: apRowSteer, label: "Start", desc: "kick off & rewrite input", get: getTurnStart, toggle: toggleTurnStart},
 		{kind: apRowSteer, label: "Permission", desc: "auto-approve gray zone", get: getPermission, toggle: togglePermission},
 		{kind: apRowSteer, label: "Bash", desc: "answer command prompts", get: getBash, toggle: toggleBash},
 		{kind: apRowSteer, label: "Question", desc: "answer AskUserQuestion", get: getQuestion, toggle: toggleQuestion},
-		{kind: apRowSteer, label: "Turn End", desc: "auto-continue the turn", get: getTurnEnd, toggle: toggleTurnEnd},
+		{kind: apRowSteer, label: "End", desc: "auto-continue the turn", get: getTurnEnd, toggle: toggleTurnEnd},
 	}
 	if p.snap.Steers.TurnEnd {
 		rows = append(rows, apRow{kind: apRowInt, label: "Continue at most", indent: 1})
@@ -353,12 +354,14 @@ func apStep(rows []apRow, start, step, fallback int) int {
 
 // ── Steer accessors ─────────────────────────────────────────────────────
 
+func getSuggest(s setting.AutoPilotSettings) bool    { return s.Steers.Suggest }
 func getTurnStart(s setting.AutoPilotSettings) bool  { return s.Steers.TurnStart }
 func getPermission(s setting.AutoPilotSettings) bool { return s.Steers.PermissionOn() }
 func getBash(s setting.AutoPilotSettings) bool       { return s.Steers.BashPrompt }
 func getQuestion(s setting.AutoPilotSettings) bool   { return s.Steers.Question }
 func getTurnEnd(s setting.AutoPilotSettings) bool    { return s.Steers.TurnEnd }
 
+func toggleSuggest(s *setting.AutoPilotSettings)   { s.Steers.Suggest = !s.Steers.Suggest }
 func toggleTurnStart(s *setting.AutoPilotSettings) { s.Steers.TurnStart = !s.Steers.TurnStart }
 func toggleBash(s *setting.AutoPilotSettings)      { s.Steers.BashPrompt = !s.Steers.BashPrompt }
 func toggleQuestion(s *setting.AutoPilotSettings)  { s.Steers.Question = !s.Steers.Question }

--- a/internal/app/input/prompt_suggestion.go
+++ b/internal/app/input/prompt_suggestion.go
@@ -2,6 +2,7 @@ package input
 
 import (
 	"context"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -36,6 +37,12 @@ If unsure, reply with nothing.`
 const SuggestionUserPrompt = `[PREDICTION MODE] Based on this conversation, predict what the user will type next.
 Stay silent if the next step isn't obvious. Match the user's language and style.`
 
+// autopilotSuggestSystemPrompt drives the input hint when the Suggest steer is
+// on: it proposes the next step toward the mission as a ready-to-send imperative
+// the human can accept, rather than guessing what the human would type.
+const autopilotSuggestSystemPrompt = `You are the autopilot copilot for a coding assistant. Given the mission and the session so far, suggest the SINGLE next instruction to give the agent — a short, direct imperative the user can accept and send as-is.
+Reply with ONLY that instruction (a few words to one sentence). No quotes, no explanation. Reply with nothing if the mission looks complete or the next step needs a human decision.`
+
 const maxSuggestionMessages = 20
 
 type PromptSuggestionRequest struct {
@@ -52,6 +59,12 @@ type PromptSuggestionDeps struct {
 	Conversation *conv.ConversationModel
 	HasProvider  bool
 	BuildClient  func() *llm.Client
+	// Mission, when set, switches the hint from "predict the human's next input"
+	// to "propose the next step toward this mission" (the Suggest steer).
+	Mission string
+	// Suppress turns the hint off entirely — set when AutoPilot is engaged with
+	// the Suggest steer off, so the copilot doesn't nudge with an input guess.
+	Suppress bool
 }
 
 func StartPromptSuggestion(deps PromptSuggestionDeps) tea.Cmd {
@@ -95,10 +108,29 @@ func SuggestPromptCmd(req PromptSuggestionRequest) tea.Cmd {
 }
 
 func BuildPromptSuggestionRequest(deps PromptSuggestionDeps) (PromptSuggestionRequest, bool) {
-	if !deps.HasProvider {
+	if !deps.HasProvider || deps.Suppress {
 		return PromptSuggestionRequest{}, false
 	}
 
+	startIdx := 0
+	if len(deps.Conversation.Messages) > maxSuggestionMessages {
+		startIdx = len(deps.Conversation.Messages) - maxSuggestionMessages
+	}
+
+	// Suggest steer: propose the next mission step. Works from the very start (no
+	// prior-turn requirement), since the opening step comes from the mission.
+	if mission := strings.TrimSpace(deps.Mission); mission != "" {
+		msgs := deps.Conversation.ConvertToProviderFrom(startIdx)
+		msgs = append(msgs, core.Message{Role: core.RoleUser, Content: "Mission:\n" + mission + "\n\nSuggest the next instruction to give the agent."})
+		return PromptSuggestionRequest{
+			Client:       deps.BuildClient(),
+			Messages:     msgs,
+			SystemPrompt: autopilotSuggestSystemPrompt,
+			MaxTokens:    60,
+		}, true
+	}
+
+	// Generic prediction needs some conversation to go on.
 	assistantCount := 0
 	for _, msg := range deps.Conversation.Messages {
 		if msg.Role == core.RoleAssistant {
@@ -107,11 +139,6 @@ func BuildPromptSuggestionRequest(deps PromptSuggestionDeps) (PromptSuggestionRe
 	}
 	if assistantCount < 2 {
 		return PromptSuggestionRequest{}, false
-	}
-
-	startIdx := 0
-	if len(deps.Conversation.Messages) > maxSuggestionMessages {
-		startIdx = len(deps.Conversation.Messages) - maxSuggestionMessages
 	}
 	msgs := deps.Conversation.ConvertToProviderFrom(startIdx)
 	msgs = append(msgs, core.Message{Role: core.RoleUser, Content: SuggestionUserPrompt})

--- a/internal/app/input/prompt_suggestion.go
+++ b/internal/app/input/prompt_suggestion.go
@@ -60,11 +60,10 @@ type PromptSuggestionDeps struct {
 	HasProvider  bool
 	BuildClient  func() *llm.Client
 	// Mission, when set, switches the hint from "predict the human's next input"
-	// to "propose the next step toward this mission" (the Suggest steer).
+	// to "propose the next step toward this mission" (the Suggest steer). Read
+	// live by the caller from the autopilot config — this package holds no
+	// autopilot state of its own.
 	Mission string
-	// Silent holds the hint back entirely — set when AutoPilot is engaged with
-	// the Suggest steer off, so the copilot doesn't nudge with an input guess.
-	Silent bool
 }
 
 func StartPromptSuggestion(deps PromptSuggestionDeps) tea.Cmd {
@@ -108,7 +107,7 @@ func SuggestPromptCmd(req PromptSuggestionRequest) tea.Cmd {
 }
 
 func BuildPromptSuggestionRequest(deps PromptSuggestionDeps) (PromptSuggestionRequest, bool) {
-	if !deps.HasProvider || deps.Silent {
+	if !deps.HasProvider {
 		return PromptSuggestionRequest{}, false
 	}
 

--- a/internal/app/input/prompt_suggestion.go
+++ b/internal/app/input/prompt_suggestion.go
@@ -62,9 +62,9 @@ type PromptSuggestionDeps struct {
 	// Mission, when set, switches the hint from "predict the human's next input"
 	// to "propose the next step toward this mission" (the Suggest steer).
 	Mission string
-	// Suppress turns the hint off entirely — set when AutoPilot is engaged with
+	// Silent holds the hint back entirely — set when AutoPilot is engaged with
 	// the Suggest steer off, so the copilot doesn't nudge with an input guess.
-	Suppress bool
+	Silent bool
 }
 
 func StartPromptSuggestion(deps PromptSuggestionDeps) tea.Cmd {
@@ -108,7 +108,7 @@ func SuggestPromptCmd(req PromptSuggestionRequest) tea.Cmd {
 }
 
 func BuildPromptSuggestionRequest(deps PromptSuggestionDeps) (PromptSuggestionRequest, bool) {
-	if !deps.HasProvider || deps.Suppress {
+	if !deps.HasProvider || deps.Silent {
 		return PromptSuggestionRequest{}, false
 	}
 

--- a/internal/app/input/prompt_suggestion.go
+++ b/internal/app/input/prompt_suggestion.go
@@ -2,7 +2,6 @@ package input
 
 import (
 	"context"
-	"strings"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -37,12 +36,6 @@ If unsure, reply with nothing.`
 const SuggestionUserPrompt = `[PREDICTION MODE] Based on this conversation, predict what the user will type next.
 Stay silent if the next step isn't obvious. Match the user's language and style.`
 
-// autopilotSuggestSystemPrompt drives the input hint when the Suggest steer is
-// on: it proposes the next step toward the mission as a ready-to-send imperative
-// the human can accept, rather than guessing what the human would type.
-const autopilotSuggestSystemPrompt = `You are the autopilot copilot for a coding assistant. Given the mission and the session so far, suggest the SINGLE next instruction to give the agent — a short, direct imperative the user can accept and send as-is.
-Reply with ONLY that instruction (a few words to one sentence). No quotes, no explanation. Reply with nothing if the mission looks complete or the next step needs a human decision.`
-
 const maxSuggestionMessages = 20
 
 type PromptSuggestionRequest struct {
@@ -59,11 +52,6 @@ type PromptSuggestionDeps struct {
 	Conversation *conv.ConversationModel
 	HasProvider  bool
 	BuildClient  func() *llm.Client
-	// Mission, when set, switches the hint from "predict the human's next input"
-	// to "propose the next step toward this mission" (the Suggest steer). Read
-	// live by the caller from the autopilot config — this package holds no
-	// autopilot state of its own.
-	Mission string
 }
 
 func StartPromptSuggestion(deps PromptSuggestionDeps) tea.Cmd {
@@ -71,14 +59,33 @@ func StartPromptSuggestion(deps PromptSuggestionDeps) tea.Cmd {
 	if !ok {
 		return nil
 	}
+	return deps.Input.PromptSuggestion.Start(req)
+}
 
-	deps.Input.PromptSuggestion.Clear()
-
+// Start runs a pre-built suggestion request, wiring its cancellation into the
+// state so it supersedes any in-flight hint. Callers that need a bespoke request
+// (e.g. the autopilot mission hint) build it and call this directly. Returns nil
+// if the request has no client.
+func (s *PromptSuggestionState) Start(req PromptSuggestionRequest) tea.Cmd {
+	if req.Client == nil {
+		return nil
+	}
+	s.Clear()
 	ctx, cancel := context.WithCancel(context.Background())
-	deps.Input.PromptSuggestion.cancel = cancel
+	s.cancel = cancel
 	req.Ctx = ctx
-
 	return SuggestPromptCmd(req)
+}
+
+// RecentSuggestionMessages returns the tail of the conversation (at most
+// maxSuggestionMessages) as provider messages — the shared context window every
+// input hint feeds its model.
+func RecentSuggestionMessages(c *conv.ConversationModel) []core.Message {
+	startIdx := 0
+	if len(c.Messages) > maxSuggestionMessages {
+		startIdx = len(c.Messages) - maxSuggestionMessages
+	}
+	return c.ConvertToProviderFrom(startIdx)
 }
 
 func HandlePromptSuggestion(state *Model, active bool, inputValue string, msg PromptSuggestionMsg) {
@@ -106,30 +113,14 @@ func SuggestPromptCmd(req PromptSuggestionRequest) tea.Cmd {
 	}
 }
 
+// BuildPromptSuggestionRequest builds the generic hint that predicts the human's
+// next input. Needs some conversation to go on; the autopilot mission hint is
+// built by the caller (see model.missionSuggestionRequest).
 func BuildPromptSuggestionRequest(deps PromptSuggestionDeps) (PromptSuggestionRequest, bool) {
 	if !deps.HasProvider {
 		return PromptSuggestionRequest{}, false
 	}
 
-	startIdx := 0
-	if len(deps.Conversation.Messages) > maxSuggestionMessages {
-		startIdx = len(deps.Conversation.Messages) - maxSuggestionMessages
-	}
-
-	// Suggest steer: propose the next mission step. Works from the very start (no
-	// prior-turn requirement), since the opening step comes from the mission.
-	if mission := strings.TrimSpace(deps.Mission); mission != "" {
-		msgs := deps.Conversation.ConvertToProviderFrom(startIdx)
-		msgs = append(msgs, core.Message{Role: core.RoleUser, Content: "Mission:\n" + mission + "\n\nSuggest the next instruction to give the agent."})
-		return PromptSuggestionRequest{
-			Client:       deps.BuildClient(),
-			Messages:     msgs,
-			SystemPrompt: autopilotSuggestSystemPrompt,
-			MaxTokens:    60,
-		}, true
-	}
-
-	// Generic prediction needs some conversation to go on.
 	assistantCount := 0
 	for _, msg := range deps.Conversation.Messages {
 		if msg.Role == core.RoleAssistant {
@@ -139,7 +130,7 @@ func BuildPromptSuggestionRequest(deps PromptSuggestionDeps) (PromptSuggestionRe
 	if assistantCount < 2 {
 		return PromptSuggestionRequest{}, false
 	}
-	msgs := deps.Conversation.ConvertToProviderFrom(startIdx)
+	msgs := RecentSuggestionMessages(deps.Conversation)
 	msgs = append(msgs, core.Message{Role: core.RoleUser, Content: SuggestionUserPrompt})
 
 	return PromptSuggestionRequest{

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -83,8 +83,15 @@ type model struct {
 	autopilotContinuing    bool
 
 	// autopilotRewrote tags the re-submit of a TurnStart-rewritten message so
-	// dispatchSubmission doesn't rewrite it a second time.
+	// dispatchSubmission doesn't rewrite it a second time; autopilotRefined marks
+	// that the rewrite actually changed the text, so the re-submitted message
+	// wears the "↖ autopilot · refined" annotation.
 	autopilotRewrote bool
+	autopilotRefined bool
+
+	// autopilotDeciding is true while a turn-end/kick decision is in flight, so
+	// the mode indicator shows "thinking…" instead of a transcript notice.
+	autopilotDeciding bool
 
 	// Streaming blocks render their markdown off the UI goroutine so a completed
 	// block never stalls repaint. See flushState and model_scrollback.go.

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -93,6 +93,10 @@ type model struct {
 	// the mode indicator shows "thinking…" instead of a transcript notice.
 	autopilotDeciding bool
 
+	// autopilotRewriting is true while a TurnStart rewrite is in flight, so a
+	// second Enter is swallowed instead of launching a duplicate rewrite/submit.
+	autopilotRewriting bool
+
 	// Streaming blocks render their markdown off the UI goroutine so a completed
 	// block never stalls repaint. See flushState and model_scrollback.go.
 	flush flushState

--- a/internal/app/model_agent_events.go
+++ b/internal/app/model_agent_events.go
@@ -13,7 +13,6 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/genai-io/san/internal/app/input"
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/log"
@@ -123,7 +122,7 @@ func (m *model) OnTurnEnd(result core.Result) tea.Cmd {
 		if cmd := m.persistAfterTurn(); cmd != nil {
 			commitCmds = append(commitCmds, cmd)
 		}
-		if cmd := input.StartPromptSuggestion(m.promptSuggestionDeps()); cmd != nil {
+		if cmd := m.startPromptSuggestion(); cmd != nil {
 			commitCmds = append(commitCmds, cmd)
 		}
 		commitCmds = append(commitCmds, m.ContinueOutbox())

--- a/internal/app/model_session.go
+++ b/internal/app/model_session.go
@@ -158,6 +158,15 @@ func (m *model) restoreSessionData(sess *session.Snapshot) {
 	if ar := parseAutoPilot(sess.Metadata.AutoPilot); !ar.IsZero() {
 		m.env.AutoPilot = ar
 	}
+
+	// Resume into the operation mode the session was saved in, so an autopilot
+	// run picks up where it left off without re-cycling shift+tab. (Bypass never
+	// round-trips — parseSessionMode maps it to Normal.)
+	if mode := parseSessionMode(sess.Metadata.Mode); mode != m.env.OperationMode {
+		m.env.OperationMode = mode
+		m.env.ApplyModePermissions(m.env.CWD)
+		m.services.Hook.SetPermissionMode(m.env.OperationModeName())
+	}
 }
 
 func (m *model) initTaskStorage(sessionID string) {

--- a/internal/app/model_session.go
+++ b/internal/app/model_session.go
@@ -154,10 +154,14 @@ func (m *model) restoreSessionData(sess *session.Snapshot) {
 	}
 
 	// Restore the session's autopilot config; an empty blob (e.g. an older
-	// session) leaves the settings-seeded default in place.
+	// session) leaves the settings-seeded default in place. Rebuild the runtime
+	// snapshot so a mid-session /resume (the agent may already be running) takes
+	// the resumed steers/model/permission config immediately, not on the next
+	// /autopilot Save.
 	if ar := parseAutoPilot(sess.Metadata.AutoPilot); !ar.IsZero() {
 		m.env.AutoPilot = ar
 	}
+	m.rebuildAutopilotReviewer()
 
 	// Resume into the operation mode the session was saved in, so an autopilot
 	// run picks up where it left off without re-cycling shift+tab. (Bypass never

--- a/internal/app/model_subfeatures.go
+++ b/internal/app/model_subfeatures.go
@@ -19,15 +19,41 @@ import (
 	"github.com/genai-io/san/internal/log"
 )
 
-// startPromptSuggestion fires the input hint, unless AutoPilot is engaged with
-// the Suggest steer off — in which case the copilot deliberately doesn't nudge.
-// Both this gate and the mission below read the live autopilot config; the hint
-// keeps no autopilot state of its own, so AutoPilot is the single source.
+// autopilotSuggestSystemPrompt drives the input hint when the Suggest steer is
+// on: it proposes the next step toward the mission as a ready-to-send imperative
+// the human can accept, rather than guessing what the human would type.
+const autopilotSuggestSystemPrompt = `You are the autopilot copilot for a coding assistant. Given the mission and the session so far, suggest the SINGLE next instruction to give the agent — a short, direct imperative the user can accept and send as-is.
+Reply with ONLY that instruction (a few words to one sentence). No quotes, no explanation. Reply with nothing if the mission looks complete or the next step needs a human decision.`
+
+// startPromptSuggestion fires the input hint. AutoPilot owns the whole decision
+// here, reading its live config directly so the hint holds no autopilot state:
+// with the Suggest steer off it stays silent (no nudge); with a mission set it
+// proposes the next step toward it; otherwise it falls back to predicting the
+// human's next input.
 func (m *model) startPromptSuggestion() tea.Cmd {
+	if m.env.LLMProvider == nil {
+		return nil
+	}
 	if m.autopilotEngaged() && !m.env.AutoPilot.Steers.Suggest {
 		return nil
 	}
+	if mission := m.autopilotSuggestMission(); mission != "" {
+		return m.userInput.PromptSuggestion.Start(m.missionSuggestionRequest(mission))
+	}
 	return input.StartPromptSuggestion(m.promptSuggestionDeps())
+}
+
+// missionSuggestionRequest builds the Suggest-steer hint: the recent session
+// plus the mission, asking for the single next instruction to give the agent.
+func (m *model) missionSuggestionRequest(mission string) input.PromptSuggestionRequest {
+	msgs := input.RecentSuggestionMessages(&m.conv.ConversationModel)
+	msgs = append(msgs, core.Message{Role: core.RoleUser, Content: "Mission:\n" + mission + "\n\nSuggest the next instruction to give the agent."})
+	return input.PromptSuggestionRequest{
+		Client:       m.buildLLMClient(),
+		Messages:     msgs,
+		SystemPrompt: autopilotSuggestSystemPrompt,
+		MaxTokens:    60,
+	}
 }
 
 func (m *model) promptSuggestionDeps() input.PromptSuggestionDeps {
@@ -36,14 +62,13 @@ func (m *model) promptSuggestionDeps() input.PromptSuggestionDeps {
 		Conversation: &m.conv.ConversationModel,
 		HasProvider:  m.env.LLMProvider != nil,
 		BuildClient:  m.buildLLMClient,
-		Mission:      m.autopilotSuggestMission(),
 	}
 }
 
 // autopilotSuggestMission returns the mission the Suggest steer should propose
 // the next step toward — the live autopilot mission when the steer is on, else
-// "" for the generic prediction. Read fresh from env every call, so clearing
-// the mission (End completion / ctrl+r / panel) takes effect immediately.
+// "". Read fresh from env every call, so clearing the mission (End completion /
+// ctrl+r / panel) takes effect immediately.
 func (m *model) autopilotSuggestMission() string {
 	if !m.autopilotEngaged() || !m.env.AutoPilot.Steers.Suggest {
 		return ""

--- a/internal/app/model_subfeatures.go
+++ b/internal/app/model_subfeatures.go
@@ -20,23 +20,23 @@ import (
 )
 
 func (m *model) promptSuggestionDeps() input.PromptSuggestionDeps {
-	mission, suppress := m.autopilotSuggestState()
+	mission, silent := m.autopilotSuggestState()
 	return input.PromptSuggestionDeps{
 		Input:        &m.userInput,
 		Conversation: &m.conv.ConversationModel,
 		HasProvider:  m.env.LLMProvider != nil,
 		BuildClient:  m.buildLLMClient,
 		Mission:      mission,
-		Suppress:     suppress,
+		Silent:       silent,
 	}
 }
 
 // autopilotSuggestState decides how the input hint behaves under AutoPilot: with
 // the Suggest steer on it always suggests — proposing the next step toward the
 // mission when one is set, or the generic prediction when not — while with the
-// steer off the hint is suppressed so the copilot doesn't nudge. Outside
+// steer off the hint stays silent so the copilot doesn't nudge. Outside
 // AutoPilot the generic prediction runs unchanged.
-func (m *model) autopilotSuggestState() (mission string, suppress bool) {
+func (m *model) autopilotSuggestState() (mission string, silent bool) {
 	if !m.autopilotEngaged() {
 		return "", false
 	}

--- a/internal/app/model_subfeatures.go
+++ b/internal/app/model_subfeatures.go
@@ -19,31 +19,36 @@ import (
 	"github.com/genai-io/san/internal/log"
 )
 
+// startPromptSuggestion fires the input hint, unless AutoPilot is engaged with
+// the Suggest steer off — in which case the copilot deliberately doesn't nudge.
+// Both this gate and the mission below read the live autopilot config; the hint
+// keeps no autopilot state of its own, so AutoPilot is the single source.
+func (m *model) startPromptSuggestion() tea.Cmd {
+	if m.autopilotEngaged() && !m.env.AutoPilot.Steers.Suggest {
+		return nil
+	}
+	return input.StartPromptSuggestion(m.promptSuggestionDeps())
+}
+
 func (m *model) promptSuggestionDeps() input.PromptSuggestionDeps {
-	mission, silent := m.autopilotSuggestState()
 	return input.PromptSuggestionDeps{
 		Input:        &m.userInput,
 		Conversation: &m.conv.ConversationModel,
 		HasProvider:  m.env.LLMProvider != nil,
 		BuildClient:  m.buildLLMClient,
-		Mission:      mission,
-		Silent:       silent,
+		Mission:      m.autopilotSuggestMission(),
 	}
 }
 
-// autopilotSuggestState decides how the input hint behaves under AutoPilot: with
-// the Suggest steer on it always suggests — proposing the next step toward the
-// mission when one is set, or the generic prediction when not — while with the
-// steer off the hint stays silent so the copilot doesn't nudge. Outside
-// AutoPilot the generic prediction runs unchanged.
-func (m *model) autopilotSuggestState() (mission string, silent bool) {
-	if !m.autopilotEngaged() {
-		return "", false
+// autopilotSuggestMission returns the mission the Suggest steer should propose
+// the next step toward — the live autopilot mission when the steer is on, else
+// "" for the generic prediction. Read fresh from env every call, so clearing
+// the mission (End completion / ctrl+r / panel) takes effect immediately.
+func (m *model) autopilotSuggestMission() string {
+	if !m.autopilotEngaged() || !m.env.AutoPilot.Steers.Suggest {
+		return ""
 	}
-	if !m.env.AutoPilot.Steers.Suggest {
-		return "", true
-	}
-	return strings.TrimSpace(m.env.AutoPilot.Mission), false
+	return strings.TrimSpace(m.env.AutoPilot.Mission)
 }
 
 func (m *model) overlayDeps() input.OverlayDeps {

--- a/internal/app/model_subfeatures.go
+++ b/internal/app/model_subfeatures.go
@@ -6,6 +6,8 @@
 package app
 
 import (
+	"strings"
+
 	tea "charm.land/bubbletea/v2"
 	"go.uber.org/zap"
 
@@ -18,12 +20,30 @@ import (
 )
 
 func (m *model) promptSuggestionDeps() input.PromptSuggestionDeps {
+	mission, suppress := m.autopilotSuggestState()
 	return input.PromptSuggestionDeps{
 		Input:        &m.userInput,
 		Conversation: &m.conv.ConversationModel,
 		HasProvider:  m.env.LLMProvider != nil,
 		BuildClient:  m.buildLLMClient,
+		Mission:      mission,
+		Suppress:     suppress,
 	}
+}
+
+// autopilotSuggestState decides how the input hint behaves under AutoPilot: with
+// the Suggest steer on it always suggests — proposing the next step toward the
+// mission when one is set, or the generic prediction when not — while with the
+// steer off the hint is suppressed so the copilot doesn't nudge. Outside
+// AutoPilot the generic prediction runs unchanged.
+func (m *model) autopilotSuggestState() (mission string, suppress bool) {
+	if !m.autopilotEngaged() {
+		return "", false
+	}
+	if !m.env.AutoPilot.Steers.Suggest {
+		return "", true
+	}
+	return strings.TrimSpace(m.env.AutoPilot.Mission), false
 }
 
 func (m *model) overlayDeps() input.OverlayDeps {

--- a/internal/app/model_turn_queue.go
+++ b/internal/app/model_turn_queue.go
@@ -11,7 +11,6 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/genai-io/san/internal/app/hub"
-	"github.com/genai-io/san/internal/app/input"
 	"github.com/genai-io/san/internal/app/trigger"
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/log"
@@ -31,7 +30,7 @@ func (m *model) handleStopHookResult(msg stopHookResultMsg) tea.Cmd {
 	if cmd := m.persistAfterTurn(); cmd != nil {
 		cmds = append(cmds, cmd)
 	}
-	if cmd := input.StartPromptSuggestion(m.promptSuggestionDeps()); cmd != nil {
+	if cmd := m.startPromptSuggestion(); cmd != nil {
 		cmds = append(cmds, cmd)
 	}
 	if msg.Result.StopReason != "" && msg.Result.StopReason != core.StopEndTurn {

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -155,6 +155,9 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case autopilotRewriteMsg:
 		// The TurnStart steer's rewrite came back; re-submit it.
 		return m, m.handleAutopilotRewrite(msg)
+	case autopilotModeSettledMsg:
+		// The mode has rested on AutoPilot long enough to open it hands-free.
+		return m, m.handleAutopilotModeSettled()
 	case input.AutopilotSavedMsg:
 		// Apply the edit to the live session (persists/resumes with the session),
 		// hot-swap the running judge so the new model/prompt/steers take effect at

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -69,8 +69,7 @@ func (m *model) handleTextareaShortcut(msg tea.KeyMsg) (tea.Cmd, bool) {
 		if !m.conv.Stream.Active && !m.userInput.Approval.IsActive() &&
 			!m.conv.Modal.Question.IsActive() &&
 			!m.userInput.Provider.Selector.IsActive() && !m.userInput.Suggestions.IsVisible() {
-			m.cycleOperationMode()
-			return nil, true
+			return m.cycleOperationMode(), true
 		}
 
 	case "ctrl+t":

--- a/internal/app/update_modal.go
+++ b/internal/app/update_modal.go
@@ -3,10 +3,13 @@
 package app
 
 import (
+	"time"
+
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/genai-io/san/internal/app/conv"
 	"github.com/genai-io/san/internal/app/input"
+	"github.com/genai-io/san/internal/setting"
 	"github.com/genai-io/san/internal/tool"
 )
 
@@ -16,13 +19,35 @@ func (m *model) cycleOperationMode() tea.Cmd {
 	m.env.ApplyModePermissions(m.env.CWD)
 
 	m.services.Hook.SetPermissionMode(m.env.OperationModeName())
-	// Landing on AutoPilot with the Start steer + a mission opens it hands-free.
+	// Landing on AutoPilot opens the mission hands-free (Start) or surfaces the
+	// opening proposal (Suggest) — but debounce it: the cycle wraps through
+	// AutoPilot, so a gesture that only passes through it must not fire a wasted
+	// LLM call. Confirm the user actually rested here (handleAutopilotModeSettled).
+	if m.env.OperationMode == setting.ModeAutoPilot {
+		return tea.Tick(autopilotSettleDelay, func(time.Time) tea.Msg { return autopilotModeSettledMsg{} })
+	}
+	return nil
+}
+
+// autopilotSettleDelay is how long the mode must rest on AutoPilot before the
+// kick/suggest fires — long enough to skip a pass-through cycle, short enough to
+// feel immediate when the user deliberately stops here.
+const autopilotSettleDelay = 250 * time.Millisecond
+
+// autopilotModeSettledMsg fires autopilotSettleDelay after landing on AutoPilot.
+type autopilotModeSettledMsg struct{}
+
+// handleAutopilotModeSettled runs the deferred kick/suggest once the mode has
+// rested on AutoPilot. It no-ops if the user has since cycled away or a turn is
+// in flight, so a pass-through cycle costs nothing.
+func (m *model) handleAutopilotModeSettled() tea.Cmd {
+	if !m.autopilotEngaged() {
+		return nil
+	}
 	if cmd := m.autopilotKickCmd(); cmd != nil {
 		return cmd
 	}
-	// With the Suggest steer on, surface the opening proposal now rather than
-	// waiting for the first turn boundary.
-	if m.autopilotEngaged() && m.env.AutoPilot.Steers.Suggest {
+	if m.env.AutoPilot.Steers.Suggest {
 		return input.StartPromptSuggestion(m.promptSuggestionDeps())
 	}
 	return nil

--- a/internal/app/update_modal.go
+++ b/internal/app/update_modal.go
@@ -47,10 +47,7 @@ func (m *model) handleAutopilotModeSettled() tea.Cmd {
 	if cmd := m.autopilotKickCmd(); cmd != nil {
 		return cmd
 	}
-	if m.env.AutoPilot.Steers.Suggest {
-		return input.StartPromptSuggestion(m.promptSuggestionDeps())
-	}
-	return nil
+	return m.startPromptSuggestion()
 }
 
 func (m *model) updateMode(msg tea.Msg) (tea.Cmd, bool) {

--- a/internal/app/update_modal.go
+++ b/internal/app/update_modal.go
@@ -10,12 +10,22 @@ import (
 	"github.com/genai-io/san/internal/tool"
 )
 
-func (m *model) cycleOperationMode() {
+func (m *model) cycleOperationMode() tea.Cmd {
 	allowBypass := m.services.Setting.AllowBypass()
 	m.env.OperationMode = m.env.OperationMode.NextWithBypass(allowBypass)
 	m.env.ApplyModePermissions(m.env.CWD)
 
 	m.services.Hook.SetPermissionMode(m.env.OperationModeName())
+	// Landing on AutoPilot with the Start steer + a mission opens it hands-free.
+	if cmd := m.autopilotKickCmd(); cmd != nil {
+		return cmd
+	}
+	// With the Suggest steer on, surface the opening proposal now rather than
+	// waiting for the first turn boundary.
+	if m.autopilotEngaged() && m.env.AutoPilot.Steers.Suggest {
+		return input.StartPromptSuggestion(m.promptSuggestionDeps())
+	}
+	return nil
 }
 
 func (m *model) updateMode(msg tea.Msg) (tea.Cmd, bool) {

--- a/internal/app/update_submit.go
+++ b/internal/app/update_submit.go
@@ -6,6 +6,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -80,11 +81,19 @@ func (m *model) dispatchSubmission(raw string) tea.Cmd {
 
 	// A human turn resets the auto-continue budget; a copilot-driven continuation
 	// (flagged) does not, so MaxContinuations bounds a run of consecutive
-	// auto-turns rather than the whole session.
+	// auto-turns rather than the whole session. Capture the copilot's note now,
+	// before the flags reset, so the built message can wear its "↖ autopilot ·
+	// <note>" annotation ("N/M" continuation, or "refined" rewrite).
+	autopilotNote := ""
 	if m.autopilotContinuing {
+		autopilotNote = fmt.Sprintf("%d/%d", m.autopilotContinuations, m.env.AutoPilot.ResolvedMaxContinuations())
 		m.autopilotContinuing = false
 	} else {
 		m.autopilotContinuations = 0
+	}
+	if m.autopilotRefined {
+		autopilotNote = "refined"
+		m.autopilotRefined = false
 	}
 
 	if blocked, reason := m.checkPromptHook(context.Background(), raw); blocked {
@@ -108,6 +117,7 @@ func (m *model) dispatchSubmission(raw string) tea.Cmd {
 	if m.imagesBlockedForModel(msg.Images) {
 		return tea.Batch(m.CommitMessages()...)
 	}
+	msg.AutopilotNote = autopilotNote
 	m.conv.Append(msg)
 	m.userInput.Reset()
 	return m.SubmitToAgent(msg.Content, msg.Images)

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -278,6 +278,7 @@ func (m model) renderModeStatus() string {
 		QueueCount:        m.userInput.Queue.Len(),
 		ReviewApprovals:   reviewApprovals,
 		ReviewEscalations: reviewEscalations,
+		AutopilotThinking: m.autopilotDeciding,
 	})
 }
 

--- a/internal/core/message.go
+++ b/internal/core/message.go
@@ -116,6 +116,12 @@ type ChatMessage struct {
 	// tool call. Display-only: dropped by ToMessage, never persisted.
 	Decision *ReviewDecision
 
+	// AutopilotNote, when set, marks a user message the copilot produced — a
+	// continuation ("2/5") or a rewrite ("refined") — and the renderer hangs a
+	// green "↖ autopilot · <note>" annotation under its "❭" line to show the
+	// copilot typed it. Display-only: dropped by ToMessage, never persisted.
+	AutopilotNote string
+
 	// Streaming-commit progress. While an assistant message streams, completed
 	// markdown blocks are flushed to native scrollback (tea.Println) as they
 	// finish, so the live view and the turn-end commit render only the

--- a/internal/setting/autopilot_test.go
+++ b/internal/setting/autopilot_test.go
@@ -43,12 +43,15 @@ func TestAutoPilotSteersRoundTrip(t *testing.T) {
 	}
 
 	var d Data
-	if err := json.Unmarshal([]byte(`{"autoPilot":{"mission":"ship it","steers":{"turnEnd":true,"permission":false}}}`), &d); err != nil {
+	if err := json.Unmarshal([]byte(`{"autoPilot":{"mission":"ship it","steers":{"suggest":true,"turnEnd":true,"permission":false}}}`), &d); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	clone := d.Clone()
 	if clone.AutoPilot.Mission != "ship it" {
 		t.Errorf("clone dropped mission: %q", clone.AutoPilot.Mission)
+	}
+	if !clone.AutoPilot.Steers.Suggest {
+		t.Error("clone dropped suggest steer")
 	}
 	if !clone.AutoPilot.Steers.TurnEnd {
 		t.Error("clone dropped turnEnd steer")
@@ -64,7 +67,7 @@ func TestAutoPilotSteersRoundTrip(t *testing.T) {
 	}
 
 	merged := mergeSettings(&d, NewData())
-	if merged.AutoPilot.Mission != "ship it" || !merged.AutoPilot.Steers.TurnEnd {
+	if merged.AutoPilot.Mission != "ship it" || !merged.AutoPilot.Steers.TurnEnd || !merged.AutoPilot.Steers.Suggest {
 		t.Error("merge dropped the autoPilot block")
 	}
 }

--- a/internal/setting/merger.go
+++ b/internal/setting/merger.go
@@ -43,6 +43,7 @@ func mergeAutoPilot(base, overlay AutoPilotSettings) AutoPilotSettings {
 		Mission:          coalesce(overlay.Mission, base.Mission),
 		MaxContinuations: coalesceInt(overlay.MaxContinuations, base.MaxContinuations),
 		Steers: SteerSettings{
+			Suggest:    overlay.Steers.Suggest || base.Steers.Suggest,
 			TurnStart:  overlay.Steers.TurnStart || base.Steers.TurnStart,
 			Permission: coalesceBool(overlay.Steers.Permission, base.Steers.Permission),
 			BashPrompt: overlay.Steers.BashPrompt || base.Steers.BashPrompt,

--- a/internal/setting/settings.go
+++ b/internal/setting/settings.go
@@ -80,6 +80,9 @@ type AutoPilotSettings struct {
 // Field names track the trigger: turnStart / turnEnd bracket the turn; the
 // middle three name the agent event that hands control over.
 type SteerSettings struct {
+	// Suggest fills the input hint with the copilot's proposed next step toward
+	// the mission — the gentlest steer: it suggests, the human accepts and sends.
+	Suggest bool `json:"suggest,omitempty"`
 	// TurnStart rewrites/augments each user input before it reaches the agent.
 	TurnStart bool `json:"turnStart,omitempty"`
 	// Permission auto-approves gray-zone tool calls. Tri-state so the baseline
@@ -128,7 +131,7 @@ func (a AutoPilotSettings) Clone() AutoPilotSettings {
 func (a AutoPilotSettings) IsZero() bool {
 	return a.Model == "" && a.SystemPrompt == "" && a.SystemPromptFile == "" &&
 		a.Mission == "" && a.MaxContinuations == 0 &&
-		!a.Steers.TurnStart && a.Steers.Permission == nil &&
+		!a.Steers.Suggest && !a.Steers.TurnStart && a.Steers.Permission == nil &&
 		!a.Steers.BashPrompt && !a.Steers.Question && !a.Steers.TurnEnd
 }
 
@@ -141,6 +144,7 @@ func (a AutoPilotSettings) Equal(b AutoPilotSettings) bool {
 		a.SystemPromptFile == b.SystemPromptFile &&
 		a.Mission == b.Mission &&
 		a.MaxContinuations == b.MaxContinuations &&
+		a.Steers.Suggest == b.Steers.Suggest &&
 		a.Steers.TurnStart == b.Steers.TurnStart &&
 		a.Steers.PermissionOn() == b.Steers.PermissionOn() &&
 		a.Steers.BashPrompt == b.Steers.BashPrompt &&


### PR DESCRIPTION
Follow-up to the merged autopilot copilot (#286), taking it from a config panel + basic steers to a hands-free autonomy loop.

- **Suggest steer** (new, gentlest): the input hint proposes the copilot's next step — mission-aware when a mission is set, generic prediction otherwise — which you accept (tab) and send. Suppressed when off so the copilot doesn't nudge. Steer labels shortened Turn Start/Turn End → Start/End.
- **Hands-free start**: entering AutoPilot with the Start steer + a mission derives and submits the opening step itself (debounced so cycling *through* AutoPilot fires nothing).
- **Mission lifecycle**: the turn-end decision now sees a compact recent-turn transcript, so multi-step completion is detected; on completion the mission is retired (cleared, steers drop to the passive baseline **keeping your Permission/Bash as configured**) without leaving AutoPilot. `ctrl+r` clears the mission in the panel.
- **One system prompt for all steers**, each riding its per-call task in the user message like the judge; the permission safety rubric lives with its task.
- **Notice language**: green `↖ autopilot · N/M` (or `· refined`) under the turn the copilot typed, amber `↩ autopilot · over to you`, green `✓ autopilot · mission complete`; the transient deciding state lives on the mode indicator (`⏵⏵ autopilot · thinking…`), not the transcript. Cancelled turns now read `↩ cancelled` to match.
- **Mode persistence**: the operation mode round-trips with the session (bypass never restores).
- **Hardening** (from a high-effort review): the async decision no longer clobbers a draft you started typing, drops its idle hooks/persistence when you cycle out, or answers a question after you leave; a rewrite in flight can't double-submit; a mid-session `/resume` rebuilds the runtime snapshot.
- **Docs**: new `docs/guides/autopilot.md` (+ zh) with a runnable demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
