### PR TITLE
feat(queue): redesign queued-message interaction (#312)

### DIFF
--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -254,26 +254,34 @@ func TestRenderTurnUsageSummaryShowsPerTurnTokens(t *testing.T) {
 	}
 }
 
-func TestRenderModeStatusHidesQueueBadgeWhenEmpty(t *testing.T) {
-	rendered := RenderModeStatus(OperationModeParams{
-		ModelName:  "gpt-test",
-		QueueCount: 0,
-		Width:      80,
-	})
-	if strings.Contains(rendered, "queued") {
-		t.Fatalf("RenderModeStatus() = %q, should not show queue badge", rendered)
-	}
-}
-
-func TestRenderQueuePreviewShowsItems(t *testing.T) {
+func TestRenderQueuePreviewShowsShadowPromptAndEditHint(t *testing.T) {
 	rendered := stripANSI(RenderQueuePreview([]QueuePreviewItem{{
 		Content: "Codex review 建议如何运行?",
 	}}, -1, 80))
 
-	for _, want := range []string{"Codex review"} {
+	for _, want := range []string{"❭ Codex review", "↑ edit"} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("RenderQueuePreview() = %q, want %q", rendered, want)
 		}
+	}
+	if strings.Contains(rendered, "1.") {
+		t.Fatalf("RenderQueuePreview() = %q, should not number items", rendered)
+	}
+}
+
+func TestRenderQueuePreviewEditingShowsFocusBarAndKeys(t *testing.T) {
+	rendered := stripANSI(RenderQueuePreview([]QueuePreviewItem{
+		{Content: "first queued"},
+		{Content: "second queued"},
+	}, 0, 80))
+
+	for _, want := range []string{"▎", "enter done · ctrl+c delete"} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("RenderQueuePreview() = %q, want %q", rendered, want)
+		}
+	}
+	if strings.Contains(rendered, "↑ edit") {
+		t.Fatalf("RenderQueuePreview() = %q, idle hint should be replaced while editing", rendered)
 	}
 }
 

--- a/internal/app/conv/queue_preview.go
+++ b/internal/app/conv/queue_preview.go
@@ -1,5 +1,7 @@
-// Package conv: the pending-prompt queue preview shown above the input area,
-// plus the compact "[N queued]" badge the status bar borrows.
+// Package conv: the pending-prompt queue preview rendered above the input
+// separator. Queued messages draw as dim "❭" shadow prompts — already
+// submitted, visually on their way into the conversation — with a key hint
+// riding the active row.
 package conv
 
 import (
@@ -7,6 +9,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+	xansi "github.com/charmbracelet/x/ansi"
 
 	"github.com/genai-io/san/internal/app/kit"
 )
@@ -17,94 +20,106 @@ type QueuePreviewItem struct {
 	HasImages bool
 }
 
+const (
+	maxVisibleQueueItems = 5
+	queueIdleHint        = "↑ edit"
+	queueEditingHint     = "enter done · ctrl+c delete"
+)
+
 var (
-	queueBadgeStyle = lipgloss.NewStyle().
-			Foreground(kit.CurrentTheme.Accent).
-			Bold(true)
+	queuePromptStyle = lipgloss.NewStyle().
+				Foreground(kit.CurrentTheme.TextDim).
+				Bold(true)
 
 	queueContentStyle = lipgloss.NewStyle().
 				Foreground(kit.CurrentTheme.TextDim)
 
 	queueSelectedContentStyle = queueContentStyle.Foreground(kit.CurrentTheme.TextBright)
 
-	queueSelectedBadgeStyle = lipgloss.NewStyle().
-				Foreground(kit.CurrentTheme.TextBright).
-				Bold(true)
+	queueHintStyle = lipgloss.NewStyle().
+			Foreground(kit.CurrentTheme.Muted).
+			Italic(true)
 
 	queueOverflowStyle = lipgloss.NewStyle().
 				Foreground(kit.CurrentTheme.Muted).
 				Italic(true)
 )
 
-// RenderQueuePreview renders queued input items above the input area.
-// selectedIdx is the currently selected item index (-1 = none).
+// RenderQueuePreview renders queued messages as dim shadow prompts above the
+// input separator, mirroring the "❭" of the live prompt below. selectedIdx is
+// the item under edit (-1 = none); the selected row carries the focus bar and
+// swaps the "↑ edit" affordance for the editing keys.
 func RenderQueuePreview(items []QueuePreviewItem, selectedIdx, width int) string {
 	if len(items) == 0 {
 		return ""
 	}
 
-	var sb strings.Builder
-
-	maxVisible := 5
 	startIdx := 0
-	if len(items) > maxVisible && selectedIdx >= maxVisible {
-		startIdx = selectedIdx - maxVisible + 1
+	if len(items) > maxVisibleQueueItems && selectedIdx >= maxVisibleQueueItems {
+		startIdx = selectedIdx - maxVisibleQueueItems + 1
 	}
-	endIdx := min(startIdx+maxVisible, len(items))
+	endIdx := min(startIdx+maxVisibleQueueItems, len(items))
 
+	// The hint rides the row the eye is on: the selected row while editing,
+	// otherwise the row nearest the input.
+	hint := queueIdleHint
+	hintIdx := endIdx - 1
+	if selectedIdx >= 0 {
+		hint = queueEditingHint
+		hintIdx = selectedIdx
+	}
+
+	var sb strings.Builder
 	for i := startIdx; i < endIdx; i++ {
 		item := items[i]
-		isSelected := i == selectedIdx
 
-		content := truncateQueueContent(item.Content, width-8)
+		gutter := " "
+		contentStyle := queueContentStyle
+		if i == selectedIdx {
+			gutter = kit.FocusBarStyle().Render(kit.FocusBar)
+			contentStyle = queueSelectedContentStyle
+		}
+
+		// Budget: gutter(1) + "❭ "(2) + right margin(2), minus the image tag
+		// and hint when this row carries them.
+		maxContentWidth := width - 5
+		if item.HasImages {
+			maxContentWidth -= lipgloss.Width("[Image] ")
+		}
+		if i == hintIdx {
+			maxContentWidth -= lipgloss.Width(hint) + 2
+		}
+
+		content := contentStyle.Render(truncateQueueContent(item.Content, maxContentWidth))
 		if item.HasImages {
 			content = PendingImageStyle.Render("[Image] ") + content
 		}
 
-		if isSelected {
-			bar := kit.FocusBarStyle().Render(kit.FocusBar)
-			num := queueSelectedBadgeStyle.Render(fmt.Sprintf("%d.", i+1))
-			preview := queueSelectedContentStyle.Render(content)
-			fmt.Fprintf(&sb, " %s %s %s\n", bar, num, preview)
-		} else {
-			badge := queueBadgeStyle.Render(fmt.Sprintf("  %d.", i+1))
-			preview := queueContentStyle.Render(content)
-			fmt.Fprintf(&sb, " %s %s\n", badge, preview)
+		line := gutter + queuePromptStyle.Render("❭ ") + content
+		if i == hintIdx {
+			if pad := width - lipgloss.Width(line) - lipgloss.Width(hint) - 1; pad >= 2 {
+				line += strings.Repeat(" ", pad) + queueHintStyle.Render(hint)
+			}
 		}
+		sb.WriteString(line + "\n")
 	}
 
-	if len(items) > maxVisible {
-		if endIdx < len(items) {
-			sb.WriteString(queueOverflowStyle.Render(fmt.Sprintf("     +%d more below", len(items)-endIdx)) + "\n")
-		}
-		if startIdx > 0 {
-			above := queueOverflowStyle.Render(fmt.Sprintf("     +%d more above", startIdx)) + "\n"
-			return above + sb.String()
-		}
+	if endIdx < len(items) {
+		sb.WriteString(queueOverflowStyle.Render(fmt.Sprintf("   +%d more below", len(items)-endIdx)) + "\n")
+	}
+	if startIdx > 0 {
+		return queueOverflowStyle.Render(fmt.Sprintf("   +%d more above", startIdx)) + "\n" + sb.String()
 	}
 
 	return sb.String()
 }
 
-// renderQueueBadge renders a compact badge for the status bar.
-func renderQueueBadge(count int) string {
-	if count == 0 {
-		return ""
-	}
-	return queueBadgeStyle.Render(fmt.Sprintf(" [%d queued]", count))
-}
-
-func truncateQueueContent(s string, maxLen int) string {
-	s = strings.ReplaceAll(s, "\n", " ")
+// truncateQueueContent flattens a queued message to one line and truncates it
+// to maxWidth display columns (CJK-aware).
+func truncateQueueContent(s string, maxWidth int) string {
 	s = strings.Join(strings.Fields(s), " ")
-
-	if maxLen <= 0 {
-		maxLen = 40
+	if maxWidth < 8 {
+		maxWidth = 8
 	}
-
-	runes := []rune(s)
-	if len(runes) <= maxLen {
-		return s
-	}
-	return string(runes[:maxLen-1]) + "…"
+	return xansi.Truncate(s, maxWidth, "…")
 }

--- a/internal/app/conv/status_bar.go
+++ b/internal/app/conv/status_bar.go
@@ -228,7 +228,6 @@ type OperationModeParams struct {
 	Width             int
 	ThinkingEffort    string
 	ShowThinking      bool
-	QueueCount        int
 	ReviewApprovals   int  // auto-review approvals this session, shown next to the mode
 	ReviewEscalations int  // auto-review escalations to the user this session
 	AutopilotThinking bool // the copilot is mid-decision — show "thinking…" on the mode indicator
@@ -246,10 +245,6 @@ func RenderModeStatus(params OperationModeParams) string {
 		if thinkingStatus := RenderThinkingIndicator(params.ThinkingEffort); thinkingStatus != "" {
 			leftParts = append(leftParts, thinkingStatus)
 		}
-	}
-
-	if queueBadge := renderQueueBadge(params.QueueCount); queueBadge != "" {
-		leftParts = append(leftParts, queueBadge)
 	}
 
 	left := strings.Join(leftParts, "  ")

--- a/internal/app/input/on_textarea.go
+++ b/internal/app/input/on_textarea.go
@@ -377,6 +377,19 @@ func (m *Model) RestoreImages(images []core.Image) {
 	m.Images.NextID += len(images)
 }
 
+// ReturnToTextarea hands a message the app could not send back to the user:
+// the content rejoins any in-progress typing on its own line and the images
+// become pending again, so nothing is silently dropped.
+func (m *Model) ReturnToTextarea(content string, images []core.Image) {
+	if existing := m.Textarea.Value(); existing != "" {
+		content = content + "\n" + existing
+	}
+	m.Textarea.SetValue(content)
+	m.Textarea.CursorEnd()
+	m.RestoreImages(images)
+	m.UpdateHeight()
+}
+
 func (m *Model) HasContent() bool {
 	return strings.TrimSpace(m.Textarea.Value()) != "" || len(m.Images.Pending) > 0
 }

--- a/internal/app/model_turn_queue.go
+++ b/internal/app/model_turn_queue.go
@@ -49,9 +49,18 @@ func (m *model) drainTurnQueues() (tea.Cmd, bool) {
 	// Drain ONE user message per call so each gets its own agent response.
 	// The agent's inner loop also drains one inbox message at a time,
 	// producing one TurnEvent per queued message.
-	if item, ok := m.userInput.Queue.Dequeue(); ok {
+	//
+	// A head item under edit holds the drain: dispatching now would send the
+	// pre-edit text and orphan the user's changes in the textarea. Leaving
+	// edit mode re-kicks the drain (see routeKeypress).
+	if m.userInput.Queue.SelectIdx == 0 {
+		log.QueueLog("drainTurnQueues: head item under edit, holding %d queued", m.userInput.Queue.Len())
+	} else if item, ok := m.userInput.Queue.Dequeue(); ok {
 		log.QueueLog("drainTurnQueues: dequeued %q remaining=%d", truncate(item.Content, 60), m.userInput.Queue.Len())
 		if m.imagesBlockedForModel(item.Images) {
+			// Hand the message back instead of dropping it — the notice tells
+			// the user to remove the image or switch models.
+			m.userInput.ReturnToTextarea(item.Content, item.Images)
 			return tea.Batch(m.CommitMessages()...), true
 		}
 		m.conv.Append(core.ChatMessage{Role: core.RoleUser, Content: item.Content, Images: item.Images})

--- a/internal/app/update_input_effects.go
+++ b/internal/app/update_input_effects.go
@@ -39,7 +39,7 @@ func (m *model) handleStreamCancel() tea.Cmd {
 	m.conv.MarkLastInterrupted()
 
 	cmds := m.CommitMessages()
-	if cmd := m.drainInputQueueAfterCancel(); cmd != nil {
+	if cmd := m.drainInputQueueWhileIdle(); cmd != nil {
 		cmds = append(cmds, cmd)
 	}
 	return tea.Batch(cmds...)

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -44,6 +44,14 @@ func (m *model) routeKeypress(msg tea.KeyMsg) (tea.Cmd, bool) {
 		return c, ok
 	}
 	if c, ok := m.userInput.HandleQueueSelectKey(msg); ok {
+		// Leaving queue-edit mode releases a drain that was held while the
+		// head item was under edit (see drainTurnQueues): if the agent went
+		// idle in the meantime, dispatch the queue now.
+		if m.userInput.Queue.SelectIdx < 0 && !m.conv.Stream.Active {
+			if drain := m.drainInputQueueWhileIdle(); drain != nil {
+				return tea.Batch(c, drain), true
+			}
+		}
 		return c, ok
 	}
 
@@ -90,6 +98,11 @@ func (m *model) handleTextareaShortcut(msg tea.KeyMsg) (tea.Cmd, bool) {
 
 	case "ctrl+u":
 		if m.userInput.Queue.Len() > 0 {
+			if m.userInput.Queue.SelectIdx >= 0 {
+				// Mid-edit: return the pre-edit stash to the textarea before
+				// wiping the queue out from under the edit session.
+				m.userInput.ExitQueueSelection()
+			}
 			m.userInput.Queue.Clear()
 			return nil, true
 		}

--- a/internal/app/update_submit.go
+++ b/internal/app/update_submit.go
@@ -49,8 +49,8 @@ func (m *model) handleSubmit() tea.Cmd {
 }
 
 // enqueueWhileStreaming parks the input in the queue and resets the
-// textarea. The queued item is dequeued either by drainInputQueueAfterCancel
-// (on stream cancel) or by drainTurnQueues (at turn boundary).
+// textarea. The queued item is dequeued either by drainInputQueueWhileIdle
+// (on stream cancel / edit exit) or by drainTurnQueues (at turn boundary).
 func (m *model) enqueueWhileStreaming(raw string) tea.Cmd {
 	images := m.userInput.PendingImages()
 	if m.userInput.Queue.Enqueue(raw, images) < 0 {
@@ -64,7 +64,7 @@ func (m *model) enqueueWhileStreaming(raw string) tea.Cmd {
 
 // dispatchSubmission runs the submission pipeline: exit shortcut →
 // prompt-hook gate → history → slash command? → otherwise send to
-// agent. Shared by the Enter handler and drainInputQueueAfterCancel.
+// agent. Shared by the Enter handler and drainInputQueueWhileIdle.
 func (m *model) dispatchSubmission(raw string) tea.Cmd {
 	if input.IsExitRequest(raw) {
 		cmd, _ := m.QuitWithCancel()
@@ -153,18 +153,38 @@ func (m *model) imagesBlockedForModel(images []core.Image) bool {
 	return true
 }
 
-// drainInputQueueAfterCancel pops one queued item (if any) and runs it
-// through the normal submission pipeline. Called from handleStreamCancel
-// so a user who queued input while a turn was streaming sees the next one
-// run after Ctrl+C.
-func (m *model) drainInputQueueAfterCancel() tea.Cmd {
+// drainInputQueueWhileIdle pops one queued item (if any) and runs it
+// through the normal submission pipeline. Called wherever queued input may
+// meet an idle agent: from handleStreamCancel, so input queued while a turn
+// was streaming runs right after Ctrl+C/Esc; and from routeKeypress when
+// leaving queue-edit mode, which releases a drain that drainTurnQueues held
+// during the edit.
+func (m *model) drainInputQueueWhileIdle() tea.Cmd {
 	item, ok := m.userInput.Queue.Dequeue()
 	if !ok {
 		return nil
 	}
+	if m.imagesBlockedForModel(item.Images) {
+		// Hand the message back instead of dropping it — the notice tells
+		// the user to remove the image or switch models.
+		m.userInput.ReturnToTextarea(item.Content, item.Images)
+		return tea.Batch(m.CommitMessages()...)
+	}
 	m.conv.Compact.ClearResult()
+
+	// The textarea may hold an unrelated draft (in-progress typing on the
+	// cancel path, the restored pre-edit stash on the edit-exit path) —
+	// dispatchSubmission resets the textarea after a send, so park the draft
+	// and put it back.
+	draft := m.userInput.Textarea.Value()
 	m.userInput.RestoreImages(item.Images)
-	return m.dispatchSubmission(item.Content)
+	cmd := m.dispatchSubmission(item.Content)
+	if draft != "" && m.userInput.Textarea.Value() == "" {
+		m.userInput.Textarea.SetValue(draft)
+		m.userInput.Textarea.CursorEnd()
+		m.userInput.UpdateHeight()
+	}
+	return cmd
 }
 
 // SubmitToAgent is the single exit point for "send this content to the

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -119,12 +119,16 @@ func (m *model) renderFooter(separator string) string {
 		b.WriteString("\n")
 		b.WriteString(turnUsage)
 	}
-	b.WriteString("\n")
-	b.WriteString(separator)
+	// Queued messages sit above the input separator: they are already
+	// submitted — on their way into the conversation — so they read as part
+	// of the chat flow, and the input strip below stays reserved for what's
+	// being typed now.
 	if queuePreview := m.renderQueuePreview(); queuePreview != "" {
 		b.WriteString("\n")
 		b.WriteString(queuePreview)
 	}
+	b.WriteString("\n")
+	b.WriteString(separator)
 	b.WriteString("\n")
 	b.WriteString(m.renderInputView())
 	if suggestions := m.userInput.Suggestions.Render(m.env.Width); suggestions != "" {
@@ -279,7 +283,6 @@ func (m model) renderModeStatus() string {
 		Width:             m.env.Width,
 		ThinkingEffort:    thinkingEffort,
 		ShowThinking:      showThinking,
-		QueueCount:        m.userInput.Queue.Len(),
 		ReviewApprovals:   reviewApprovals,
 		ReviewEscalations: reviewEscalations,
 		AutopilotThinking: m.autopilotDeciding,


### PR DESCRIPTION
Closes #312.

Queued messages now read as part of the conversation instead of a status-bar footnote.

### Before
- A separate `[N queued]` badge in the status bar (redundant with the list).
- Queued items rendered as a numbered list (`1.` `2.` `3.`) below the input separator, visually detached from the chat.

### After
- Each queued item renders as a dim `❭` **shadow prompt** above the input separator, mirroring the live prompt below — already submitted, on its way into the conversation.
- The `[N queued]` status-bar badge is gone; the queue block is the single, richer indicator.
- The queue block sits **above** the input separator (conversation flow), leaving the input strip for what's being typed now.
- The edit affordance is now discoverable: `↑ edit` when idle, `enter done · ctrl+c delete` while editing, with a focus bar on the selected row.

```
 ❭ codex 中的skill也应该更新一下
 ❭ 顺便把 README 的示例命令也对一下                                ↑ edit
──────────────────────────────────────────────────────────────────
❭                                          ← live input (bright ❭)
──────────────────────────────────────────────────────────────────
  normal · GPT-5.6-Luna (high) · ctx 72.4k/272.0k    ← no [N queued]
```

### Edge cases fixed along the way
- **Edit race:** hold the turn-boundary drain while the head item is under edit (`SelectIdx == 0`) so an in-flight edit isn't sent as its pre-edit text; leaving edit mode re-kicks the drain. `drainInputQueueAfterCancel` → `drainInputQueueWhileIdle` to cover both paths.
- **No silent drops:** a dequeued item carrying images the active model can't accept is handed back to the textarea (new `input.Model.ReturnToTextarea`) instead of vanishing.
- **Draft preservation:** an unrelated textarea draft survives an idle drain, and `ctrl+u` restores the pre-edit stash before clearing the queue.

### Testing
- `go build ./...`, `go test ./internal/app/...` green.
- Updated `conv` render tests to assert the shadow-prompt + hint and the focus-bar/editing-keys states.