### PR TITLE
feat(setting): make Bypass Permissions opt-out, in the cycle by default

### DIFF
--- a/internal/setting/service.go
+++ b/internal/setting/service.go
@@ -69,10 +69,13 @@ func (s *Settings) Snapshot() *Data {
 	return s.data.Clone()
 }
 
+// AllowBypass reports whether Bypass Permissions mode is reachable (in the
+// Shift+Tab cycle and as a settings defaultMode). It is opt-out: enabled
+// unless the user explicitly sets "allowBypass": false to lock it out.
 func (s *Settings) AllowBypass() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.data != nil && s.data.AllowBypass != nil && *s.data.AllowBypass
+	return s.data == nil || s.data.AllowBypass == nil || *s.data.AllowBypass
 }
 
 func (s *Settings) IsGitRepo(cwd string) bool {

--- a/internal/setting/settings.go
+++ b/internal/setting/settings.go
@@ -31,7 +31,10 @@ type Data struct {
 	DisabledTools  map[string]bool    `json:"disabledTools,omitempty"`
 	Theme          string             `json:"theme,omitempty"`
 	SearchProvider string             `json:"searchProvider,omitempty"`
-	AllowBypass    *bool              `json:"allowBypass,omitempty"`
+	// AllowBypass gates Bypass Permissions mode. Opt-out: nil/absent means
+	// allowed (bypass is in the Shift+Tab cycle by default); set false to
+	// lock it out. Read via Settings.AllowBypass().
+	AllowBypass *bool `json:"allowBypass,omitempty"`
 	// StreamFirstChunkTimeout overrides the core default (5m) for time-to-first-
 	// chunk. A valid time.Duration string (e.g. "5m", "120s"); empty = core default.
 	StreamFirstChunkTimeout string `json:"streamFirstChunkTimeout,omitempty"`


### PR DESCRIPTION
Bypass Permissions mode is now reachable by default. `allowBypass` becomes opt-out: it's enabled unless the user explicitly sets `"allowBypass": false` to lock it out.

- Shift+Tab now cycles `Normal → Accept Edits → AutoPilot → Bypass Permissions` with no config needed.
- Setting `"allowBypass": false` removes it from the cycle and downgrades a `defaultMode: "bypassPermissions"` to Normal, as before.
- Unchanged: bypass-immune safety checks still apply in bypass mode, and resumed sessions never silently restore into bypass.