### PR TITLE
chore: bump version to 1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to San are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [v1.21.0] - 2026-07-09
+
+### Added
+- Add configurable Autopilot copilot settings, panel, and lifecycle steers ([@yanmxa](https://github.com/yanmxa) in [#286](https://github.com/genai-io/san/pull/286))
+- Add Autopilot follow-ups with Suggest steer, hands-free start, and mission lifecycle ([@yanmxa](https://github.com/yanmxa) in [#287](https://github.com/genai-io/san/pull/287))
+
+### Changed
+- Improve Autopilot start flow and interactive bash handling ([@yanmxa](https://github.com/yanmxa) in [a320e52](https://github.com/genai-io/san/commit/a320e52c))
+
 ## [v1.20.11] - 2026-07-05
 
 ### Added

--- a/cmd/san/main.go
+++ b/cmd/san/main.go
@@ -31,7 +31,7 @@ import (
 	_ "github.com/genai-io/san/internal/llm/volcengine"
 )
 
-var version = "1.20.11"
+var version = "1.21.0"
 
 // cliOpts holds all CLI flag values in one place.
 var cliOpts struct {

--- a/docs/guides/autopilot.md
+++ b/docs/guides/autopilot.md
@@ -5,16 +5,18 @@
 Autopilot is San's autonomy system, designed to minimize human intervention: a
 copilot model cruises the session, keeping routine work moving and handing
 control back only when something genuinely needs you. It acts through a set of
-independently enabled **steers** — proposing or rewriting input, approving
-gray-zone tool calls, answering a command's interactive prompts, answering
+independently enabled **steers** — proposing the next step, approving gray-zone
+tool calls, answering a command's interactive prompts, answering
 `AskUserQuestion`, and continuing finished turns toward a mission. Only
 gray-zone permission judging is on by default.
 
 Enter AutoPilot mode with `shift+tab` (cycle until the amber
-`⏵⏵ autopilot on`), and configure it with the `/autopilot` panel. A resumed
-session (`san -r <id>`) comes back in the mode it was saved in.
+`⏵⏵ autopilot on`), and configure it with the `/autopilot` panel. To launch a
+mission hands-free, hit the panel's **Start** button — it engages AutoPilot and
+submits the opening step in one action (see [Start](#start-the-mission)). A
+resumed session (`san -r <id>`) comes back in the mode it was saved in.
 
-## The six steers
+## The five steers
 
 Steers are à-la-carte toggles, ordered by increasing autonomy. None fire unless
 AutoPilot mode is engaged.
@@ -22,7 +24,6 @@ AutoPilot mode is engaged.
 | Steer | Default | What it does |
 |---|---|---|
 | **Suggest** | off | Fills the input hint (ghost text) with the copilot's proposed next step — toward the mission when one is set, the generic prediction otherwise. `tab` accepts, `enter` sends. It suggests; it never acts. With Suggest *off*, AutoPilot suppresses the hint entirely so the copilot doesn't nudge. |
-| **Start** | off | Owns the turn's input: rewrites each message you send into a clearer, mission-aligned instruction, and — when you enter AutoPilot with a mission set and an empty composer — kicks off the mission by deriving and submitting the first step itself. |
 | **Permission** | **on** | Auto-approves gray-zone tool calls the static rules couldn't resolve, judging reversibility, blast radius, and data exfiltration. Fails closed: any error escalates to you. |
 | **Bash** | off | Answers an already-approved command's interactive prompt (`Continue? [Y/n]`) when the answer just continues the approved action; skips anything that would widen scope. |
 | **Question** | off | Answers `AskUserQuestion` for you when the mission makes the choice clear and low-risk; defers to you otherwise. Option labels are validated verbatim — a partial or invented answer becomes a defer. |
@@ -32,14 +33,31 @@ AutoPilot mode is engaged.
 
 The mission is what the copilot drives toward this session — briefed
 conversationally in the `/autopilot` panel's Mission dialog (`enter` sends,
-`ctrl+r` clears, `esc` saves back). The steering steers (Suggest, Start,
-Question, End) read it; the safety steers (Permission, Bash) deliberately never
-see it, so an action's risk is judged independently of intent.
+`ctrl+r` clears, `esc` saves back). The steering steers (Suggest, Question, End)
+read it; the safety steers (Permission, Bash) deliberately never see it, so an
+action's risk is judged independently of intent.
 
 When the End steer decides the mission is **fully accomplished**, it retires
 it: the mission is cleared and the steers reset to the passive baseline
 (Permission + Bash) — AutoPilot stays on, you take the wheel back with the
 auto-approve safety net intact.
+
+## Start the mission
+
+The panel's bottom row is two buttons — **Save** and **Start** (`←`/`→` to
+pick, `enter` to run):
+
+- **Save** applies the config to the live session and writes it to
+  `settings.json` as the default seed, without changing the mode. Use it when
+  you're only tuning steers, or want to engage later with `shift+tab`.
+- **Start** does everything Save does, then engages AutoPilot and kicks the
+  mission hands-free: it derives the opening step from the mission and submits
+  it itself, so briefing a mission and hitting Start is the whole launch. Start
+  needs a mission — with none set it nudges you instead of engaging.
+
+Landing on AutoPilot via `shift+tab` no longer auto-starts; it only surfaces the
+Suggest steer's proposal (if on). Kicking the mission is always the explicit
+Start button.
 
 ## Demo: a hands-free scaffold
 
@@ -55,19 +73,18 @@ mkdir /tmp/autopilot-demo && cd /tmp/autopilot-demo && san
 
 **2. Configure the copilot** — run `/autopilot`:
 
-- Toggle **Start** and **End** on (Permission is already on).
+- Toggle **End** on (Permission is already on).
 - Open **Mission** and brief it:
 
   > Scaffold a `notes/` directory: `todo.md` with a 3-item checklist, `done.md`
   > empty, and `README.md` explaining the layout. Work one file per turn. When
   > all three exist, verify with `ls notes/` — then the mission is complete.
 
-- `esc` back, then **Save**.
+- `esc` back.
 
-**3. Engage** — press `shift+tab` until the mode line shows
-`⏵⏵ autopilot on`. That's the last key you need to press: with Start on, a
-mission set, and an empty composer, the copilot derives the opening step and
-submits it itself.
+**3. Engage** — on the bottom row, press `→` to focus **Start** and hit
+`enter`. That's the last key you need to press: Start engages AutoPilot and,
+with a mission set, derives the opening step and submits it itself.
 
 **4. Watch the run.** Expect a transcript like:
 
@@ -91,16 +108,15 @@ gray-zone call the Permission steer approved inline. On `✓ mission complete` t
 to the passive baseline — open `/autopilot` to confirm — while AutoPilot stays
 engaged.
 
-To see the gentler end of the spectrum, rerun with only **Suggest** on: the
-copilot proposes each step as ghost text in the composer and you accept with
-`tab` + `enter`.
+To see the gentler end of the spectrum, rerun with only **Suggest** on and
+engage with `shift+tab`: the copilot proposes each step as ghost text in the
+composer and you accept with `tab` + `enter`.
 
 ## Reading the transcript
 
 | Mark | Meaning |
 |---|---|
 | green `↖ autopilot · 2/5` | the `❭` line above was typed by the copilot (continuation 2 of 5) |
-| green `↖ autopilot · refined` | the `❭` line above is your message, rewritten by the Start steer |
 | green `↳ auto-approved · <reason>` | the permission judge let the tool call above through |
 | amber `↳ escalated · <reason>` | the judge sent the call back to you |
 | green `⏵ autopilot · answered for you` | the copilot answered an `AskUserQuestion` |
@@ -127,7 +143,6 @@ the transcript and restore on `/resume`.
     "maxContinuations": 20,
     "steers": {
       "suggest": true,
-      "turnStart": true,   // the Start steer
       "permission": true,  // omit for the default (on); false escalates everything
       "bashPrompt": true,  // the Bash steer
       "question": true,
@@ -137,7 +152,7 @@ the transcript and restore on `/resume`.
 }
 ```
 
-Named presets: the panel's **▲ Export / ▼ Import** save and load whole configs
+Named presets: the panel's **▴ Export / ▾ Import** save and load whole configs
 under `~/.san/autopilot/<name>.json`.
 
 ## Relationship to other features

--- a/docs/guides/autopilot.zh.md
+++ b/docs/guides/autopilot.zh.md
@@ -4,14 +4,17 @@
 
 Autopilot 是 San 的自动驾驶系统,旨在最大限度减少人工介入:由一个 copilot
 模型对会话进行巡航,让例行工作持续推进,只在真正需要人的时刻交还控制权。
-它通过一组可独立启用的介入点(**steer**)行动 —— 提议或改写输入、放行灰区
+它通过一组可独立启用的介入点(**steer**)行动 —— 提议下一步、放行灰区
 工具调用、回答命令的交互问询、回答 `AskUserQuestion`,以及在回合结束后朝
 mission 继续推进。默认仅开启灰区权限判定。
 
 用 `shift+tab` 切换到 AutoPilot 模式(循环到琥珀色的 `⏵⏵ autopilot on`),
-用 `/autopilot` 面板配置。恢复会话(`san -r <id>`)会回到保存时所在的模式。
+用 `/autopilot` 面板配置。要免人工启动一个 mission,按面板的 **Start** 按钮
+—— 它一步完成「开启 AutoPilot + 提交开场那一步」(见
+[启动 mission](#启动-mission))。恢复会话(`san -r <id>`)会回到保存时所在
+的模式。
 
-## 六个 steer
+## 五个 steer
 
 Steer 是按需组合的开关,按自主程度从低到高排列。AutoPilot 模式未开启时,
 任何 steer 都不会触发。
@@ -19,7 +22,6 @@ Steer 是按需组合的开关,按自主程度从低到高排列。AutoPilot 模
 | Steer | 默认 | 作用 |
 |---|---|---|
 | **Suggest** | 关 | 把副驾提议的下一步填进输入提示(幽灵文本)—— 有 mission 时朝 mission 提议,没有则退回通用预测。`tab` 接受、`enter` 发送。只建议、不代发。Suggest *关闭*时,AutoPilot 会整体压掉提示,避免副驾怂恿你。 |
-| **Start** | 关 | 负责回合的输入:把你发的每条消息改写成更清晰、贴合 mission 的指令;当你带着 mission、输入框为空进入 AutoPilot 时,自己从 mission 推出第一步并提交,免去开场那一句。 |
 | **Permission** | **开** | 自动放行静态规则解不了的灰区工具调用,按可逆性、影响面、数据外泄三轴判断。失败即收紧:任何错误都升级给你。 |
 | **Bash** | 关 | 回答已批准命令的交互问询(`Continue? [Y/n]`),仅当回答只是让已批准的动作继续;会扩大范围的一律跳过。 |
 | **Question** | 关 | 当 mission 使选择明确且低风险时替你回答 `AskUserQuestion`,否则留给你。选项标签逐字校验 —— 部分或凭空的回答一律转为留给你。 |
@@ -29,12 +31,26 @@ Steer 是按需组合的开关,按自主程度从低到高排列。AutoPilot 模
 
 Mission 是副驾本会话要开往的目标 —— 在 `/autopilot` 面板的 Mission 对话框里
 口头交代(`enter` 发送、`ctrl+r` 清空、`esc` 存回)。推进类 steer(Suggest、
-Start、Question、End)读它;安全类 steer(Permission、Bash)刻意对它不可见,
-使动作风险的判断独立于意图。
+Question、End)读它;安全类 steer(Permission、Bash)刻意对它不可见,使动作
+风险的判断独立于意图。
 
 当 End steer 判定 mission **已完全达成**,会将其退役:清空 mission、steer 归位
 到被动基线(Permission + Bash)—— AutoPilot 保持开启,你重新接手,自动放行的
 安全网仍在。
+
+## 启动 mission
+
+面板底部一行是两个按钮 —— **Save** 和 **Start**(`←`/`→` 选择、`enter`
+执行):
+
+- **Save** 把配置应用到实时会话,并写入 `settings.json` 作为默认种子,但不
+  改变模式。只调 steer、或想稍后再用 `shift+tab` 启动时用它。
+- **Start** 先做 Save 做的一切,再开启 AutoPilot 并免人工发动 mission:从
+  mission 推出开场那一步并自己提交 —— 交代好 mission、按下 Start 就是完整的
+  启动。Start 需要一个 mission,没设时它会提示你而不是空转开启。
+
+用 `shift+tab` 落到 AutoPilot 不再自动起步,只会浮出 Suggest steer 的提议
+(若开启)。发动 mission 始终是显式的 Start 按钮。
 
 ## Demo:一次免人工的脚手架搭建
 
@@ -49,18 +65,18 @@ mkdir /tmp/autopilot-demo && cd /tmp/autopilot-demo && san
 
 **2. 配置 copilot** —— 运行 `/autopilot`:
 
-- 打开 **Start** 和 **End**(Permission 默认已开)。
+- 打开 **End**(Permission 默认已开)。
 - 打开 **Mission**,交代任务:
 
   > 搭建一个 `notes/` 目录:`todo.md` 放一个 3 项的清单、`done.md` 留空、
   > `README.md` 说明目录结构。每回合处理一个文件。三个文件齐了之后用
   > `ls notes/` 验证 —— 然后任务即完成。
 
-- `esc` 返回,然后 **Save**。
+- `esc` 返回。
 
-**3. 启动巡航** —— 按 `shift+tab` 直到模式行显示 `⏵⏵ autopilot on`。
-这是你需要按的最后一个键:Start 开启、mission 已设、输入框为空时,
-copilot 会自己推出第一步并提交。
+**3. 启动巡航** —— 在底部一行按 `→` 选中 **Start**,回车。这是你需要按的
+最后一个键:Start 开启 AutoPilot,且在 mission 已设时自己推出开场那一步并
+提交。
 
 **4. 观察运行。** 预期的转录大致是:
 
@@ -84,15 +100,14 @@ copilot 敲入,你没有碰过输入框。那条 `ls` 是灰区调用,由 Permis
 `✓ mission complete` 时,mission 被清空、steer 归位到被动基线(打开
 `/autopilot` 可确认),而 AutoPilot 保持开启。
 
-想体验最轻的一档,只开 **Suggest** 重跑一遍:copilot 把每一步以幽灵文本
-提议在输入框里,你用 `tab` + `enter` 接受发送。
+想体验最轻的一档,只开 **Suggest** 重跑一遍、用 `shift+tab` 启动:copilot 把
+每一步以幽灵文本提议在输入框里,你用 `tab` + `enter` 接受发送。
 
 ## 读懂转录里的标记
 
 | 标记 | 含义 |
 |---|---|
 | 绿 `↖ autopilot · 2/5` | 上方那条 `❭` 是副驾敲的(第 2 / 共 5 次续跑) |
-| 绿 `↖ autopilot · refined` | 上方那条 `❭` 是你的消息,被 Start steer 改写过 |
 | 绿 `↳ auto-approved · <理由>` | 判官放行了上方的工具调用 |
 | 琥珀 `↳ escalated · <理由>` | 判官把调用退回给你 |
 | 绿 `⏵ autopilot · answered for you` | 副驾替你回答了 `AskUserQuestion` |
@@ -118,7 +133,6 @@ copilot 敲入,你没有碰过输入框。那条 `ls` 是灰区调用,由 Permis
     "maxContinuations": 20,
     "steers": {
       "suggest": true,
-      "turnStart": true,   // Start steer
       "permission": true,  // 省略即默认开;false 则一律升级给你
       "bashPrompt": true,  // Bash steer
       "question": true,
@@ -128,7 +142,7 @@ copilot 敲入,你没有碰过输入框。那条 `ls` 是灰区调用,由 Permis
 }
 ```
 
-命名预设:面板的 **▲ Export / ▼ Import** 把整份配置存取于
+命名预设:面板的 **▴ Export / ▾ Import** 把整份配置存取于
 `~/.san/autopilot/<name>.json`。
 
 ## 关联

--- a/internal/app/autopilot.go
+++ b/internal/app/autopilot.go
@@ -233,16 +233,16 @@ func (m *model) autopilotContinueCmd(result core.Result) tea.Cmd {
 	return m.autopilotDecideCmd(result, false)
 }
 
-// autopilotKickCmd opens the mission when the human hasn't: on entering AutoPilot
-// with the TurnStart steer on, a mission set, and the agent idle, it derives the
-// first step from the mission (the same decision as TurnEnd, just an empty-ish
-// transcript) and submits it — so briefing a mission and switching autopilot on
-// is enough to start, with no opening turn to type. Returns nil when any
+// autopilotKickCmd opens the mission hands-free — the /autopilot panel's Start
+// button dispatches it after engaging AutoPilot. With a mission set and the agent
+// idle it derives the first step from the mission (the same decision as TurnEnd,
+// just an empty-ish transcript) and submits it, so briefing a mission and hitting
+// Start is enough to begin with no opening turn to type. Returns nil when any
 // precondition is unmet, the human is mid-compose (don't clobber input), or a
-// decision is already in flight (don't stack on rapid mode cycling).
+// decision is already in flight (don't stack on a double-press).
 func (m *model) autopilotKickCmd() tea.Cmd {
 	ar := m.env.AutoPilot
-	if !m.autopilotEngaged() || !ar.Steers.TurnStart || m.autopilotDeciding {
+	if !m.autopilotEngaged() || m.autopilotDeciding {
 		return nil
 	}
 	if m.conv.Stream.Active || strings.TrimSpace(m.userInput.FullValue()) != "" {
@@ -383,16 +383,16 @@ func (m *model) handleAutopilotDecision(msg autopilotDecisionMsg) tea.Cmd {
 }
 
 // retireAutopilotMission winds down a finished mission without leaving AutoPilot:
-// it clears the mission and turns off the driving steers (Suggest, TurnStart,
-// Question, TurnEnd), so the copilot stops actively driving — no more suggest,
-// rewrite, auto-answer, or continue — while the passive safety steers stay
-// exactly as the user configured them (a Bash steer they left off is NOT flipped
-// on, an explicit permission:false is NOT overridden). Session-scoped: the saved
-// settings.json config (the user's template) is left untouched.
+// it clears the mission and turns off the driving steers (Suggest, Question,
+// TurnEnd), so the copilot stops actively driving — no more suggest, auto-answer,
+// or continue — while the passive safety steers stay exactly as the user
+// configured them (a Bash steer they left off is NOT flipped on, an explicit
+// permission:false is NOT overridden). Session-scoped: the saved settings.json
+// config (the user's template) is left untouched.
 func (m *model) retireAutopilotMission() {
 	m.env.AutoPilot.Mission = ""
 	s := &m.env.AutoPilot.Steers
-	s.Suggest, s.TurnStart, s.Question, s.TurnEnd = false, false, false, false
+	s.Suggest, s.Question, s.TurnEnd = false, false, false
 	m.rebuildAutopilotReviewer()
 }
 
@@ -511,84 +511,6 @@ func autopilotAnswerQuestion(ctx context.Context, provider llm.Provider, modelID
 		answers[i] = chosen
 	}
 	return answers, true
-}
-
-// ── TurnStart steer (#1): rewrite the user's input ──────────────────────
-
-// autopilotRewriteMsg carries the copilot's rewrite of a human message back to
-// the UI so it can be re-submitted.
-type autopilotRewriteMsg struct {
-	original  string
-	rewritten string
-}
-
-const rewriteTask = `Rewrite the user's message into a clearer, more complete instruction for the agent, aligned with the session mission — keep the user's intent, add the specifics the mission implies, and drop nothing they asked for.
-
-Return ONLY the rewritten message, with no preamble, quotes, or explanation. If the message is already clear and complete, return it unchanged.`
-
-// autopilotRewriteCmd intercepts a human submission when AutoPilot mode and the
-// TurnStart steer are on, returning (cmd, true) to rewrite it asynchronously
-// before sending. It returns (nil, false) — proceed normally — for the re-submit
-// of an already rewritten message, copilot continuations, slash commands, and
-// empty input. While a rewrite is already in flight it swallows the submission
-// (nil, true) so a second Enter can't launch a second rewrite / double-submit.
-func (m *model) autopilotRewriteCmd(userMessage string) (tea.Cmd, bool) {
-	if m.autopilotRewrote {
-		m.autopilotRewrote = false // this IS the rewritten re-submit
-		return nil, false
-	}
-	ar := m.env.AutoPilot
-	if !m.autopilotEngaged() || !ar.Steers.TurnStart || m.autopilotContinuing {
-		return nil, false
-	}
-	if m.autopilotRewriting {
-		return nil, true // a rewrite is in flight; it will submit — swallow this Enter
-	}
-	userMessage = strings.TrimSpace(userMessage)
-	if userMessage == "" || strings.HasPrefix(userMessage, "/") {
-		return nil, false // never touch slash commands or empty input
-	}
-	provider, modelID := m.resolveReviewerModel(ar.Model)
-	if provider == nil {
-		return nil, false
-	}
-	mission := strings.TrimSpace(ar.Mission)
-	systemPrompt := m.autopilotSystemPrompt()
-	m.autopilotRewriting = true
-	m.autopilotDeciding = true // rewrite in flight — "thinking…" on the mode line
-	return autopilotAsync(func(ctx context.Context) tea.Msg {
-		return autopilotRewriteMsg{original: userMessage, rewritten: autopilotRewriteInput(ctx, provider, modelID, systemPrompt, mission, userMessage)}
-	}), true
-}
-
-func autopilotRewriteInput(ctx context.Context, provider llm.Provider, modelID, systemPrompt, mission, userMessage string) string {
-	user := userMessage
-	if mission != "" {
-		user = "Mission:\n" + mission + "\n\nUser's message:\n" + userMessage
-	}
-	out, err := autopilotComplete(ctx, provider, modelID, systemPrompt, rewriteTask+"\n\n"+user, 1000)
-	if err != nil || out == "" {
-		return userMessage // fail open: send the original
-	}
-	return out
-}
-
-// handleAutopilotRewrite re-submits the (possibly) rewritten message. When the
-// rewrite changed the text, the re-submitted message wears the "↖ autopilot ·
-// refined" annotation (via autopilotRefined → dispatchSubmission) instead of a
-// separate notice. The message must never be lost, so this submits even if the
-// user left AutoPilot while the rewrite ran.
-func (m *model) handleAutopilotRewrite(msg autopilotRewriteMsg) tea.Cmd {
-	m.autopilotDeciding = false
-	m.autopilotRewriting = false
-	text := msg.rewritten
-	if text == "" {
-		text = msg.original
-	}
-	m.autopilotRefined = text != msg.original
-	m.autopilotRewrote = true
-	m.userInput.Textarea.SetValue(text)
-	return m.handleSubmit()
 }
 
 // validQuestionLabels keeps only labels that match a real option verbatim,

--- a/internal/app/input/autopilot_panel.go
+++ b/internal/app/input/autopilot_panel.go
@@ -37,6 +37,10 @@ const (
 // default seed for new sessions.
 type AutopilotSavedMsg struct{ Config setting.AutoPilotSettings }
 
+// AutopilotStartMsg is emitted on Start: everything Save does, then the app
+// engages AutoPilot and kicks the mission hands-free. Carries the same config.
+type AutopilotStartMsg struct{ Config setting.AutoPilotSettings }
+
 // AutopilotSelector is the /autopilot overlay.
 type AutopilotSelector struct {
 	respond MissionResponder                 // injected; nil disables live mission replies
@@ -58,6 +62,7 @@ type AutopilotSelector struct {
 	status        string // transient export/import notice under the menu
 
 	actionCursor int      // menu: 0 = Export, 1 = Import on the actions row
+	saveCursor   int      // menu: 0 = Save, 1 = Start on the save/start row
 	nameBuffer   string   // apExport: the preset name being typed
 	presets      []string // apImport: available preset names
 	importCursor int      // apImport: selection
@@ -100,6 +105,7 @@ func (p *AutopilotSelector) Enter(width, height int) {
 	p.cursor = p.firstSelectable()
 	p.status = ""
 	p.actionCursor = 0
+	p.saveCursor = 0
 	p.resetMission()
 }
 
@@ -146,12 +152,18 @@ func (p *AutopilotSelector) handleMenuKey(msg tea.KeyMsg) tea.Cmd {
 	case "down", "j":
 		p.cursor = apStep(rows, p.cursor+1, +1, p.cursor)
 	case "left", "h":
-		if rows[p.cursor].kind == apRowActions {
+		switch rows[p.cursor].kind {
+		case apRowActions:
 			p.actionCursor = 0
+		case apRowSaveStart:
+			p.saveCursor = 0
 		}
 	case "right", "l":
-		if rows[p.cursor].kind == apRowActions {
+		switch rows[p.cursor].kind {
+		case apRowActions:
 			p.actionCursor = 1
+		case apRowSaveStart:
+			p.saveCursor = 1
 		}
 	case "space":
 		// Space is a shortcut for the primary action of a toggle row only; on any
@@ -182,8 +194,11 @@ func (p *AutopilotSelector) activateRow(row apRow) tea.Cmd {
 		} else {
 			p.beginImport()
 		}
-	case apRowSave:
-		return p.save()
+	case apRowSaveStart:
+		if p.saveCursor == 0 {
+			return p.save()
+		}
+		return p.start()
 	}
 	return nil
 }
@@ -247,6 +262,19 @@ func (p *AutopilotSelector) save() tea.Cmd {
 	return func() tea.Msg { return AutopilotSavedMsg{Config: cfg} }
 }
 
+// start saves the working buffer and asks the app to engage AutoPilot and kick
+// the mission. There is nothing to kick without a mission, so an empty one keeps
+// the panel open with a nudge instead of engaging into a no-op.
+func (p *AutopilotSelector) start() tea.Cmd {
+	if strings.TrimSpace(p.snap.Mission) == "" {
+		p.status = "set a mission before starting"
+		return nil
+	}
+	cfg := p.snap.Clone()
+	p.active = false
+	return func() tea.Msg { return AutopilotStartMsg{Config: cfg} }
+}
+
 // ── System Prompt editor view ───────────────────────────────────────────
 
 func (p *AutopilotSelector) handlePromptKey(msg tea.KeyMsg) tea.Cmd {
@@ -272,13 +300,13 @@ func (p *AutopilotSelector) handlePromptKey(msg tea.KeyMsg) tea.Cmd {
 type apRowKind int
 
 const (
-	apRowEntry   apRowKind = iota // opens a sub-view (System Prompt / Mission)
-	apRowSteer                    // bool toggle
-	apRowInt                      // continuation cap
-	apRowActions                  // Export | Import on one line (left/right picks)
-	apRowSave                     // save action
-	apRowSection                  // section header
-	apRowSpacer                   // blank line
+	apRowEntry     apRowKind = iota // opens a sub-view (System Prompt / Mission)
+	apRowSteer                      // bool toggle
+	apRowInt                        // continuation cap
+	apRowActions                    // Export | Import on one line (left/right picks)
+	apRowSaveStart                  // Save | Start on one line (left/right picks)
+	apRowSection                    // section header
+	apRowSpacer                     // blank line
 )
 
 // apRow is one renderable menu row. Fields unused by the kind stay zero.
@@ -295,7 +323,7 @@ type apRow struct {
 
 func (r apRow) selectable() bool {
 	switch r.kind {
-	case apRowEntry, apRowSteer, apRowInt, apRowActions, apRowSave:
+	case apRowEntry, apRowSteer, apRowInt, apRowActions, apRowSaveStart:
 		return true
 	default:
 		return false
@@ -308,7 +336,6 @@ func (p *AutopilotSelector) rows() []apRow {
 		{kind: apRowSpacer},
 		{kind: apRowSection, label: "Steer"},
 		{kind: apRowSteer, label: "Suggest", desc: "propose the next step", get: getSuggest, toggle: toggleSuggest},
-		{kind: apRowSteer, label: "Start", desc: "kick off & rewrite input", get: getTurnStart, toggle: toggleTurnStart},
 		{kind: apRowSteer, label: "Permission", desc: "auto-approve gray zone", get: getPermission, toggle: togglePermission},
 		{kind: apRowSteer, label: "Bash", desc: "answer command prompts", get: getBash, toggle: toggleBash},
 		{kind: apRowSteer, label: "Question", desc: "answer AskUserQuestion", get: getQuestion, toggle: toggleQuestion},
@@ -324,7 +351,7 @@ func (p *AutopilotSelector) rows() []apRow {
 		apRow{kind: apRowSpacer},
 		apRow{kind: apRowActions},
 		apRow{kind: apRowSpacer},
-		apRow{kind: apRowSave, label: "Save"},
+		apRow{kind: apRowSaveStart},
 	)
 	return rows
 }
@@ -355,17 +382,15 @@ func apStep(rows []apRow, start, step, fallback int) int {
 // ── Steer accessors ─────────────────────────────────────────────────────
 
 func getSuggest(s setting.AutoPilotSettings) bool    { return s.Steers.Suggest }
-func getTurnStart(s setting.AutoPilotSettings) bool  { return s.Steers.TurnStart }
 func getPermission(s setting.AutoPilotSettings) bool { return s.Steers.PermissionOn() }
 func getBash(s setting.AutoPilotSettings) bool       { return s.Steers.BashPrompt }
 func getQuestion(s setting.AutoPilotSettings) bool   { return s.Steers.Question }
 func getTurnEnd(s setting.AutoPilotSettings) bool    { return s.Steers.TurnEnd }
 
-func toggleSuggest(s *setting.AutoPilotSettings)   { s.Steers.Suggest = !s.Steers.Suggest }
-func toggleTurnStart(s *setting.AutoPilotSettings) { s.Steers.TurnStart = !s.Steers.TurnStart }
-func toggleBash(s *setting.AutoPilotSettings)      { s.Steers.BashPrompt = !s.Steers.BashPrompt }
-func toggleQuestion(s *setting.AutoPilotSettings)  { s.Steers.Question = !s.Steers.Question }
-func toggleTurnEnd(s *setting.AutoPilotSettings)   { s.Steers.TurnEnd = !s.Steers.TurnEnd }
+func toggleSuggest(s *setting.AutoPilotSettings)  { s.Steers.Suggest = !s.Steers.Suggest }
+func toggleBash(s *setting.AutoPilotSettings)     { s.Steers.BashPrompt = !s.Steers.BashPrompt }
+func toggleQuestion(s *setting.AutoPilotSettings) { s.Steers.Question = !s.Steers.Question }
+func toggleTurnEnd(s *setting.AutoPilotSettings)  { s.Steers.TurnEnd = !s.Steers.TurnEnd }
 
 // togglePermission flips the tri-state permission steer, writing an explicit
 // value so an off-toggle persists distinctly from the default-on.

--- a/internal/app/input/autopilot_render.go
+++ b/internal/app/input/autopilot_render.go
@@ -38,7 +38,7 @@ func (p *AutopilotSelector) Render() string {
 			p.renderMenu(p.innerWidth()),
 			kit.HintLine(
 				keycap("↑↓")+" navigate", keycap("←→")+" pick",
-				keycap("space")+" toggle", keycap("enter")+" open/save", keycap("esc")+" close",
+				keycap("space")+" toggle", keycap("enter")+" open/run", keycap("esc")+" close",
 			),
 		)
 	}
@@ -100,8 +100,8 @@ func (p *AutopilotSelector) renderMenu(width int) string {
 			b.WriteString(p.renderInt(i, row))
 		case apRowActions:
 			b.WriteString(p.renderActions(i))
-		case apRowSave:
-			b.WriteString(p.renderSave(i))
+		case apRowSaveStart:
+			b.WriteString(p.renderSaveStart(i))
 		case apRowSpacer:
 			// blank line
 		}
@@ -115,16 +115,18 @@ func (p *AutopilotSelector) renderMenu(width int) string {
 }
 
 // renderActions draws Export / Import on one line; the focused half is picked
-// with ←/→ and lit, the other stays muted.
+// with ←/→ and lit, the other stays muted. The up/down glyph stays small and
+// dim so the label leads and the marker doesn't overshadow it.
 func (p *AutopilotSelector) renderActions(i int) string {
-	seg := func(active bool, label string) string {
+	seg := func(active bool, glyph, label string) string {
+		g := apChipStyle.Render(glyph + " ")
 		if i == p.cursor && active {
-			return apActionActiveStyle.Render(label)
+			return g + apActionActiveStyle.Render(label)
 		}
-		return apActionIdleStyle.Render(label)
+		return g + apActionIdleStyle.Render(label)
 	}
-	exp := seg(p.actionCursor == 0, "▲ Export")
-	imp := seg(p.actionCursor == 1, "▼ Import")
+	exp := seg(p.actionCursor == 0, "▴", "Export")
+	imp := seg(p.actionCursor == 1, "▾", "Import")
 	return p.cursorMark(i) + exp + apChipStyle.Render("    ") + imp
 }
 
@@ -178,8 +180,22 @@ func (p *AutopilotSelector) renderInt(i int, row apRow) string {
 	return indent + p.cursorMark(i) + row.label + " " + chip + " " + apDescStyle.Render("times")
 }
 
-func (p *AutopilotSelector) renderSave(i int) string {
-	return p.cursorMark(i) + apSaveStyle.Render("Save")
+// renderSaveStart draws Save and Start as two filled pill keys side by side —
+// both sit on the neutral keycap surface so they read as buttons at rest. The
+// focused pick (←/→) keeps the same pill and just takes a bold accent label
+// (green Save, accent Start); the other stays neutral. Focus is carried by that
+// accent, so this row skips the ▸ mark and indents to sit under the content
+// column instead.
+func (p *AutopilotSelector) renderSaveStart(i int) string {
+	seg := func(active bool, lit lipgloss.Style, label string) string {
+		if i == p.cursor && active {
+			return lit.Render(label)
+		}
+		return apButtonIdleStyle.Render(label)
+	}
+	save := seg(p.saveCursor == 0, apSaveButtonStyle, "Save")
+	start := seg(p.saveCursor == 1, apStartButtonStyle, "Start")
+	return "  " + save + "  " + start
 }
 
 // ── Styles ──────────────────────────────────────────────────────────────
@@ -219,9 +235,12 @@ var (
 	apUnsavedDotStyle  = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Warning).Bold(true)
 	apUnsavedTextStyle = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Warning)
 
-	apSaveStyle = lipgloss.NewStyle().
-			Background(kit.CurrentTheme.Success).
-			Foreground(kit.CurrentTheme.Background).
-			Bold(true).
-			Padding(0, 2)
+	// Save/Start buttons: filled neutral pills on the panel's keycap surface, so
+	// they read as raised keys at rest — depth from the fill, no frame. Focus is a
+	// light touch: the picked pill keeps the same surface and just takes a bold
+	// accent label (green Save, accent Start); no heavy fill swap.
+	apButtonBaseStyle  = lipgloss.NewStyle().Padding(0, 2).Background(kit.SearchBg)
+	apButtonIdleStyle  = apButtonBaseStyle.Foreground(kit.CurrentTheme.Text)
+	apSaveButtonStyle  = apButtonBaseStyle.Foreground(kit.CurrentTheme.Success).Bold(true)
+	apStartButtonStyle = apButtonBaseStyle.Foreground(kit.CurrentTheme.Accent).Bold(true)
 )

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -82,20 +82,9 @@ type model struct {
 	autopilotContinuations int
 	autopilotContinuing    bool
 
-	// autopilotRewrote tags the re-submit of a TurnStart-rewritten message so
-	// dispatchSubmission doesn't rewrite it a second time; autopilotRefined marks
-	// that the rewrite actually changed the text, so the re-submitted message
-	// wears the "↖ autopilot · refined" annotation.
-	autopilotRewrote bool
-	autopilotRefined bool
-
 	// autopilotDeciding is true while a turn-end/kick decision is in flight, so
 	// the mode indicator shows "thinking…" instead of a transcript notice.
 	autopilotDeciding bool
-
-	// autopilotRewriting is true while a TurnStart rewrite is in flight, so a
-	// second Enter is swallowed instead of launching a duplicate rewrite/submit.
-	autopilotRewriting bool
 
 	// Streaming blocks render their markdown off the UI goroutine so a completed
 	// block never stalls repaint. See flushState and model_scrollback.go.

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -152,9 +152,6 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case autopilotQuestionMsg:
 		// The Question steer's answer (or defer) came back.
 		return m, m.handleAutopilotQuestion(msg)
-	case autopilotRewriteMsg:
-		// The TurnStart steer's rewrite came back; re-submit it.
-		return m, m.handleAutopilotRewrite(msg)
 	case autopilotModeSettledMsg:
 		// The mode has rested on AutoPilot long enough to open it hands-free.
 		return m, m.handleAutopilotModeSettled()
@@ -169,6 +166,18 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.conv.AddNotice("Autopilot config saved")
 		return m, nil
+	case input.AutopilotStartMsg:
+		// Save & Start: apply + persist exactly like a Save, then engage AutoPilot
+		// and kick the mission hands-free. The explicit counterpart to shift+tab
+		// (which only lands the mode and, with Suggest on, proposes a step).
+		m.env.AutoPilot = msg.Config.Clone()
+		m.rebuildAutopilotReviewer()
+		if err := setting.UpdateAutoPilotAt(msg.Config, true); err != nil {
+			log.Logger().Warn("persist autopilot default failed", zap.Error(err))
+		}
+		m.enterAutoPilotMode()
+		m.conv.AddNotice("Autopilot engaged")
+		return m, m.autopilotKickCmd()
 	case input.ConfigSavedMsg:
 		// Refresh the in-memory settings handle so re-opening /config (and any
 		// in-session reader) sees the just-saved values rather than the stale

--- a/internal/app/update_modal.go
+++ b/internal/app/update_modal.go
@@ -16,17 +16,30 @@ import (
 func (m *model) cycleOperationMode() tea.Cmd {
 	allowBypass := m.services.Setting.AllowBypass()
 	m.env.OperationMode = m.env.OperationMode.NextWithBypass(allowBypass)
-	m.env.ApplyModePermissions(m.env.CWD)
-
-	m.services.Hook.SetPermissionMode(m.env.OperationModeName())
-	// Landing on AutoPilot opens the mission hands-free (Start) or surfaces the
-	// opening proposal (Suggest) — but debounce it: the cycle wraps through
-	// AutoPilot, so a gesture that only passes through it must not fire a wasted
-	// LLM call. Confirm the user actually rested here (handleAutopilotModeSettled).
+	m.applyOperationMode()
+	// Landing on AutoPilot surfaces the opening proposal (Suggest) — but debounce
+	// it: the cycle wraps through AutoPilot, so a gesture that only passes through
+	// it must not fire a wasted LLM call. Confirm the user actually rested here
+	// (handleAutopilotModeSettled).
 	if m.env.OperationMode == setting.ModeAutoPilot {
 		return tea.Tick(autopilotSettleDelay, func(time.Time) tea.Msg { return autopilotModeSettledMsg{} })
 	}
 	return nil
+}
+
+// applyOperationMode re-applies the current mode's permission posture and hook
+// mode — the shared tail of any mode change.
+func (m *model) applyOperationMode() {
+	m.env.ApplyModePermissions(m.env.CWD)
+	m.services.Hook.SetPermissionMode(m.env.OperationModeName())
+}
+
+// enterAutoPilotMode switches the operation posture to AutoPilot without cycling,
+// so the /autopilot panel's Start button engages the copilot even from another
+// mode (otherwise the kick's autopilotEngaged() gate would drop it).
+func (m *model) enterAutoPilotMode() {
+	m.env.OperationMode = setting.ModeAutoPilot
+	m.applyOperationMode()
 }
 
 // autopilotSettleDelay is how long the mode must rest on AutoPilot before the
@@ -37,15 +50,13 @@ const autopilotSettleDelay = 250 * time.Millisecond
 // autopilotModeSettledMsg fires autopilotSettleDelay after landing on AutoPilot.
 type autopilotModeSettledMsg struct{}
 
-// handleAutopilotModeSettled runs the deferred kick/suggest once the mode has
-// rested on AutoPilot. It no-ops if the user has since cycled away or a turn is
-// in flight, so a pass-through cycle costs nothing.
+// handleAutopilotModeSettled surfaces the Suggest steer's opening proposal once
+// the mode has rested on AutoPilot. It no-ops if the user has since cycled away,
+// so a pass-through cycle costs nothing. The mission kick-off is deliberately NOT
+// here — that's the panel's explicit Start button, not a side effect of landing.
 func (m *model) handleAutopilotModeSettled() tea.Cmd {
 	if !m.autopilotEngaged() {
 		return nil
-	}
-	if cmd := m.autopilotKickCmd(); cmd != nil {
-		return cmd
 	}
 	return m.startPromptSuggestion()
 }

--- a/internal/app/update_submit.go
+++ b/internal/app/update_submit.go
@@ -71,29 +71,17 @@ func (m *model) dispatchSubmission(raw string) tea.Cmd {
 		return cmd
 	}
 
-	// TurnStart steer (#1): rewrite a human message toward the mission before it
-	// reaches the agent, then re-submit. Passes through for slash commands,
-	// continuations, and the already-rewritten re-submit. Runs before the budget
-	// reset below so it can still read autopilotContinuing.
-	if cmd, intercepted := m.autopilotRewriteCmd(raw); intercepted {
-		return cmd
-	}
-
 	// A human turn resets the auto-continue budget; a copilot-driven continuation
 	// (flagged) does not, so MaxContinuations bounds a run of consecutive
 	// auto-turns rather than the whole session. Capture the copilot's note now,
-	// before the flags reset, so the built message can wear its "↖ autopilot ·
-	// <note>" annotation ("N/M" continuation, or "refined" rewrite).
+	// before the flag resets, so the built message can wear its "↖ autopilot ·
+	// N/M" continuation annotation.
 	autopilotNote := ""
 	if m.autopilotContinuing {
 		autopilotNote = fmt.Sprintf("%d/%d", m.autopilotContinuations, m.env.AutoPilot.ResolvedMaxContinuations())
 		m.autopilotContinuing = false
 	} else {
 		m.autopilotContinuations = 0
-	}
-	if m.autopilotRefined {
-		autopilotNote = "refined"
-		m.autopilotRefined = false
 	}
 
 	if blocked, reason := m.checkPromptHook(context.Background(), raw); blocked {

--- a/internal/setting/merger.go
+++ b/internal/setting/merger.go
@@ -44,7 +44,6 @@ func mergeAutoPilot(base, overlay AutoPilotSettings) AutoPilotSettings {
 		MaxContinuations: coalesceInt(overlay.MaxContinuations, base.MaxContinuations),
 		Steers: SteerSettings{
 			Suggest:    overlay.Steers.Suggest || base.Steers.Suggest,
-			TurnStart:  overlay.Steers.TurnStart || base.Steers.TurnStart,
 			Permission: coalesceBool(overlay.Steers.Permission, base.Steers.Permission),
 			BashPrompt: overlay.Steers.BashPrompt || base.Steers.BashPrompt,
 			Question:   overlay.Steers.Question || base.Steers.Question,

--- a/internal/setting/settings.go
+++ b/internal/setting/settings.go
@@ -77,14 +77,13 @@ type AutoPilotSettings struct {
 }
 
 // SteerSettings toggles each point where the copilot steers the session.
-// Field names track the trigger: turnStart / turnEnd bracket the turn; the
-// middle three name the agent event that hands control over.
+// Field names track the trigger: turnEnd caps the turn; the middle three name
+// the agent event that hands control over. (The mission kick-off is an explicit
+// action — the panel's Start button — not a persisted steer.)
 type SteerSettings struct {
 	// Suggest fills the input hint with the copilot's proposed next step toward
 	// the mission — the gentlest steer: it suggests, the human accepts and sends.
 	Suggest bool `json:"suggest,omitempty"`
-	// TurnStart rewrites/augments each user input before it reaches the agent.
-	TurnStart bool `json:"turnStart,omitempty"`
 	// Permission auto-approves gray-zone tool calls. Tri-state so the baseline
 	// can default on while an explicit off still persists: nil = on (autopilot's
 	// whole point), false = escalate every gray-zone prompt to the human.
@@ -131,7 +130,7 @@ func (a AutoPilotSettings) Clone() AutoPilotSettings {
 func (a AutoPilotSettings) IsZero() bool {
 	return a.Model == "" && a.SystemPrompt == "" && a.SystemPromptFile == "" &&
 		a.Mission == "" && a.MaxContinuations == 0 &&
-		!a.Steers.Suggest && !a.Steers.TurnStart && a.Steers.Permission == nil &&
+		!a.Steers.Suggest && a.Steers.Permission == nil &&
 		!a.Steers.BashPrompt && !a.Steers.Question && !a.Steers.TurnEnd
 }
 
@@ -145,7 +144,6 @@ func (a AutoPilotSettings) Equal(b AutoPilotSettings) bool {
 		a.Mission == b.Mission &&
 		a.MaxContinuations == b.MaxContinuations &&
 		a.Steers.Suggest == b.Steers.Suggest &&
-		a.Steers.TurnStart == b.Steers.TurnStart &&
 		a.Steers.PermissionOn() == b.Steers.PermissionOn() &&
 		a.Steers.BashPrompt == b.Steers.BashPrompt &&
 		a.Steers.Question == b.Steers.Question &&

--- a/internal/tool/fs/bash_interactive.go
+++ b/internal/tool/fs/bash_interactive.go
@@ -5,6 +5,7 @@ package fs
 import (
 	"bytes"
 	"context"
+	"os"
 	"os/exec"
 	"strings"
 	"syscall"
@@ -32,24 +33,59 @@ const (
 	drainTimeout = 2 * time.Second
 )
 
-// runInteractive runs cmd attached to a pseudo-terminal and answers interactive
-// prompts through responder, returning the full combined output. A skipped or
-// unanswerable prompt is sent EOF (not a kill) so a real prompt aborts while a
-// command working silently keeps running; a cancelled ctx kills the whole
-// process group so children holding the pty are reaped too.
+// runInteractive runs cmd with a terminal for stdin only — stdout and stderr are
+// plain pipes — then answers interactive prompts through responder and returns
+// the combined output. Splitting the fds is deliberate: prompts gate on
+// isatty(stdin) (still a tty, so they appear and can be answered), while pagers
+// and full-screen/curses apps gate on isatty(stdout) (now a pipe, so `git diff`,
+// `less`, `man`, `vim`, … never engage and can never wedge the call). A skipped
+// or unanswerable prompt is sent EOF (not a kill) so a real prompt aborts while a
+// command working silently keeps running; a cancelled ctx kills the whole process
+// group so descendants holding a fd are reaped too.
 func runInteractive(ctx context.Context, command string, cmd *exec.Cmd, responder BashPromptResponder) (string, error) {
-	cmd.WaitDelay = 5 * time.Second // backstop for Wait if a child keeps the pty
-	ptmx, err := pty.Start(cmd)
+	cmd.WaitDelay = 5 * time.Second // backstop for Wait if a child keeps a fd open
+
+	// stdin: a pty slave, so isatty(stdin) is true and prompts fire; we write
+	// answers to the master (ptmx).
+	ptmx, pts, err := pty.Open()
 	if err != nil {
 		return "", err
 	}
 	defer func() { _ = ptmx.Close() }()
 
+	// stdout+stderr: one pipe. isatty(stdout) is false, so nothing pages or draws
+	// full-screen; the reader below watches this stream for prompt text.
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		_ = pts.Close()
+		return "", err
+	}
+	defer func() { _ = outR.Close() }()
+
+	cmd.Stdin = pts
+	cmd.Stdout = outW
+	cmd.Stderr = outW
+	// New session (no controlling terminal): /dev/tty grabs fail fast instead of
+	// stealing the parent TUI's terminal, and the session leader is a process-group
+	// leader TerminateGroup can reap.
+	proc.DetachSession(cmd)
+
+	if err := cmd.Start(); err != nil {
+		_ = pts.Close()
+		_ = outW.Close()
+		return "", err
+	}
+	// Drop the parent's copies of the child's fds: the child owns the pts, and
+	// closing outW lets the reader see EOF once the child (and any fd-inheriting
+	// descendant) exits.
+	_ = pts.Close()
+	_ = outW.Close()
+
 	chunks := make(chan []byte, 16)
 	go func() {
 		buf := make([]byte, 4096)
 		for {
-			n, err := ptmx.Read(buf)
+			n, err := outR.Read(buf)
 			if n > 0 {
 				chunks <- append([]byte(nil), buf[:n]...)
 			}

--- a/internal/tool/fs/bash_interactive_test.go
+++ b/internal/tool/fs/bash_interactive_test.go
@@ -142,6 +142,30 @@ func Test_runInteractive_timeoutReapsChildHoldingPTY(t *testing.T) {
 	}
 }
 
+func Test_runInteractive_stdinIsTTYButStdoutIsPipe(t *testing.T) {
+	// The core of the split-fd fix: stdin is a terminal (so prompts still fire and
+	// can be answered) while stdout is a pipe (so pagers/curses never engage). The
+	// second line simulates a pager: `cat` blocks reading stdin forever *only* when
+	// stdout is a tty. Under the old full-pty path this hung to the timeout; with a
+	// pipe stdout it takes the else branch and returns at once.
+	r := &fakeResponder{}
+	script := "[ -t 0 ] && echo stdin-tty || echo stdin-pipe\n" +
+		"if [ -t 1 ]; then cat; else echo stdout-pipe; fi"
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.Command("bash", "-c", script)
+	out, err := runInteractive(ctx, script, cmd, r)
+	if err != nil {
+		t.Fatalf("runInteractive errored (a hang would surface as a timeout here): %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "stdin-tty") {
+		t.Errorf("stdin must stay a tty so prompts still work; out=%q", out)
+	}
+	if !strings.Contains(out, "stdout-pipe") {
+		t.Errorf("stdout must be a pipe so pagers never engage; out=%q", out)
+	}
+}
+
 func Test_trimToLine(t *testing.T) {
 	cases := map[string]string{
 		"foo\nbar":        "bar",


### PR DESCRIPTION
Bump San to v1.21.0.\n\nIncludes:\n- Autopilot copilot configuration and lifecycle follow-ups\n- Autopilot start flow and interactive bash handling improvements\n- CHANGELOG.md entry for v1.21.0