### PR TITLE
feat(openai): discover model reasoning capabilities

### DIFF
--- a/docs/packages/2-feature/llm.md
+++ b/docs/packages/2-feature/llm.md
@@ -58,7 +58,11 @@ func ResetDefaultConn()       // test-only
   `core.LLM`, tracks per-call token counts, streams `core.Chunk`, applies
   retry/cost logic via `logging.go` and `money.go`.
 - `Store` (`store.go`) — persists user's provider connections under
-  `~/.san/providers.json`; tracks current model.
+  `~/.san/providers.json`; tracks current model and caches provider-scoped
+  model metadata. `ModelInfo.Reasoning` carries live supported/default effort
+  values when a provider advertises them; application resolution prefers that
+  metadata and falls back to `ThinkingEffortProvider` for catalogs (such as the
+  standard OpenAI `/v1/models` response) that omit reasoning capabilities.
 - `stream/` — provider-side helpers for SSE parsing.
 - Provider subpackages: `anthropic/`, `openai/`, `google/`, `moonshot/`,
   `alibaba/`, `bigmodel/`, `minmax/`, `mimo/`, `deepseek/`, `ollama/`, `sensenova/`, `volcengine/`, `agnesai/`, `openaicompat/`.

--- a/internal/app/env.go
+++ b/internal/app/env.go
@@ -152,7 +152,11 @@ func (m *env) GetModelDisplayName() string {
 }
 
 func (m *env) EffectiveThinkingEffort() string {
-	return llm.ResolveThinkingEffort(m.LLMProvider, m.GetModelID(), m.ThinkingEffort)
+	return llm.ResolveThinkingEffortForModel(m.LLMProvider, m.store, m.CurrentModel, m.ThinkingEffort)
+}
+
+func (m *env) ThinkingEfforts() []string {
+	return llm.ThinkingEffortsForModel(m.LLMProvider, m.store, m.CurrentModel)
 }
 
 func (m *env) OperationModeName() string {
@@ -200,7 +204,7 @@ func (m *env) ApplyBypassPermissions() {
 
 func (m *env) DetectThinkingKeywords(input string) {
 	lower := strings.ToLower(input)
-	efforts := llm.ThinkingEfforts(m.LLMProvider, m.GetModelID())
+	efforts := m.ThinkingEfforts()
 	if len(efforts) == 0 {
 		return
 	}

--- a/internal/app/input/on_provider.go
+++ b/internal/app/input/on_provider.go
@@ -253,11 +253,18 @@ func UpdateProvider(deps OverlayDeps, state *ProviderState, msg tea.Msg) (tea.Cm
 		}
 		return nil, true
 	case providerConnectResultMsg:
-		return state.Selector.HandleConnectResult(msg), true
+		cmd := state.Selector.HandleConnectResult(msg)
+		if msg.Success && deps.ReloadModelStore != nil {
+			deps.ReloadModelStore()
+		}
+		return cmd, true
 	case providerModelSelectedMsg:
 		return handleProviderModelSelected(deps, state, msg), true
 	case providerModelsLoadedMsg:
 		state.Selector.HandleModelsLoaded(msg)
+		if deps.ReloadModelStore != nil {
+			deps.ReloadModelStore()
+		}
 		return nil, true
 	case kit.StatusExpiredMsg:
 		if msg.Token == state.statusToken {

--- a/internal/app/input/on_provider.go
+++ b/internal/app/input/on_provider.go
@@ -69,6 +69,7 @@ type providerModelItem struct {
 	ID               string
 	Name             string
 	DisplayName      string
+	Description      string
 	ProviderName     string
 	AuthMethod       llm.AuthMethod
 	IsCurrent        bool
@@ -81,6 +82,7 @@ func newProviderModelItem(mdl llm.ModelInfo, providerName string, authMethod llm
 		ID:               mdl.ID,
 		Name:             mdl.Name,
 		DisplayName:      mdl.DisplayName,
+		Description:      mdl.Description,
 		ProviderName:     providerName,
 		AuthMethod:       authMethod,
 		IsCurrent:        current != nil && current.ModelID == mdl.ID && string(current.Provider) == providerName && current.AuthMethod == authMethod,

--- a/internal/app/input/on_provider_test.go
+++ b/internal/app/input/on_provider_test.go
@@ -78,6 +78,19 @@ func (a *storedCredentialAuthenticator) Logout() error { return nil }
 
 func (a *storedCredentialAuthenticator) HasCredentials() bool { return a.has }
 
+func TestUpdateProviderReloadsSharedModelStoreAfterCatalogRefresh(t *testing.T) {
+	reloads := 0
+	deps := OverlayDeps{ReloadModelStore: func() { reloads++ }}
+	state := &ProviderState{}
+
+	if _, handled := UpdateProvider(deps, state, providerModelsLoadedMsg{}); !handled {
+		t.Fatal("providerModelsLoadedMsg was not handled")
+	}
+	if reloads != 1 {
+		t.Fatalf("shared model store reloads = %d, want 1", reloads)
+	}
+}
+
 func TestCancelClearsTransientState(t *testing.T) {
 	m := NewProviderSelector()
 	m.active = true

--- a/internal/app/input/on_provider_view.go
+++ b/internal/app/input/on_provider_view.go
@@ -228,6 +228,18 @@ func (s *ProviderSelector) renderModelRow(item providerListItem, isSelected bool
 	}
 
 	line := fmt.Sprintf("%s %s%s", indicatorStyle.Render(indicator), displayName, warning)
+
+	// When the catalog describes the model, trail the name with a dimmed
+	// description. Truncate it to whatever room is left on the row (after the
+	// selection prefix and a two-column gap) so a long blurb never wraps.
+	if desc := strings.TrimSpace(m.Description); desc != "" {
+		const prefixAndGap = 6 // up to 4 cols of selection prefix + a 2-col gap
+		budget := s.panel().ContentWidth() - lipgloss.Width(line) - prefixAndGap
+		if budget >= 8 {
+			line += "  " + kit.DimStyle().Render(kit.TruncateText(desc, budget))
+		}
+	}
+
 	return kit.RenderSelectableRow(line, isSelected)
 }
 

--- a/internal/app/input/runtime.go
+++ b/internal/app/input/runtime.go
@@ -18,6 +18,7 @@ type OverlayDeps struct {
 
 	SwitchProvider          func(llm.Provider)
 	SetCurrentModel         func(*llm.CurrentModelInfo)
+	ReloadModelStore        func()
 	ClearCachedInstructions func()
 	RefreshMemoryContext    func(cwd, reason string)
 	FireFileChanged         func(path, tool string)

--- a/internal/app/input/slash_command.go
+++ b/internal/app/input/slash_command.go
@@ -477,11 +477,8 @@ func (c *SlashCommandController) handleAgentCommand(_ context.Context, _ string)
 }
 
 func (c *SlashCommandController) handleThinkCommand(_ context.Context, args string) (string, tea.Cmd, error) {
-	model := ""
-	if c.env.LLM.CurrentModel() != nil {
-		model = c.env.LLM.CurrentModel().ModelID
-	}
-	efforts := llm.ThinkingEfforts(c.env.LLM.Provider(), model)
+	currentModel := c.env.LLM.CurrentModel()
+	efforts := llm.ThinkingEffortsForModel(c.env.LLM.Provider(), c.env.LLM.Store(), currentModel)
 	if len(efforts) == 0 {
 		return "Current provider does not support thinking effort.", nil, nil
 	}
@@ -489,7 +486,7 @@ func (c *SlashCommandController) handleThinkCommand(_ context.Context, args stri
 	arg := strings.TrimSpace(strings.ToLower(args))
 	var effort string
 	if arg == "" || arg == "toggle" {
-		next, _ := llm.NextThinkingEffort(c.env.LLM.Provider(), model, c.env.GetThinkingEffort())
+		next, _ := llm.NextThinkingEffortForModel(c.env.LLM.Provider(), c.env.LLM.Store(), currentModel, c.env.GetThinkingEffort())
 		effort = next
 	} else {
 		if arg == "off" && !containsThinkingEffort(efforts, "off") && containsThinkingEffort(efforts, "none") {

--- a/internal/app/kit/token.go
+++ b/internal/app/kit/token.go
@@ -48,12 +48,7 @@ func GetModelTokenLimits(store *llm.Store, currentModel *llm.CurrentModelInfo) (
 	if store == nil || currentModel == nil {
 		return 0, 0
 	}
-	authMethod := currentModel.AuthMethod
-	if authMethod == "" {
-		if conn, ok := store.GetConnection(currentModel.Provider); ok {
-			authMethod = conn.AuthMethod
-		}
-	}
+	authMethod := store.ResolveAuthMethod(currentModel)
 	if input, output := store.CachedModelLimitsForProvider(currentModel.Provider, authMethod, currentModel.ModelID); input > 0 {
 		return input, output
 	}

--- a/internal/app/model_subfeatures.go
+++ b/internal/app/model_subfeatures.go
@@ -77,6 +77,13 @@ func (m *model) autopilotSuggestMission() string {
 }
 
 func (m *model) overlayDeps() input.OverlayDeps {
+	reloadModelStore := func() {
+		if store := m.services.LLM.Store(); store != nil {
+			if err := store.Reload(); err != nil {
+				log.Logger().Warn("reload provider store after model catalog update", zap.Error(err))
+			}
+		}
+	}
 	return input.OverlayDeps{
 		State:             &m.userInput,
 		Conv:              &m.conv.ConversationModel,
@@ -95,13 +102,10 @@ func (m *model) overlayDeps() input.OverlayDeps {
 			// limits) through its own Store; reload the shared store so the
 			// status bar reflects the new model's name and context-window
 			// limit instead of the raw ID and "--".
-			if store := m.services.LLM.Store(); store != nil {
-				if err := store.Reload(); err != nil {
-					log.Logger().Warn("reload provider store after model switch", zap.Error(err))
-				}
-			}
+			reloadModelStore()
 			m.env.LoadThinkingEffortFromStore()
 		},
+		ReloadModelStore: reloadModelStore,
 		// No welcome reprint on model switch: the live status line already
 		// shows the current model, and the startup brand line is a one-time
 		// splash (re-emitting it duplicated the banner / leaked blank lines).

--- a/internal/app/update_key_test.go
+++ b/internal/app/update_key_test.go
@@ -60,6 +60,40 @@ func TestCtrlTCyclesThinkingEffort(t *testing.T) {
 	}
 }
 
+func TestCtrlTUsesCachedModelReasoningMetadata(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	store, err := llm.NewStore()
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := store.CacheModels(llm.OpenAI, llm.AuthSubscription, []llm.ModelInfo{{
+		ID:        "dynamic-model",
+		Reasoning: llm.NewReasoningCapability([]string{"low", "ultra"}, "low"),
+	}}); err != nil {
+		t.Fatalf("CacheModels() error = %v", err)
+	}
+
+	m := &model{}
+	m.env.store = store
+	m.env.LLMProvider = &testThinkingProvider{
+		efforts: []string{"high"},
+		def:     "high",
+	}
+	m.env.CurrentModel = &llm.CurrentModelInfo{
+		ModelID:    "dynamic-model",
+		Provider:   llm.OpenAI,
+		AuthMethod: llm.AuthSubscription,
+	}
+
+	cmd, handled := m.handleTextareaShortcut(tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
+	if !handled || cmd == nil {
+		t.Fatal("Ctrl+T should be handled and return a status timer")
+	}
+	if m.env.ThinkingEffort != "ultra" {
+		t.Fatalf("ThinkingEffort = %q, want dynamic next effort ultra", m.env.ThinkingEffort)
+	}
+}
+
 func TestAltTTogglesTaskPanel(t *testing.T) {
 	m := &model{}
 

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -176,7 +176,7 @@ func (m *model) handleTextareaShortcut(msg tea.KeyMsg) (tea.Cmd, bool) {
 
 func (m *model) cycleThinkingEffort() tea.Cmd {
 	current := m.env.EffectiveThinkingEffort()
-	next, ok := llm.NextThinkingEffort(m.env.LLMProvider, m.env.GetModelID(), current)
+	next, ok := llm.NextThinkingEffortForModel(m.env.LLMProvider, m.env.store, m.env.CurrentModel, current)
 	if !ok {
 		token := m.userInput.Provider.SetStatusMessage("reasoning is not supported by this provider")
 		return kit.StatusTimer(3*time.Second, token)

--- a/internal/llm/capability_test.go
+++ b/internal/llm/capability_test.go
@@ -40,8 +40,8 @@ func TestNewReasoningCapabilityNormalizesProviderValues(t *testing.T) {
 	if capability == nil {
 		t.Fatal("NewReasoningCapability() = nil")
 	}
-	if !slices.Equal(capability.Efforts, []string{"low", "ultra"}) {
-		t.Fatalf("efforts = %v, want [low ultra]", capability.Efforts)
+	if !slices.Equal(capability.SupportedEfforts, []string{"low", "ultra"}) {
+		t.Fatalf("efforts = %v, want [low ultra]", capability.SupportedEfforts)
 	}
 	if capability.DefaultEffort != "ultra" {
 		t.Fatalf("default = %q, want ultra", capability.DefaultEffort)

--- a/internal/llm/capability_test.go
+++ b/internal/llm/capability_test.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"context"
+	"slices"
 	"testing"
 )
 
@@ -18,11 +19,69 @@ type textOnlyProvider struct{ plainProvider }
 
 func (textOnlyProvider) SupportsImages(string) bool { return false }
 
+type staticReasoningProvider struct{ plainProvider }
+
+func (staticReasoningProvider) ThinkingEfforts(string) []string { return []string{"high"} }
+func (staticReasoningProvider) DefaultThinkingEffort(string) string {
+	return "high"
+}
+
 func TestSupportsImages(t *testing.T) {
 	if !SupportsImages(plainProvider{}, "m") {
 		t.Error("a provider that doesn't implement ImageSupportProvider should default to supported")
 	}
 	if SupportsImages(textOnlyProvider{}, "m") {
 		t.Error("a provider that opts out should report no image support")
+	}
+}
+
+func TestNewReasoningCapabilityNormalizesProviderValues(t *testing.T) {
+	capability := NewReasoningCapability([]string{" Low ", "ULTRA", "low", ""}, " Ultra ")
+	if capability == nil {
+		t.Fatal("NewReasoningCapability() = nil")
+	}
+	if !slices.Equal(capability.Efforts, []string{"low", "ultra"}) {
+		t.Fatalf("efforts = %v, want [low ultra]", capability.Efforts)
+	}
+	if capability.DefaultEffort != "ultra" {
+		t.Fatalf("default = %q, want ultra", capability.DefaultEffort)
+	}
+	if got := NewReasoningCapability(nil, "high"); got != nil {
+		t.Fatalf("empty capability = %+v, want nil", got)
+	}
+}
+
+func TestModelReasoningMetadataOverridesProviderFallback(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	store, err := NewStore()
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := store.CacheModels(OpenAI, AuthSubscription, []ModelInfo{{
+		ID:        "gpt-dynamic",
+		Reasoning: NewReasoningCapability([]string{"low", "ultra"}, "low"),
+	}}); err != nil {
+		t.Fatalf("CacheModels() error = %v", err)
+	}
+	reloaded, err := NewStore()
+	if err != nil {
+		t.Fatalf("reload NewStore() error = %v", err)
+	}
+
+	provider := staticReasoningProvider{}
+	current := &CurrentModelInfo{ModelID: "gpt-dynamic", Provider: OpenAI, AuthMethod: AuthSubscription}
+	if got := ThinkingEffortsForModel(provider, reloaded, current); !slices.Equal(got, []string{"low", "ultra"}) {
+		t.Fatalf("ThinkingEffortsForModel() = %v, want dynamic [low ultra]", got)
+	}
+	if got := ResolveThinkingEffortForModel(provider, reloaded, current, "invalid"); got != "low" {
+		t.Fatalf("ResolveThinkingEffortForModel(invalid) = %q, want dynamic default low", got)
+	}
+	if got, ok := NextThinkingEffortForModel(provider, reloaded, current, "low"); !ok || got != "ultra" {
+		t.Fatalf("NextThinkingEffortForModel(low) = (%q, %v), want (ultra, true)", got, ok)
+	}
+
+	legacy := &CurrentModelInfo{ModelID: "legacy", Provider: OpenAI, AuthMethod: AuthSubscription}
+	if got := ThinkingEffortsForModel(provider, reloaded, legacy); !slices.Equal(got, []string{"high"}) {
+		t.Fatalf("legacy fallback efforts = %v, want [high]", got)
 	}
 }

--- a/internal/llm/openai/catalog.go
+++ b/internal/llm/openai/catalog.go
@@ -43,6 +43,14 @@ func openAIThinkingEfforts(model string) []string {
 	}
 }
 
+// openAIModelInfo builds catalog metadata for a model ID. It deliberately
+// leaves Reasoning unset: the standard /v1/models catalog advertises no
+// reasoning levels, and freezing our static name-based guesses into the
+// on-disk cache would mask a later binary's updated rules, since the cache is
+// read ignoring TTL. Only live catalogs that actually advertise levels — the
+// ChatGPT subscription /models response — attach Reasoning (see subscription.go);
+// everything else falls back to the provider's static ThinkingEffortProvider
+// rules at resolution time.
 func openAIModelInfo(modelID string) llm.ModelInfo {
 	input, output := openAILimits(modelID)
 	return llm.ModelInfo{
@@ -51,10 +59,6 @@ func openAIModelInfo(modelID string) llm.ModelInfo {
 		DisplayName:      modelID,
 		InputTokenLimit:  input,
 		OutputTokenLimit: output,
-		Reasoning: llm.NewReasoningCapability(
-			openAIThinkingEfforts(modelID),
-			openAIDefaultThinkingEffort(modelID),
-		),
 	}
 }
 

--- a/internal/llm/openai/catalog.go
+++ b/internal/llm/openai/catalog.go
@@ -7,6 +7,7 @@ import (
 )
 
 var reasoningEfforts = []string{"none", "low", "medium", "high", "xhigh"}
+var gpt56ReasoningEfforts = []string{"none", "low", "medium", "high", "xhigh", "max"}
 var highOnlyReasoningEfforts = []string{"high"}
 
 func (c *Client) ThinkingEfforts(model string) []string {
@@ -14,6 +15,10 @@ func (c *Client) ThinkingEfforts(model string) []string {
 }
 
 func (c *Client) DefaultThinkingEffort(model string) string {
+	return openAIDefaultThinkingEffort(model)
+}
+
+func openAIDefaultThinkingEffort(model string) string {
 	switch efforts := openAIThinkingEfforts(model); len(efforts) {
 	case 0:
 		return ""
@@ -27,6 +32,8 @@ func (c *Client) DefaultThinkingEffort(model string) string {
 func openAIThinkingEfforts(model string) []string {
 	normalized := strings.ToLower(strings.TrimSpace(model))
 	switch {
+	case strings.HasPrefix(normalized, "gpt-5.6"):
+		return gpt56ReasoningEfforts
 	case strings.HasPrefix(normalized, "gpt-5.5"), strings.HasPrefix(normalized, "gpt-5.4"), strings.HasPrefix(normalized, "gpt-6"):
 		return reasoningEfforts
 	case strings.HasPrefix(normalized, "gpt-5"), strings.HasPrefix(normalized, "o1"), strings.HasPrefix(normalized, "o3"), strings.HasPrefix(normalized, "o4"), strings.Contains(normalized, "codex"):
@@ -44,6 +51,10 @@ func openAIModelInfo(modelID string) llm.ModelInfo {
 		DisplayName:      modelID,
 		InputTokenLimit:  input,
 		OutputTokenLimit: output,
+		Reasoning: llm.NewReasoningCapability(
+			openAIThinkingEfforts(modelID),
+			openAIDefaultThinkingEffort(modelID),
+		),
 	}
 }
 

--- a/internal/llm/openai/catalog.go
+++ b/internal/llm/openai/catalog.go
@@ -15,10 +15,6 @@ func (c *Client) ThinkingEfforts(model string) []string {
 }
 
 func (c *Client) DefaultThinkingEffort(model string) string {
-	return openAIDefaultThinkingEffort(model)
-}
-
-func openAIDefaultThinkingEffort(model string) string {
 	switch efforts := openAIThinkingEfforts(model); len(efforts) {
 	case 0:
 		return ""

--- a/internal/llm/openai/client_test.go
+++ b/internal/llm/openai/client_test.go
@@ -78,8 +78,17 @@ func drain(ch <-chan llm.StreamChunk) []llm.StreamChunk {
 
 func TestOpenAIThinkingEfforts(t *testing.T) {
 	client := newTestClient(&captureStreamingTransport{})
-	got := client.ThinkingEfforts("gpt-5.5")
-	want := []string{"none", "low", "medium", "high", "xhigh"}
+	got := client.ThinkingEfforts("gpt-5.6-sol")
+	want := []string{"none", "low", "medium", "high", "xhigh", "max"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("ThinkingEfforts(gpt-5.6-sol) = %#v, want %#v", got, want)
+	}
+	if client.DefaultThinkingEffort("gpt-5.6-sol") != "medium" {
+		t.Fatalf("expected GPT-5.6 API default effort medium")
+	}
+
+	got = client.ThinkingEfforts("gpt-5.5")
+	want = []string{"none", "low", "medium", "high", "xhigh"}
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("ThinkingEfforts() = %#v, want %#v", got, want)
 	}

--- a/internal/llm/openai/subscription.go
+++ b/internal/llm/openai/subscription.go
@@ -140,12 +140,16 @@ type codexModelsResponse struct {
 type codexModel struct {
 	Slug                     string                `json:"slug"`
 	DisplayName              string                `json:"display_name"`
+	Description              string                `json:"description"`
 	ContextWindow            int                   `json:"context_window"`
 	ShowInPicker             *bool                 `json:"show_in_picker"`
 	SupportedReasoningLevels []codexReasoningLevel `json:"supported_reasoning_levels"`
 	DefaultReasoningLevel    string                `json:"default_reasoning_level"`
 }
 
+// codexReasoningLevel is one entry of supported_reasoning_levels. The backend
+// also sends a per-level "description" blurb next to each effort, which san
+// doesn't surface, so only the effort label is parsed.
 type codexReasoningLevel struct {
 	Effort string `json:"effort"`
 }
@@ -171,6 +175,9 @@ func (r codexModelsResponse) toModelInfos() []llm.ModelInfo {
 		}
 		if m.ContextWindow > 0 {
 			info.InputTokenLimit = m.ContextWindow
+		}
+		if m.Description != "" {
+			info.Description = m.Description
 		}
 		if len(m.SupportedReasoningLevels) > 0 {
 			efforts := make([]string, 0, len(m.SupportedReasoningLevels))

--- a/internal/llm/openai/subscription.go
+++ b/internal/llm/openai/subscription.go
@@ -33,7 +33,7 @@ const modelsFetchTimeout = 8 * time.Second
 // Codex CLI version (matching the codex originator we already send); the backend
 // returns the current lineup for any sufficiently recent version. Bump if the
 // list ever goes stale.
-const codexClientVersion = "0.142.5"
+const codexClientVersion = "0.144.0"
 
 // staticSubscriptionModels is the fallback catalog used when the live ChatGPT
 // Codex model list can't be fetched. Keep this intentionally small so the UI
@@ -138,10 +138,16 @@ type codexModelsResponse struct {
 // reports the context window and, via show_in_picker, whether the entry should be
 // user-selectable (null means shown).
 type codexModel struct {
-	Slug          string `json:"slug"`
-	DisplayName   string `json:"display_name"`
-	ContextWindow int    `json:"context_window"`
-	ShowInPicker  *bool  `json:"show_in_picker"`
+	Slug                     string                `json:"slug"`
+	DisplayName              string                `json:"display_name"`
+	ContextWindow            int                   `json:"context_window"`
+	ShowInPicker             *bool                 `json:"show_in_picker"`
+	SupportedReasoningLevels []codexReasoningLevel `json:"supported_reasoning_levels"`
+	DefaultReasoningLevel    string                `json:"default_reasoning_level"`
+}
+
+type codexReasoningLevel struct {
+	Effort string `json:"effort"`
 }
 
 // toModelInfos converts the catalog to llm.ModelInfo, dropping picker-hidden and
@@ -165,6 +171,15 @@ func (r codexModelsResponse) toModelInfos() []llm.ModelInfo {
 		}
 		if m.ContextWindow > 0 {
 			info.InputTokenLimit = m.ContextWindow
+		}
+		if len(m.SupportedReasoningLevels) > 0 {
+			efforts := make([]string, 0, len(m.SupportedReasoningLevels))
+			for _, level := range m.SupportedReasoningLevels {
+				efforts = append(efforts, level.Effort)
+			}
+			if capability := llm.NewReasoningCapability(efforts, m.DefaultReasoningLevel); capability != nil {
+				info.Reasoning = capability
+			}
 		}
 		models = append(models, info)
 	}

--- a/internal/llm/openai/subscription_test.go
+++ b/internal/llm/openai/subscription_test.go
@@ -86,11 +86,12 @@ const reasoningStreamBody = "" +
 	"data: [DONE]\n\n"
 
 // modelsCatalogBody is a sample ChatGPT Codex /models JSON response (real shape:
-// a "models" array of {slug, display_name, context_window, ...}): two picker
+// a "models" array of {slug, display_name, context_window, ...}): three picker
 // models plus one hidden entry that must be filtered out.
 const modelsCatalogBody = `{"models":[` +
-	`{"slug":"gpt-5.5","display_name":"GPT-5.5","context_window":272000},` +
-	`{"slug":"gpt-5.4","display_name":"GPT-5.4","context_window":272000},` +
+	`{"slug":"gpt-5.6-sol","display_name":"GPT-5.6-Sol","context_window":372000,"default_reasoning_level":"low","supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"},{"effort":"xhigh"},{"effort":"max"},{"effort":"ultra"}]},` +
+	`{"slug":"gpt-5.6-terra","display_name":"GPT-5.6-Terra","context_window":372000,"default_reasoning_level":"low","supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"},{"effort":"xhigh"},{"effort":"max"},{"effort":"ultra"}]},` +
+	`{"slug":"gpt-5.6-luna","display_name":"GPT-5.6-Luna","context_window":372000,"default_reasoning_level":"low","supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"},{"effort":"xhigh"},{"effort":"max"},{"effort":"ultra"}]},` +
 	`{"slug":"gpt-hidden","display_name":"Hidden","show_in_picker":false}` +
 	`]}`
 
@@ -259,20 +260,30 @@ func TestSubscriptionCatalogParsesLiveResponse(t *testing.T) {
 
 	// The /models endpoint requires the client_version query param; without it
 	// the backend 400s and we'd silently fall back.
-	if !strings.Contains(transport.query, "client_version=") {
-		t.Errorf("models request query = %q, want a client_version param", transport.query)
+	wantVersionQuery := "client_version=" + codexClientVersion
+	if !strings.Contains(transport.query, wantVersionQuery) {
+		t.Errorf("models request query = %q, want %q", transport.query, wantVersionQuery)
 	}
 
-	// Two visible entries; the show_in_picker=false one is dropped.
-	if len(models) != 2 {
-		t.Fatalf("got %d models, want 2: %v", len(models), models)
+	// Three visible entries; the show_in_picker=false one is dropped.
+	if len(models) != 3 {
+		t.Fatalf("got %d models, want 3: %v", len(models), models)
 	}
 	byID := map[string]llm.ModelInfo{}
 	for _, m := range models {
 		byID[m.ID] = m
 	}
-	if got, ok := byID["gpt-5.5"]; !ok || got.DisplayName != "GPT-5.5" || got.InputTokenLimit != 272000 {
-		t.Errorf("gpt-5.5 = %+v (present=%v), want display GPT-5.5 / limit 272000", got, ok)
+	for _, id := range []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"} {
+		if got, ok := byID[id]; !ok || got.InputTokenLimit != 372000 {
+			t.Errorf("%s = %+v (present=%v), want limit 372000", id, got, ok)
+		} else {
+			wantEfforts := []string{"low", "medium", "high", "xhigh", "max", "ultra"}
+			if got.Reasoning == nil || strings.Join(got.Reasoning.Efforts, ",") != strings.Join(wantEfforts, ",") {
+				t.Errorf("%s reasoning = %+v, want efforts %v", id, got.Reasoning, wantEfforts)
+			} else if got.Reasoning.DefaultEffort != "low" {
+				t.Errorf("%s default reasoning = %q, want low", id, got.Reasoning.DefaultEffort)
+			}
+		}
 	}
 	if _, hidden := byID["gpt-hidden"]; hidden {
 		t.Error("show_in_picker=false model must be dropped")

--- a/internal/llm/openai/subscription_test.go
+++ b/internal/llm/openai/subscription_test.go
@@ -86,12 +86,14 @@ const reasoningStreamBody = "" +
 	"data: [DONE]\n\n"
 
 // modelsCatalogBody is a sample ChatGPT Codex /models JSON response (real shape:
-// a "models" array of {slug, display_name, context_window, ...}): three picker
-// models plus one hidden entry that must be filtered out.
+// a "models" array of {slug, display_name, description, context_window, ...}):
+// three picker models plus one hidden entry that must be filtered out. gpt-5.6-sol
+// carries the per-effort "description" blurbs the backend sends inside
+// supported_reasoning_levels, which san parses past (only the effort is kept).
 const modelsCatalogBody = `{"models":[` +
-	`{"slug":"gpt-5.6-sol","display_name":"GPT-5.6-Sol","context_window":372000,"default_reasoning_level":"low","supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"},{"effort":"xhigh"},{"effort":"max"},{"effort":"ultra"}]},` +
-	`{"slug":"gpt-5.6-terra","display_name":"GPT-5.6-Terra","context_window":372000,"default_reasoning_level":"low","supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"},{"effort":"xhigh"},{"effort":"max"},{"effort":"ultra"}]},` +
-	`{"slug":"gpt-5.6-luna","display_name":"GPT-5.6-Luna","context_window":372000,"default_reasoning_level":"low","supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"},{"effort":"xhigh"},{"effort":"max"},{"effort":"ultra"}]},` +
+	`{"slug":"gpt-5.6-sol","display_name":"GPT-5.6-Sol","description":"Fast, balanced default.","context_window":372000,"default_reasoning_level":"low","supported_reasoning_levels":[{"effort":"low","description":"Quick"},{"effort":"medium","description":"Balanced"},{"effort":"high"},{"effort":"xhigh"},{"effort":"max"},{"effort":"ultra"}]},` +
+	`{"slug":"gpt-5.6-terra","display_name":"GPT-5.6-Terra","description":"Deeper reasoning for hard tasks.","context_window":372000,"default_reasoning_level":"low","supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"},{"effort":"xhigh"},{"effort":"max"},{"effort":"ultra"}]},` +
+	`{"slug":"gpt-5.6-luna","display_name":"GPT-5.6-Luna","description":"Long-context specialist.","context_window":372000,"default_reasoning_level":"low","supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"},{"effort":"xhigh"},{"effort":"max"},{"effort":"ultra"}]},` +
 	`{"slug":"gpt-hidden","display_name":"Hidden","show_in_picker":false}` +
 	`]}`
 
@@ -273,15 +275,23 @@ func TestSubscriptionCatalogParsesLiveResponse(t *testing.T) {
 	for _, m := range models {
 		byID[m.ID] = m
 	}
+	wantDescriptions := map[string]string{
+		"gpt-5.6-sol":   "Fast, balanced default.",
+		"gpt-5.6-terra": "Deeper reasoning for hard tasks.",
+		"gpt-5.6-luna":  "Long-context specialist.",
+	}
 	for _, id := range []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"} {
 		if got, ok := byID[id]; !ok || got.InputTokenLimit != 372000 {
 			t.Errorf("%s = %+v (present=%v), want limit 372000", id, got, ok)
 		} else {
 			wantEfforts := []string{"low", "medium", "high", "xhigh", "max", "ultra"}
-			if got.Reasoning == nil || strings.Join(got.Reasoning.Efforts, ",") != strings.Join(wantEfforts, ",") {
+			if got.Reasoning == nil || strings.Join(got.Reasoning.SupportedEfforts, ",") != strings.Join(wantEfforts, ",") {
 				t.Errorf("%s reasoning = %+v, want efforts %v", id, got.Reasoning, wantEfforts)
 			} else if got.Reasoning.DefaultEffort != "low" {
 				t.Errorf("%s default reasoning = %q, want low", id, got.Reasoning.DefaultEffort)
+			}
+			if got.Description != wantDescriptions[id] {
+				t.Errorf("%s description = %q, want %q", id, got.Description, wantDescriptions[id])
 			}
 		}
 	}

--- a/internal/llm/store.go
+++ b/internal/llm/store.go
@@ -369,7 +369,7 @@ func (s *Store) CachedModelReasoningForProvider(provider Name, authMethod AuthMe
 		if model.ID != id || model.Reasoning == nil {
 			continue
 		}
-		capability := NewReasoningCapability(model.Reasoning.Efforts, model.Reasoning.DefaultEffort)
+		capability := NewReasoningCapability(model.Reasoning.SupportedEfforts, model.Reasoning.DefaultEffort)
 		return capability, capability != nil
 	}
 	return nil, false

--- a/internal/llm/store.go
+++ b/internal/llm/store.go
@@ -353,6 +353,28 @@ func (s *Store) CachedModelLimitsForProvider(provider Name, authMethod AuthMetho
 	return 0, 0
 }
 
+// CachedModelReasoningForProvider returns normalized reasoning metadata for one
+// model from a single provider/auth cache, ignoring TTL. Like token limits, the
+// same model ID can expose different capabilities through different auth paths,
+// so this lookup must remain provider-scoped and deterministic.
+func (s *Store) CachedModelReasoningForProvider(provider Name, authMethod AuthMethod, id string) (*ReasoningCapability, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	cache, ok := s.data.Models[makemodelCacheKey(provider, authMethod)]
+	if !ok {
+		return nil, false
+	}
+	for _, model := range cache.Models {
+		if model.ID != id || model.Reasoning == nil {
+			continue
+		}
+		capability := NewReasoningCapability(model.Reasoning.Efforts, model.Reasoning.DefaultEffort)
+		return capability, capability != nil
+	}
+	return nil, false
+}
+
 // CachedModelLimits returns the token limits for a model ID found in any
 // cached provider list, ignoring TTL. Returns (0, 0) when no cached entry
 // reports a context window for the ID.

--- a/internal/llm/store.go
+++ b/internal/llm/store.go
@@ -190,6 +190,24 @@ func (s *Store) GetConnection(provider Name) (ConnectionInfo, bool) {
 	return conn, ok
 }
 
+// ResolveAuthMethod returns the model's own auth method, falling back to its
+// provider's stored connection when the model doesn't carry one. Provider-scoped
+// cache lookups (token limits, reasoning) key on provider+auth, so they resolve
+// the auth this way to avoid missing the cache for a model selected without an
+// explicit method.
+func (s *Store) ResolveAuthMethod(current *CurrentModelInfo) AuthMethod {
+	if current == nil {
+		return ""
+	}
+	if current.AuthMethod != "" {
+		return current.AuthMethod
+	}
+	if conn, ok := s.GetConnection(current.Provider); ok {
+		return conn.AuthMethod
+	}
+	return ""
+}
+
 // GetConnections returns all connections
 func (s *Store) GetConnections() map[string]ConnectionInfo {
 	s.mu.RLock()
@@ -366,11 +384,12 @@ func (s *Store) CachedModelReasoningForProvider(provider Name, authMethod AuthMe
 		return nil, false
 	}
 	for _, model := range cache.Models {
-		if model.ID != id || model.Reasoning == nil {
-			continue
+		// The cached capability was already normalized by NewReasoningCapability
+		// at write time, so hand it back as-is rather than re-normalizing on every
+		// (hot-path) lookup. Callers treat it as read-only.
+		if model.ID == id && model.Reasoning != nil {
+			return model.Reasoning, true
 		}
-		capability := NewReasoningCapability(model.Reasoning.SupportedEfforts, model.Reasoning.DefaultEffort)
-		return capability, capability != nil
 	}
 	return nil, false
 }

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -193,12 +193,7 @@ func reasoningCapabilityForModel(p Provider, store *Store, current *CurrentModel
 		return nil
 	}
 	if store != nil {
-		authMethod := current.AuthMethod
-		if authMethod == "" {
-			if conn, ok := store.GetConnection(current.Provider); ok {
-				authMethod = conn.AuthMethod
-			}
-		}
+		authMethod := store.ResolveAuthMethod(current)
 		if capability, ok := store.CachedModelReasoningForProvider(current.Provider, authMethod, current.ModelID); ok {
 			return capability
 		}

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -144,34 +144,6 @@ func DefaultThinkingEffort(p Provider, model string) string {
 	return normalizeThinkingEffort(ep.DefaultThinkingEffort(model), ep.ThinkingEfforts(model))
 }
 
-func ResolveThinkingEffort(p Provider, model, selected string) string {
-	efforts := ThinkingEfforts(p, model)
-	if len(efforts) == 0 {
-		return ""
-	}
-	if effort := normalizeThinkingEffort(selected, efforts); effort != "" {
-		return effort
-	}
-	return DefaultThinkingEffort(p, model)
-}
-
-func NextThinkingEffort(p Provider, model, current string) (string, bool) {
-	efforts := ThinkingEfforts(p, model)
-	if len(efforts) == 0 {
-		return "", false
-	}
-	current = normalizeThinkingEffort(current, efforts)
-	if current == "" {
-		current = DefaultThinkingEffort(p, model)
-	}
-	for i, effort := range efforts {
-		if effort == current {
-			return efforts[(i+1)%len(efforts)], true
-		}
-	}
-	return efforts[0], true
-}
-
 // ThinkingEffortsForModel returns live cached model metadata when available,
 // falling back to the provider's static ThinkingEffortProvider implementation.
 func ThinkingEffortsForModel(p Provider, store *Store, current *CurrentModelInfo) []string {

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -73,8 +73,8 @@ type ThinkingEffortProvider interface {
 // model. Providers that return this metadata from ListModels let the rest of the
 // app follow the live catalog instead of guessing capabilities from model IDs.
 type ReasoningCapability struct {
-	Efforts       []string `json:"efforts,omitempty"`
-	DefaultEffort string   `json:"defaultEffort,omitempty"`
+	SupportedEfforts []string `json:"supportedEfforts,omitempty"`
+	DefaultEffort    string   `json:"defaultEffort,omitempty"`
 }
 
 // NewReasoningCapability normalizes provider-supplied reasoning metadata.
@@ -100,8 +100,8 @@ func NewReasoningCapability(efforts []string, defaultEffort string) *ReasoningCa
 
 	defaultEffort = normalizeThinkingEffort(defaultEffort, normalized)
 	return &ReasoningCapability{
-		Efforts:       normalized,
-		DefaultEffort: defaultEffort,
+		SupportedEfforts: normalized,
+		DefaultEffort:    defaultEffort,
 	}
 }
 
@@ -151,8 +151,8 @@ func ThinkingEffortsForModel(p Provider, store *Store, current *CurrentModelInfo
 	if capability == nil {
 		return nil
 	}
-	out := make([]string, len(capability.Efforts))
-	copy(out, capability.Efforts)
+	out := make([]string, len(capability.SupportedEfforts))
+	copy(out, capability.SupportedEfforts)
 	return out
 }
 
@@ -163,7 +163,7 @@ func ResolveThinkingEffortForModel(p Provider, store *Store, current *CurrentMod
 	if capability == nil {
 		return ""
 	}
-	if effort := normalizeThinkingEffort(selected, capability.Efforts); effort != "" {
+	if effort := normalizeThinkingEffort(selected, capability.SupportedEfforts); effort != "" {
 		return effort
 	}
 	return capability.DefaultEffort
@@ -176,16 +176,16 @@ func NextThinkingEffortForModel(p Provider, store *Store, current *CurrentModelI
 	if capability == nil {
 		return "", false
 	}
-	currentEffort := normalizeThinkingEffort(selected, capability.Efforts)
+	currentEffort := normalizeThinkingEffort(selected, capability.SupportedEfforts)
 	if currentEffort == "" {
 		currentEffort = capability.DefaultEffort
 	}
-	for i, effort := range capability.Efforts {
+	for i, effort := range capability.SupportedEfforts {
 		if effort == currentEffort {
-			return capability.Efforts[(i+1)%len(capability.Efforts)], true
+			return capability.SupportedEfforts[(i+1)%len(capability.SupportedEfforts)], true
 		}
 	}
-	return capability.Efforts[0], true
+	return capability.SupportedEfforts[0], true
 }
 
 func reasoningCapabilityForModel(p Provider, store *Store, current *CurrentModelInfo) *ReasoningCapability {
@@ -227,6 +227,7 @@ type ModelInfo struct {
 	ID               string               `json:"id"`
 	Name             string               `json:"name"`
 	DisplayName      string               `json:"displayName,omitempty"`
+	Description      string               `json:"description,omitempty"`
 	InputTokenLimit  int                  `json:"inputTokenLimit,omitempty"`
 	OutputTokenLimit int                  `json:"outputTokenLimit,omitempty"`
 	Reasoning        *ReasoningCapability `json:"reasoning,omitempty"`

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -69,6 +69,42 @@ type ThinkingEffortProvider interface {
 	DefaultThinkingEffort(model string) string
 }
 
+// ReasoningCapability describes the reasoning-effort values advertised for one
+// model. Providers that return this metadata from ListModels let the rest of the
+// app follow the live catalog instead of guessing capabilities from model IDs.
+type ReasoningCapability struct {
+	Efforts       []string `json:"efforts,omitempty"`
+	DefaultEffort string   `json:"defaultEffort,omitempty"`
+}
+
+// NewReasoningCapability normalizes provider-supplied reasoning metadata.
+// Unknown effort labels are intentionally preserved so newly introduced
+// provider-native levels work without a san release.
+func NewReasoningCapability(efforts []string, defaultEffort string) *ReasoningCapability {
+	normalized := make([]string, 0, len(efforts))
+	seen := make(map[string]struct{}, len(efforts))
+	for _, effort := range efforts {
+		effort = strings.ToLower(strings.TrimSpace(effort))
+		if effort == "" {
+			continue
+		}
+		if _, ok := seen[effort]; ok {
+			continue
+		}
+		seen[effort] = struct{}{}
+		normalized = append(normalized, effort)
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+
+	defaultEffort = normalizeThinkingEffort(defaultEffort, normalized)
+	return &ReasoningCapability{
+		Efforts:       normalized,
+		DefaultEffort: defaultEffort,
+	}
+}
+
 // ImageSupportProvider is implemented by providers that declare whether a model
 // accepts image input. Providers that don't implement it are assumed to support
 // images (the common case); a text-only provider opts out by returning false.
@@ -136,6 +172,71 @@ func NextThinkingEffort(p Provider, model, current string) (string, bool) {
 	return efforts[0], true
 }
 
+// ThinkingEffortsForModel returns live cached model metadata when available,
+// falling back to the provider's static ThinkingEffortProvider implementation.
+func ThinkingEffortsForModel(p Provider, store *Store, current *CurrentModelInfo) []string {
+	capability := reasoningCapabilityForModel(p, store, current)
+	if capability == nil {
+		return nil
+	}
+	out := make([]string, len(capability.Efforts))
+	copy(out, capability.Efforts)
+	return out
+}
+
+// ResolveThinkingEffortForModel validates a selected effort against the live
+// model metadata, then falls back to that model's advertised default.
+func ResolveThinkingEffortForModel(p Provider, store *Store, current *CurrentModelInfo, selected string) string {
+	capability := reasoningCapabilityForModel(p, store, current)
+	if capability == nil {
+		return ""
+	}
+	if effort := normalizeThinkingEffort(selected, capability.Efforts); effort != "" {
+		return effort
+	}
+	return capability.DefaultEffort
+}
+
+// NextThinkingEffortForModel cycles through the live model-specific effort
+// values, using the advertised default when no valid current value is set.
+func NextThinkingEffortForModel(p Provider, store *Store, current *CurrentModelInfo, selected string) (string, bool) {
+	capability := reasoningCapabilityForModel(p, store, current)
+	if capability == nil {
+		return "", false
+	}
+	currentEffort := normalizeThinkingEffort(selected, capability.Efforts)
+	if currentEffort == "" {
+		currentEffort = capability.DefaultEffort
+	}
+	for i, effort := range capability.Efforts {
+		if effort == currentEffort {
+			return capability.Efforts[(i+1)%len(capability.Efforts)], true
+		}
+	}
+	return capability.Efforts[0], true
+}
+
+func reasoningCapabilityForModel(p Provider, store *Store, current *CurrentModelInfo) *ReasoningCapability {
+	if current == nil || current.ModelID == "" {
+		return nil
+	}
+	if store != nil {
+		authMethod := current.AuthMethod
+		if authMethod == "" {
+			if conn, ok := store.GetConnection(current.Provider); ok {
+				authMethod = conn.AuthMethod
+			}
+		}
+		if capability, ok := store.CachedModelReasoningForProvider(current.Provider, authMethod, current.ModelID); ok {
+			return capability
+		}
+	}
+	return NewReasoningCapability(
+		ThinkingEfforts(p, current.ModelID),
+		DefaultThinkingEffort(p, current.ModelID),
+	)
+}
+
 func normalizeThinkingEffort(effort string, efforts []string) string {
 	effort = strings.TrimSpace(strings.ToLower(effort))
 	if effort == "" {
@@ -151,11 +252,12 @@ func normalizeThinkingEffort(effort string, efforts []string) string {
 
 // ModelInfo represents information about an available model
 type ModelInfo struct {
-	ID               string `json:"id"`
-	Name             string `json:"name"`
-	DisplayName      string `json:"displayName,omitempty"`
-	InputTokenLimit  int    `json:"inputTokenLimit,omitempty"`
-	OutputTokenLimit int    `json:"outputTokenLimit,omitempty"`
+	ID               string               `json:"id"`
+	Name             string               `json:"name"`
+	DisplayName      string               `json:"displayName,omitempty"`
+	InputTokenLimit  int                  `json:"inputTokenLimit,omitempty"`
+	OutputTokenLimit int                  `json:"outputTokenLimit,omitempty"`
+	Reasoning        *ReasoningCapability `json:"reasoning,omitempty"`
 }
 
 // CompletionOptions contains options for a completion request


### PR DESCRIPTION
## Summary

- update the ChatGPT Codex model catalog client version so entitled GPT-5.6 models are discoverable
- persist per-model reasoning capabilities in `ModelInfo` and prefer live provider metadata over model-name guesses
- parse `supported_reasoning_levels` and `default_reasoning_level` from the ChatGPT Subscription catalog
- route `/think`, Ctrl+T, keyword detection, and request defaults through the current provider/auth/model metadata
- retain static OpenAI capability rules as a backward-compatible fallback when `/v1/models` or an old cache omits reasoning metadata

## Why

The Codex backend filters its model catalog by `client_version`, so san's older version marker hid the GPT-5.6 lineup. Reasoning levels were also hardcoded by model prefix even though the subscription catalog already advertises account- and model-specific supported levels and defaults. That made new models require code changes and could mix capabilities between direct API and subscription auth paths.

## Impact

After refreshing the ChatGPT Subscription provider, san discovers `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` for entitled accounts and uses the reasoning levels returned for each model. Unknown future effort labels are normalized and preserved. Existing provider caches remain compatible and fall back to provider-defined capabilities when metadata is absent.

## Validation

- `go test -count=1 -timeout=90s ./...`
- `go test ./internal/llm ./internal/llm/openai ./internal/app ./internal/app/input`
- `git diff --check`
- `make build` with `GOCACHE=/private/tmp/san-go-build-cache`
