### PR TITLE
fix(app,llm): drop turn-usage line, fix OpenAI cached-token mapping

### DIFF
--- a/docs/concepts/data-flow.md
+++ b/docs/concepts/data-flow.md
@@ -448,7 +448,6 @@ Update → routeToSubModel                update.go
          │
          ▼
    PreInfer                             applyPreInfer
-       ├─ rt.OnTurnBegin()              turn start; reset token counters
        ├─ m.Stream.Active = true
        ├─ m.Append({Role: assistant})   empty assistant message — chunks
        │                                will be appended to it

--- a/docs/concepts/data-flow.zh.md
+++ b/docs/concepts/data-flow.zh.md
@@ -426,7 +426,6 @@ Update → routeToSubModel                update.go
          │
          ▼
    PreInfer                             applyPreInfer
-       ├─ rt.OnTurnBegin()              一轮开始；token 计数清零
        ├─ m.Stream.Active = true
        ├─ m.Append({Role: assistant})   空的 assistant 消息 ——
        │                                后续 chunk 会追加进它

--- a/docs/concepts/rendering.md
+++ b/docs/concepts/rendering.md
@@ -201,8 +201,7 @@ Enter handler).
 
 ```
 event:           core.PreInfer
-applyPreInfer:   rt.OnTurnBegin()
-                 m.Stream.Active = true
+applyPreInfer:   m.Stream.Active = true
                  m.Append({Role: assistant, Content: ""})
                  start spinner
 

--- a/docs/concepts/rendering.zh.md
+++ b/docs/concepts/rendering.zh.md
@@ -188,8 +188,7 @@ InlinedResults.IsResultInlined(idx)      // 这条 result 是否会被
 
 ```
 event:           core.PreInfer
-applyPreInfer:   rt.OnTurnBegin()
-                 m.Stream.Active = true
+applyPreInfer:   m.Stream.Active = true
                  m.Append({Role: assistant, Content: ""})
                  启动 spinner
 

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -245,12 +245,21 @@ func TestRenderModeStatusShowsTemporaryStatusMessage(t *testing.T) {
 	}
 }
 
-func TestRenderTurnUsageSummaryShowsPerTurnTokens(t *testing.T) {
-	rendered := RenderTurnUsageSummary(1234, 56, 80)
-	for _, want := range []string{"↑1.2k", "↓56"} {
-		if !strings.Contains(rendered, want) {
-			t.Fatalf("RenderTurnUsageSummary() = %q, want %q", rendered, want)
-		}
+// The bottom status line must carry the ctx readout but never the old
+// per-turn "↑… ↓…" usage summary (removed to avoid a second, confusingly
+// scoped token figure above the input area).
+func TestRenderModeStatusShowsCtxWithoutTurnUsageArrows(t *testing.T) {
+	visible := stripANSI(RenderModeStatus(OperationModeParams{
+		ModelName:   "gpt-test",
+		InputTokens: 164600,
+		InputLimit:  272000,
+		Width:       120,
+	}))
+	if !strings.Contains(visible, "ctx") {
+		t.Fatalf("RenderModeStatus() = %q, want the ctx label", visible)
+	}
+	if strings.ContainsAny(visible, "↑↓") {
+		t.Fatalf("RenderModeStatus() = %q, must not render per-turn usage arrows", visible)
 	}
 }
 

--- a/internal/app/conv/runtime.go
+++ b/internal/app/conv/runtime.go
@@ -20,7 +20,6 @@ type Runtime interface {
 	CommitMessages() []tea.Cmd
 	FlushStreamingBlocks() []tea.Cmd
 	ContinueOutbox() tea.Cmd
-	OnTurnBegin()
 	OnTokenUsage(resp *core.InferResponse)
 	OnAgentMessage(msg core.Message) tea.Cmd
 	OnToolResult(tr core.ToolResult) *core.ToolResult

--- a/internal/app/conv/status_bar.go
+++ b/internal/app/conv/status_bar.go
@@ -310,22 +310,6 @@ func renderStatusCluster(p OperationModeParams) string {
 	return strings.Join(survivors, sep)
 }
 
-func RenderTurnUsageSummary(inputTokens, outputTokens, width int) string {
-	if inputTokens == 0 && outputTokens == 0 {
-		return ""
-	}
-
-	summary := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted).Render(
-		fmt.Sprintf("↑%s ↓%s", kit.FormatTokenCount(inputTokens), kit.FormatTokenCount(outputTokens)),
-	)
-	if width <= 0 {
-		return summary
-	}
-
-	gap := max(0, width-lipgloss.Width(summary))
-	return strings.Repeat(" ", gap) + summary
-}
-
 func compactStatusHint(percent float64) string {
 	switch {
 	case percent >= pctCritical:

--- a/internal/app/conv/update.go
+++ b/internal/app/conv/update.go
@@ -169,7 +169,6 @@ func applyAgentEvent(rt Runtime, m *Model, ev core.Event) tea.Cmd {
 }
 
 func applyPreInfer(rt Runtime, m *Model) tea.Cmd {
-	rt.OnTurnBegin()
 	m.Stream.Active = true
 	m.Stream.BuildingTool = ""
 	commitCmds := rt.CommitMessages()

--- a/internal/app/env.go
+++ b/internal/app/env.go
@@ -33,13 +33,6 @@ type env struct {
 	// active — see InferResponse.TotalInputTokens.
 	InputTokens  int
 	OutputTokens int
-	// TurnInputTokens / TurnOutputTokens track the current agent turn.
-	// A "turn" here means the whole think-act cycle, which may include multiple
-	// LLM calls around tool use. These totals are reset at the first infer of a
-	// new turn and then accumulated after each infer in that turn.
-	TurnInputTokens  int
-	TurnOutputTokens int
-	turnUsageActive  bool
 	// ConversationCost is the session-cumulative spend shown in the status
 	// bar. It survives ResetContextDisplay (per-compaction) so compaction
 	// doesn't erase prior spend; only ResetTokens (/clear, /new) zeroes it.
@@ -306,8 +299,5 @@ func (m *env) ResetContextDisplay() {
 func (m *env) ResetTokens() {
 	m.ResetContextDisplay()
 	m.ConversationCost = llm.Money{}
-	m.TurnInputTokens = 0
-	m.TurnOutputTokens = 0
-	m.turnUsageActive = false
 	m.Compressions = 0
 }

--- a/internal/app/env_test.go
+++ b/internal/app/env_test.go
@@ -30,13 +30,13 @@ func TestResetContextDisplay_PreservesConversationCost(t *testing.T) {
 }
 
 func TestResetTokens_ZeroesCompressions(t *testing.T) {
-	e := &env{Compressions: 5, TurnInputTokens: 80, TurnOutputTokens: 40}
+	e := &env{Compressions: 5, InputTokens: 80, OutputTokens: 40}
 	e.ResetTokens()
 	if e.Compressions != 0 {
 		t.Errorf("Compressions = %d, want 0 after ResetTokens", e.Compressions)
 	}
-	if e.TurnInputTokens != 0 || e.TurnOutputTokens != 0 {
-		t.Errorf("turn tokens not zeroed: %d/%d", e.TurnInputTokens, e.TurnOutputTokens)
+	if e.InputTokens != 0 || e.OutputTokens != 0 {
+		t.Errorf("context tokens not zeroed: %d/%d", e.InputTokens, e.OutputTokens)
 	}
 }
 

--- a/internal/app/model_agent_events.go
+++ b/internal/app/model_agent_events.go
@@ -19,15 +19,6 @@ import (
 	"github.com/genai-io/san/internal/tool"
 )
 
-func (m *model) OnTurnBegin() {
-	if m.env.turnUsageActive {
-		return
-	}
-	m.env.TurnInputTokens = 0
-	m.env.TurnOutputTokens = 0
-	m.env.turnUsageActive = true
-}
-
 func (m *model) OnTokenUsage(resp *core.InferResponse) {
 	if resp == nil {
 		return
@@ -37,17 +28,12 @@ func (m *model) OnTokenUsage(resp *core.InferResponse) {
 		m.userInput.Provider.StatusMessage = ""
 	}
 
-	// Bottom-right context usage reflects the latest prompt/output, not a
+	// Bottom-right context usage reflects the latest infer call, not a
 	// lifetime sum across the whole session. Use the full prompt size
-	// (incl. the cached system prompt) so the ctx readout matches real
+	// (fresh + cache read + cache creation) so the ctx readout matches real
 	// context-window occupancy rather than just the uncached delta.
 	m.env.InputTokens = resp.TotalInputTokens()
 	m.env.OutputTokens = resp.OutputTokens
-	// Turn totals accumulate per infer step. Keep the raw (uncached) input
-	// here: each step re-reads the same cached prompt, so summing the cached
-	// portion across steps would multi-count it.
-	m.env.TurnInputTokens += resp.InputTokens
-	m.env.TurnOutputTokens += resp.OutputTokens
 
 	if m.env.CurrentModel != nil {
 		usage := llm.Usage{
@@ -101,7 +87,6 @@ func (m *model) OnToolResult(tr core.ToolResult) *core.ToolResult {
 }
 
 func (m *model) OnTurnEnd(result core.Result) tea.Cmd {
-	m.env.turnUsageActive = false
 	if m.services.Tracker.AllDone() {
 		m.services.Tracker.Reset()
 	}
@@ -162,7 +147,6 @@ func (m *model) OnTurnEnd(result core.Result) tea.Cmd {
 }
 
 func (m *model) OnAgentStop(err error) tea.Cmd {
-	m.env.turnUsageActive = false
 	// /clear and manual stop cancel the active agent context; that is expected
 	// shutdown, not an agent failure the user needs to see.
 	if err != nil && !errors.Is(err, context.Canceled) {

--- a/internal/app/model_token_test.go
+++ b/internal/app/model_token_test.go
@@ -11,33 +11,40 @@ import (
 	"github.com/genai-io/san/internal/todo"
 )
 
-func TestOnTokenUsageTracksLatestTurnUsage(t *testing.T) {
+// The bottom-right ctx readout must reflect only the most recent infer call's
+// full context, never a running sum across the turn's infer steps. Two
+// consecutive OnTokenUsage calls (as happens around a tool loop): the second
+// must fully replace the first, not accumulate on top of it.
+func TestOnTokenUsageUsesLatestCallNotAccumulated(t *testing.T) {
 	m := &model{}
-	m.OnTurnBegin()
 
-	m.OnTokenUsage(&core.InferResponse{Usage: core.Usage{InputTokens: 1200, OutputTokens: 80}})
-	if m.env.InputTokens != 1200 || m.env.OutputTokens != 80 {
-		t.Fatalf("first token update = in:%d out:%d, want in:1200 out:80", m.env.InputTokens, m.env.OutputTokens)
-	}
-	if m.env.TurnInputTokens != 1200 || m.env.TurnOutputTokens != 80 {
-		t.Fatalf("first turn totals = in:%d out:%d, want in:1200 out:80", m.env.TurnInputTokens, m.env.TurnOutputTokens)
+	// First infer: a large cached prompt. ctx = full prompt (fresh + cached).
+	m.OnTokenUsage(&core.InferResponse{Usage: core.Usage{
+		InputTokens:          500,
+		OutputTokens:         80,
+		CacheReadInputTokens: 140000,
+	}})
+	if m.env.InputTokens != 140500 || m.env.OutputTokens != 80 {
+		t.Fatalf("first update = in:%d out:%d, want in:140500 out:80", m.env.InputTokens, m.env.OutputTokens)
 	}
 
-	m.OnTokenUsage(&core.InferResponse{Usage: core.Usage{InputTokens: 400, OutputTokens: 25}})
-	if m.env.InputTokens != 400 || m.env.OutputTokens != 25 {
-		t.Fatalf("latest token update = in:%d out:%d, want in:400 out:25", m.env.InputTokens, m.env.OutputTokens)
-	}
-	if m.env.TurnInputTokens != 1600 || m.env.TurnOutputTokens != 105 {
-		t.Fatalf("accumulated turn totals = in:%d out:%d, want in:1600 out:105", m.env.TurnInputTokens, m.env.TurnOutputTokens)
+	// Second infer in the same turn: ctx must become THIS call's full context,
+	// not the sum of both calls (which would be 281800).
+	m.OnTokenUsage(&core.InferResponse{Usage: core.Usage{
+		InputTokens:          300,
+		OutputTokens:         25,
+		CacheReadInputTokens: 141000,
+	}})
+	if m.env.InputTokens != 141300 || m.env.OutputTokens != 25 {
+		t.Fatalf("latest update = in:%d out:%d, want in:141300 out:25 (latest full context, not accumulated)", m.env.InputTokens, m.env.OutputTokens)
 	}
 }
 
-// The ctx readout must count the cached system prompt (reported separately by
-// Anthropic) so it reflects real window occupancy; the per-turn totals stay raw
-// so the cached prompt isn't re-counted on every infer step.
+// The ctx readout must count the cached prompt (reported separately in
+// Anthropic-style usage) so it reflects real window occupancy: the full prompt
+// is fresh + cache read + cache creation.
 func TestOnTokenUsageCountsCachedPromptInContext(t *testing.T) {
 	m := &model{}
-	m.OnTurnBegin()
 
 	m.OnTokenUsage(&core.InferResponse{Usage: core.Usage{
 		InputTokens:              500,
@@ -48,9 +55,6 @@ func TestOnTokenUsageCountsCachedPromptInContext(t *testing.T) {
 
 	if want := 141500; m.env.InputTokens != want {
 		t.Fatalf("context InputTokens = %d, want %d (fresh + cache read + cache creation)", m.env.InputTokens, want)
-	}
-	if m.env.TurnInputTokens != 500 {
-		t.Fatalf("TurnInputTokens = %d, want 500 (raw, excludes cached prompt)", m.env.TurnInputTokens)
 	}
 }
 
@@ -81,38 +85,18 @@ func TestOnTokenUsageClearsCompactedStatusOnNextInfer(t *testing.T) {
 	}
 }
 
-func TestOnTurnBeginResetsTurnTotalsOnlyForNewTurn(t *testing.T) {
-	m := &model{}
-	m.env.TurnInputTokens = 1600
-	m.env.TurnOutputTokens = 105
-
-	m.env.turnUsageActive = true
-	m.OnTurnBegin()
-	if m.env.TurnInputTokens != 1600 || m.env.TurnOutputTokens != 105 {
-		t.Fatalf("existing turn totals changed unexpectedly: in:%d out:%d", m.env.TurnInputTokens, m.env.TurnOutputTokens)
-	}
-
-	m.env.turnUsageActive = false
-	m.OnTurnBegin()
-	if m.env.TurnInputTokens != 0 || m.env.TurnOutputTokens != 0 {
-		t.Fatalf("new turn reset = in:%d out:%d, want zeros", m.env.TurnInputTokens, m.env.TurnOutputTokens)
-	}
-}
-
-func TestResetContextDisplayPreservesTurnTotals(t *testing.T) {
+// ResetContextDisplay zeroes the bottom-right context readout (latest infer
+// call's input/output) so a post-compaction transitional frame doesn't show
+// stale occupancy until the next infer.
+func TestResetContextDisplayZeroesContextReadout(t *testing.T) {
 	m := &model{}
 	m.env.InputTokens = 1200
 	m.env.OutputTokens = 80
-	m.env.TurnInputTokens = 1600
-	m.env.TurnOutputTokens = 105
 
 	m.env.ResetContextDisplay()
 
 	if m.env.InputTokens != 0 || m.env.OutputTokens != 0 {
 		t.Fatalf("context display reset = in:%d out:%d, want zeros", m.env.InputTokens, m.env.OutputTokens)
-	}
-	if m.env.TurnInputTokens != 1600 || m.env.TurnOutputTokens != 105 {
-		t.Fatalf("turn totals changed unexpectedly: in:%d out:%d", m.env.TurnInputTokens, m.env.TurnOutputTokens)
 	}
 }
 

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -68,8 +68,7 @@ func isDockedModal(ov overlayPanel) bool {
 }
 
 // renderNormalView composes the standard layout: chat scrollback area,
-// turn-usage summary, queue preview, textarea + suggestions, and the
-// bottom status line.
+// queue preview, textarea + suggestions, and the bottom status line.
 //
 // Only the active (uncommitted) tail is rendered here; finished messages are
 // already in the terminal's native scrollback (committed via tea.Println, see
@@ -110,15 +109,11 @@ func tailLines(s string, maxLines int) string {
 	return strings.Join(lines[len(lines)-maxLines:], "\n")
 }
 
-// renderFooter renders everything below the chat section (turn usage,
-// separators, queue preview, input area, suggestions, status line) into a
-// single string so its line count can be measured.
+// renderFooter renders everything below the chat section (separators, queue
+// preview, input area, suggestions, status line) into a single string so its
+// line count can be measured.
 func (m *model) renderFooter(separator string) string {
 	var b strings.Builder
-	if turnUsage := conv.RenderTurnUsageSummary(m.env.TurnInputTokens, m.env.TurnOutputTokens, m.env.Width); turnUsage != "" {
-		b.WriteString("\n")
-		b.WriteString(turnUsage)
-	}
 	// Queued messages sit above the input separator: they are already
 	// submitted — on their way into the conversation — so they read as part
 	// of the chat flow, and the input strip below stays reserved for what's

--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -241,8 +241,12 @@ func (c *Client) streamResponses(ctx context.Context, opts llm.CompletionOptions
 					state.Response.Reasoning = extractReasoning(resp.Output)
 				}
 
-				// Map usage
-				state.UpdateUsage(int(resp.Usage.InputTokens), int(resp.Usage.OutputTokens))
+				// input_tokens is the full prompt; the cached slice lives under
+				// input_tokens_details. Split into the Anthropic fresh/cache-read
+				// convention the app assumes — see openaicompat.SplitInputTokens.
+				fresh, cached := openaicompat.SplitInputTokens(int(resp.Usage.InputTokens), int(resp.Usage.InputTokensDetails.CachedTokens))
+				state.UpdateUsage(fresh, int(resp.Usage.OutputTokens))
+				state.UpdateCacheUsage(0, cached)
 
 				// Determine stop reason
 				switch resp.Status {

--- a/internal/llm/openai/client_test.go
+++ b/internal/llm/openai/client_test.go
@@ -59,11 +59,31 @@ const responsesStreamBody = "" +
 	"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"created_at\":0,\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":2,\"output_tokens_details\":{\"reasoning_tokens\":1}}}}\n\n" +
 	"data: [DONE]\n\n"
 
-func newTestClient(t *captureStreamingTransport) *Client {
+// cachedResponsesTransport returns a Responses stream whose usage reports a
+// mostly-cached prompt: input_tokens is the FULL prompt (1000) with
+// input_tokens_details.cached_tokens (900) as its cached slice.
+type cachedResponsesTransport struct{}
+
+func (t *cachedResponsesTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	body := "" +
+		"data: {\"type\":\"response.output_text.delta\",\"item_id\":\"msg_1\",\"output_index\":0,\"content_index\":0,\"delta\":\"ok\"}\n\n" +
+		"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"created_at\":0,\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1000,\"input_tokens_details\":{\"cached_tokens\":900},\"output_tokens\":20,\"output_tokens_details\":{\"reasoning_tokens\":0}}}}\n\n" +
+		"data: [DONE]\n\n"
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}, nil
+}
+
+func newTestClient(rt http.RoundTripper) *Client {
 	client := sdk.NewClient(
 		option.WithAPIKey("test"),
 		option.WithBaseURL("https://example.com/v1"),
-		option.WithHTTPClient(&http.Client{Transport: t}),
+		option.WithHTTPClient(&http.Client{Transport: rt}),
 	)
 	return NewClient(client, "openai:test")
 }
@@ -233,5 +253,41 @@ func TestStreamResponsesIncludesImageInputs(t *testing.T) {
 	}
 	if got, _ := imagePart["image_url"].(string); got != "data:image/png;base64,ZmFrZQ==" {
 		t.Fatalf("expected data URL image, got %#v", imagePart["image_url"])
+	}
+}
+
+func TestStreamResponsesSplitsCachedInputTokens(t *testing.T) {
+	c := newTestClient(&cachedResponsesTransport{})
+
+	var done *llm.CompletionResponse
+	for chunk := range c.Stream(context.Background(), llm.CompletionOptions{
+		Model:    "gpt-5.4",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	}) {
+		if chunk.Type == llm.ChunkTypeDone {
+			done = chunk.Response
+		}
+	}
+
+	if done == nil {
+		t.Fatal("missing done chunk")
+	}
+	// input_tokens (1000) is the FULL prompt; the cached slice (900) moves to
+	// CacheRead so InputTokens holds only the fresh tokens (Anthropic
+	// convention), keeping cost from billing the cached prefix at the full rate.
+	if done.Usage.InputTokens != 100 {
+		t.Fatalf("InputTokens = %d, want 100 (1000 input - 900 cached)", done.Usage.InputTokens)
+	}
+	if done.Usage.CacheReadInputTokens != 900 {
+		t.Fatalf("CacheReadInputTokens = %d, want 900", done.Usage.CacheReadInputTokens)
+	}
+	if done.Usage.OutputTokens != 20 {
+		t.Fatalf("OutputTokens = %d, want 20", done.Usage.OutputTokens)
+	}
+	// The fresh + cached split must still sum to the API's reported input_tokens
+	// so the bottom-bar ctx readout (TotalInputTokens) stays accurate.
+	total := done.Usage.InputTokens + done.Usage.CacheReadInputTokens + done.Usage.CacheCreationInputTokens
+	if total != 1000 {
+		t.Fatalf("total input = %d, want 1000 (equal to API input_tokens)", total)
 	}
 }

--- a/internal/llm/openaicompat/stream.go
+++ b/internal/llm/openaicompat/stream.go
@@ -89,19 +89,12 @@ func StreamChatCompletions(ctx context.Context, cfg ChatStreamConfig) <-chan llm
 				}
 			}
 
-			// OpenAI-compatible APIs report prompt_tokens as the FULL prompt
-			// (cached tokens included) and expose the cached slice under
-			// prompt_tokens_details.cached_tokens. Split it so InputTokens holds
-			// only the fresh tokens and the cached portion lands in
-			// CacheReadInputTokens — the Anthropic convention the rest of the app
-			// assumes. Without the split, summing InputTokens across a turn's
-			// infer steps multi-counts the re-read cache (inflating the ↑ usage
-			// readout) and cost bills the cached prefix at the full input rate
-			// instead of the cache-read rate. TotalInputTokens stays the full
-			// prompt, so the ctx occupancy readout is unchanged.
-			cachedTokens := int(chunk.Usage.PromptTokensDetails.CachedTokens)
-			state.UpdateUsage(int(chunk.Usage.PromptTokens)-cachedTokens, int(chunk.Usage.CompletionTokens))
-			state.UpdateCacheUsage(0, cachedTokens)
+			// prompt_tokens is the full prompt; the cached slice lives under
+			// prompt_tokens_details. Split into the Anthropic fresh/cache-read
+			// convention the app assumes — see SplitInputTokens.
+			fresh, cached := SplitInputTokens(int(chunk.Usage.PromptTokens), int(chunk.Usage.PromptTokensDetails.CachedTokens))
+			state.UpdateUsage(fresh, int(chunk.Usage.CompletionTokens))
+			state.UpdateCacheUsage(0, cached)
 		}
 
 		if err := stream.Err(); err != nil {

--- a/internal/llm/openaicompat/usage.go
+++ b/internal/llm/openaicompat/usage.go
@@ -1,0 +1,25 @@
+package openaicompat
+
+// SplitInputTokens separates an OpenAI-family "full prompt" token count into
+// the fresh (uncached) and cached-read halves the rest of the app expects.
+// The Anthropic convention the app assumes is: InputTokens holds only fresh
+// tokens, and the cached prefix lives in CacheReadInputTokens. OpenAI's Chat
+// Completions and Responses APIs instead report the whole prompt in a single
+// figure (prompt_tokens / input_tokens) and expose the cached slice under
+// *_tokens_details.cached_tokens; callers pass both and receive the split.
+//
+// fresh + cached always equals the (non-negative) full prompt, so
+// InferResponse.TotalInputTokens stays exactly the API's reported input and
+// the bottom-bar ctx readout is unchanged. Splitting the cached portion out of
+// InputTokens keeps a turn's per-step sums from multi-counting the re-read
+// cache and lets cost accounting bill the cached prefix at the cache-read rate
+// rather than the full input rate.
+//
+// The split is defensive against malformed wire data: a cached count that is
+// negative, or larger than the full prompt, is clamped so fresh never goes
+// negative.
+func SplitInputTokens(fullInput, cachedTokens int) (fresh, cached int) {
+	fullInput = max(fullInput, 0)
+	cached = min(max(cachedTokens, 0), fullInput)
+	return fullInput - cached, cached
+}

--- a/internal/llm/openaicompat/usage_test.go
+++ b/internal/llm/openaicompat/usage_test.go
@@ -1,0 +1,32 @@
+package openaicompat
+
+import "testing"
+
+func TestSplitInputTokens(t *testing.T) {
+	tests := []struct {
+		name       string
+		fullInput  int
+		cached     int
+		wantFresh  int
+		wantCached int
+	}{
+		{name: "no cache", fullInput: 1000, cached: 0, wantFresh: 1000, wantCached: 0},
+		{name: "partial cache", fullInput: 1000, cached: 900, wantFresh: 100, wantCached: 900},
+		{name: "fully cached", fullInput: 1000, cached: 1000, wantFresh: 0, wantCached: 1000},
+		// Defensive normalization: malformed wire data must never yield a
+		// negative fresh count or over-report the cached slice.
+		{name: "cached exceeds input", fullInput: 500, cached: 900, wantFresh: 0, wantCached: 500},
+		{name: "negative cached", fullInput: 500, cached: -10, wantFresh: 500, wantCached: 0},
+		{name: "negative input", fullInput: -10, cached: 5, wantFresh: 0, wantCached: 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fresh, cached := SplitInputTokens(tc.fullInput, tc.cached)
+			if fresh != tc.wantFresh || cached != tc.wantCached {
+				t.Fatalf("SplitInputTokens(%d, %d) = (%d, %d), want (%d, %d)",
+					tc.fullInput, tc.cached, fresh, cached, tc.wantFresh, tc.wantCached)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Two related fixes to token/context accounting in the TUI:

1. **Remove the per-turn `↑… ↓…` usage line above the input area.** The bottom status line already reports real context-window occupancy as `ctx used/limit`. The top summary used a *different* scope (per-turn accumulation), so the two numbers disagreed and read as contradictory. This drops the top line and everything that fed only it.
2. **Fix OpenAI cached-token mapping** so the bottom `ctx` figure and cost accounting are both correct when prompt caching is active.

## Why

`ctx 164.6k/272.0k` (bottom) and `↑491.2k ↓1.9k` (top) measure different things, which is confusing. Keeping a single, correct readout is clearer. Separately, OpenAI's Responses client billed cached input at the full input rate.

## Changes

**UI / state removal**
- Delete `conv.RenderTurnUsageSummary` and its `View()` call.
- Drop `env.TurnInputTokens` / `TurnOutputTokens` / `turnUsageActive`, the per-infer accumulation in `OnTokenUsage`, and the now-orphaned `OnTurnBegin` callback — removed from the `conv.Runtime` interface, `applyPreInfer`, the `model` impl, and the data-flow / rendering docs.
- Bottom `ctx` semantics unchanged: `InputTokens` is the **full prompt of the latest infer call** (`fresh + cache read + cache creation` via `InferResponse.TotalInputTokens`), never a cross-call sum; `OutputTokens` is not folded into it. Compact / `/clear` / `/new` resets stay correct.

**OpenAI cached-token fix**
- OpenAI-family APIs report the full prompt in `input_tokens` / `prompt_tokens`, with the cached slice under `*_tokens_details.cached_tokens`. The Responses client passed the whole figure to `UpdateUsage`, ignoring `cached_tokens`.
- Extract a shared `openaicompat.SplitInputTokens(fullInput, cached)` helper — used by **both** the Responses (`openai/client.go`) and Chat Completions (`openaicompat/stream.go`) paths so they can't drift — that splits into `fresh input + cache-read`, defensively clamped so malformed usage never yields a negative.
- `TotalInputTokens()` still equals the API's reported input, so the `ctx` readout is unchanged and accurate, while cost no longer bills the cached prefix at the full input rate.

## Testing

`go test ./...` — all green (66 packages). New/updated coverage:
- Responses stream splits non-zero `cached_tokens`; `InputTokens` = fresh, `CacheReadInputTokens` = cached, total = API `input_tokens`.
- Two consecutive `OnTokenUsage` calls: bottom `ctx` uses the latest full context, not the sum.
- Status line renders `ctx` and never the `↑…↓…` arrows.
- Unit coverage for `SplitInputTokens` including defensive clamping.

## Screenshots

Before (input area): a `↑491.2k ↓1.9k` line sat above the separator. After: that line is gone; the bottom line still shows e.g. `GPT-5.6-Luna (high) · ctx 164.6k/272.0k`.
