### PR TITLE
feat(bash): render multi-line commands as a readable block

### DIFF
--- a/internal/app/conv/bash_render_demo_test.go
+++ b/internal/app/conv/bash_render_demo_test.go
@@ -1,0 +1,61 @@
+package conv
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/genai-io/san/internal/core"
+)
+
+// TestBashRenderDemo prints how Bash tool calls render, for eyeballing.
+// Run:  go test ./internal/app/conv/ -run TestBashRenderDemo -v
+// Tweak the `width` and add your own cases to `samples`.
+func TestBashRenderDemo(t *testing.T) {
+	const width = 70 // terminal width; block wraps at ~80% of this
+
+	samples := []struct {
+		name  string
+		input string
+	}{
+		{
+			"short single-line (stays compact)",
+			`{"command":"git status"}`,
+		},
+		{
+			"long single-line (wraps into block)",
+			`{"command":"git log --oneline --graph --all --decorate --abbrev-commit | head -50"}`,
+		},
+		{
+			"multi-line for-loop + description",
+			`{"command":"for f in $(git diff --name-only); do\n  gofmt -w \"$f\"\ndone","description":"Format changed Go files"}`,
+		},
+		{
+			"multi-line, no description",
+			`{"command":"set -e\nmake build\nmake test\necho done"}`,
+		},
+		{
+			"blank line in the middle is kept",
+			`{"command":"echo start\n\necho end"}`,
+		},
+		{
+			"very long unbroken token (hard-wrapped)",
+			`{"command":"curl -sSL https://example.com/some/really/long/path/that/keeps/going/and/going/and/will/not/fit"}`,
+		},
+		{
+			"CJK / wide chars",
+			`{"command":"echo 你好世界，这是一个比较长的中文命令用来测试换行宽度是否正确"}`,
+		},
+	}
+
+	fmt.Printf("\n==== Bash tool-call rendering (width=%d) ====\n\n", width)
+	for _, s := range samples {
+		params := ToolCallsParams{
+			ToolCalls: []core.ToolCall{{ID: "tc", Name: "Bash", Input: s.input}},
+			ResultMap: map[string]ToolResultData{},
+			Width:     width,
+		}
+		fmt.Printf("--- %s ---\n", s.name)
+		fmt.Print(RenderToolCalls(params))
+		fmt.Println()
+	}
+}

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -540,6 +540,8 @@ func RenderToolCalls(params ToolCallsParams) string {
 			if tc.Name == tool.ToolTaskGet && params.TaskOwnerMap != nil {
 				args := extractTaskGetDisplay(tc.Input, params.TaskOwnerMap)
 				sb.WriteString(renderToolLineWithIcon(fmt.Sprintf("%s(%s)", tc.Name, args), params.Width, icon) + "\n")
+			} else if tc.Name == tool.ToolBash {
+				sb.WriteString(renderBashToolCall(tc.Input, params.Width, icon))
 			} else {
 				args := extractToolArgs(tc.Input)
 				sb.WriteString(renderToolLineWithIcon(fmt.Sprintf("%s(%s)", tc.Name, args), params.Width, icon) + "\n")

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"charm.land/lipgloss/v2"
+
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/llm"
 )
@@ -115,6 +117,68 @@ func Test_extractToolArgsPreservesFullCommand(t *testing.T) {
 	got := extractToolArgs(input)
 	if !strings.Contains(got, "git describe --tags --abbrev=0") {
 		t.Fatalf("extractToolArgs() = %q, want full command", got)
+	}
+}
+
+func Test_renderBashToolCallSingleLineStaysCompact(t *testing.T) {
+	out := renderBashToolCall(`{"command":"git status"}`, 100, "●")
+	if !strings.Contains(out, "Bash(git status)") {
+		t.Fatalf("single-line command should render compact, got %q", out)
+	}
+	if strings.Contains(out, "│") {
+		t.Fatalf("single-line command should not render a command block, got %q", out)
+	}
+}
+
+func Test_renderBashToolCallMultiLineShowsEveryLine(t *testing.T) {
+	input := `{"command":"for f in a b; do\n  echo \"$f\"\ndone","description":"loop over files"}`
+	out := renderBashToolCall(input, 100, "●")
+
+	// Every command line renders in the block, not folded away behind ctrl+o.
+	for _, want := range []string{"for f in a b; do", `echo "$f"`, "done"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("multi-line command should show %q in place, got %q", want, out)
+		}
+	}
+	// The description rides the header as a caption.
+	if !strings.Contains(out, "loop over files") {
+		t.Fatalf("multi-line command should show its description, got %q", out)
+	}
+	// The raw command is never crammed into the Bash(...) one-line label.
+	if strings.Contains(out, "Bash(for f") {
+		t.Fatalf("multi-line command should not be crammed into a one-line label, got %q", out)
+	}
+}
+
+func Test_renderBashToolCallShowsShellPrompt(t *testing.T) {
+	// A long single line wraps into the block, which reads as a terminal command:
+	// the first row is led by a "$" prompt, later rows align under the command
+	// text without repeating it. No gutter bar, no background fill.
+	long := `{"command":"git log --oneline --graph --all --decorate --abbrev-commit --since='2 weeks ago' | head -50"}`
+	raw := renderBashToolCall(long, 70, "●")
+	if strings.ContainsAny(raw, "│┊") || strings.Contains(raw, "48;2;") {
+		t.Fatalf("command block should have no bar and no background, got %q", raw)
+	}
+
+	rows := strings.Split(strings.TrimRight(stripANSI(raw), "\n"), "\n")[1:]
+	if len(rows) < 2 {
+		t.Fatalf("expected the long command to wrap onto multiple rows, got %q", raw)
+	}
+	if !strings.HasPrefix(rows[0], bashPrompt) {
+		t.Fatalf("first command row should carry the %q prompt: %q", bashPrompt, rows[0])
+	}
+	// Continuations hang under the command text: a blank indent the width of the
+	// prompt, so command text lines up down one column and the prompt never repeats.
+	contIndent := strings.Repeat(" ", lipgloss.Width(bashPrompt))
+	for i, row := range rows[1:] {
+		if !strings.HasPrefix(row, contIndent) || strings.HasPrefix(row, bashPrompt) {
+			t.Fatalf("continuation row %d should hang under the command text, not repeat the prompt: %q", i+1, row)
+		}
+	}
+
+	// The "$" sits in the "⎿" result column, so the two markers line up down the left.
+	if strings.IndexByte(bashPrompt, '$') != strings.Index("  ⎿  ", "⎿") {
+		t.Fatalf("prompt $ column must equal the result ⎿ column")
 	}
 }
 
@@ -294,7 +358,8 @@ func TestRenderQueuePreviewEditingShowsFocusBarAndKeys(t *testing.T) {
 	}
 }
 
-func TestRenderToolCallsUsesEightyPercentWidth(t *testing.T) {
+func TestRenderToolCallsWrapsLongBashCommandWithoutTruncating(t *testing.T) {
+	const width = 100
 	params := ToolCallsParams{
 		ToolCalls: []core.ToolCall{{
 			ID:    "tc-1",
@@ -302,15 +367,28 @@ func TestRenderToolCallsUsesEightyPercentWidth(t *testing.T) {
 			Input: `{"command":"cd /Users/myan/Workspace/ideas/san && git describe --tags --abbrev=0 2>/dev/null"}`,
 		}},
 		ResultMap: map[string]ToolResultData{},
-		Width:     100,
+		Width:     width,
 	}
 
-	rendered := RenderToolCalls(params)
-	if !strings.Contains(rendered, "git describe --tags --abbrev") {
-		t.Fatalf("RenderToolCalls() = %q, want wider command preview", rendered)
+	rendered := stripANSI(RenderToolCalls(params))
+
+	// A long single-line command wraps into the block form rather than being
+	// clipped: the whole command survives, including its tail, and no ellipsis.
+	if !strings.Contains(rendered, "git describe --tags --abbrev=0") {
+		t.Fatalf("RenderToolCalls() = %q, want the full command", rendered)
 	}
-	if !strings.Contains(rendered, "…") {
-		t.Fatalf("RenderToolCalls() = %q, want truncation at 80%% width", rendered)
+	if !strings.Contains(rendered, "2>/dev/null") {
+		t.Fatalf("RenderToolCalls() = %q, want the command tail kept, not truncated", rendered)
+	}
+	if strings.Contains(rendered, "…") {
+		t.Fatalf("RenderToolCalls() = %q, want no truncation ellipsis", rendered)
+	}
+	// Wrapping still honors the 80%-width budget: every line stays within it.
+	budget := maxToolLabelWidth(width)
+	for _, line := range strings.Split(strings.TrimRight(rendered, "\n"), "\n") {
+		if w := lipgloss.Width(line); w > budget {
+			t.Fatalf("wrapped line %q width %d exceeds budget %d", line, w, budget)
+		}
 	}
 }
 

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+	xansi "github.com/charmbracelet/x/ansi"
 
 	"github.com/genai-io/san/internal/app/kit"
 	"github.com/genai-io/san/internal/tool"
@@ -48,6 +49,15 @@ var (
 
 	errorStyle = lipgloss.NewStyle().
 			Foreground(kit.CurrentTheme.Error)
+
+	// A multi-line Bash command renders as an indented block below the header. The
+	// command itself is drawn in the shared dim result tone (toolResultStyle) —
+	// the same tone as the "$" prompt and the "⎿" trailer — so the whole block
+	// reads as quiet code, one step below body prose. Only the description differs:
+	// italic, so it reads as a prose caption distinct from the code.
+	bashDescStyle = lipgloss.NewStyle().
+			Foreground(kit.CurrentTheme.TextDim).
+			Italic(true)
 )
 
 // RenderToolResult renders a complete tool result with header and content.
@@ -900,6 +910,75 @@ func renderToolLine(label string, width int) string {
 func renderToolLineWithIcon(label string, width int, iconText string) string {
 	icon := toolCallStyle.Width(2).Render(iconText)
 	return lipgloss.JoinHorizontal(lipgloss.Top, icon, toolCallStyle.Render(truncateToolLabel(label, width)))
+}
+
+// bashPrompt marks the first command row with a shell "$" so the block reads as
+// a terminal command. Every later row (a wrap or a continued command line) hangs
+// under the command text by an indent the width of the prompt, so the whole
+// command body lines up in one column with the "$" as a hanging prompt to its
+// left. The "$" sits in column 2, shared with the "⎿" result trailer below and
+// in the same dim tone, so the two markers still line up down the left.
+const bashPrompt = "  $ "
+
+// renderBashToolCall renders a Bash tool call so its command is always readable
+// in full. A short single-line command keeps the compact Bash(cmd) label; a
+// multi-line command — or a single line too long for that label — renders as a
+// dimmed block below a "● Bash" header, led by a shell "$" prompt, with the
+// optional description as a caption. Command lines soft-wrap to the width rather
+// than truncate, so the full command is always visible, never clipped.
+func renderBashToolCall(input string, width int, icon string) string {
+	command, description := extractBashCommand(input)
+	if command == "" {
+		return renderToolLineWithIcon(fmt.Sprintf("%s(%s)", tool.ToolBash, extractToolArgs(input)), width, icon) + "\n"
+	}
+
+	budget := maxToolLabelWidth(width)
+
+	// A short single-line command fits on the compact label untouched.
+	if !strings.Contains(command, "\n") {
+		if label := fmt.Sprintf("%s(%s)", tool.ToolBash, command); lipgloss.Width(label) <= budget {
+			return renderToolLineWithIcon(label, width, icon) + "\n"
+		}
+	}
+
+	var sb strings.Builder
+
+	// Header line: ● Bash, trailed by the optional description as a dim caption.
+	// The caption may be shortened (it's metadata); the command below never is.
+	iconCell := toolCallStyle.Width(2).Render(icon)
+	header := toolCallStyle.Render(tool.ToolBash)
+	if description != "" {
+		header += "  " + bashDescStyle.Render(kit.TruncateText(description, budget))
+	}
+	sb.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, iconCell, header) + "\n")
+
+	// Soft-wrap the whole command to the width left of the prompt, so long lines
+	// flow onto more rows instead of being clipped. xansi.Wrap treats embedded
+	// newlines as hard breaks and breaks any run with no break point, so
+	// multi-line commands and unbroken tokens alike stay within the width — one
+	// wrap covers every line. The first row carries the "$" prompt; every later
+	// row hangs under the command text on an indent the width of that prompt.
+	promptWidth := lipgloss.Width(bashPrompt)
+	contIndent := strings.Repeat(" ", promptWidth)
+	segments := strings.Split(xansi.Wrap(command, budget-promptWidth, " "), "\n")
+	sb.WriteString(toolResultStyle.Render(bashPrompt+segments[0]) + "\n")
+	for _, segment := range segments[1:] {
+		sb.WriteString(contIndent + toolResultStyle.Render(segment) + "\n")
+	}
+	return sb.String()
+}
+
+// extractBashCommand pulls the command and optional description out of a Bash
+// tool call's raw JSON input.
+func extractBashCommand(input string) (command, description string) {
+	var params struct {
+		Command     string `json:"command"`
+		Description string `json:"description"`
+	}
+	if err := json.Unmarshal([]byte(input), &params); err != nil {
+		return "", ""
+	}
+	return params.Command, params.Description
 }
 
 func renderAgentToolLine(label string, width int, iconText string, color string) string {

--- a/internal/tool/schema.go
+++ b/internal/tool/schema.go
@@ -4,6 +4,7 @@ import "github.com/genai-io/san/internal/core"
 
 // Tool name constants used in runtime comparisons across the codebase.
 const (
+	ToolBash        = "Bash"
 	ToolAgent       = "Agent"
 	ToolSendMessage = "SendMessage"
 	ToolTaskOutput  = "TaskOutput"


### PR DESCRIPTION
## Problem

Multi-line Bash commands were fed whole — newlines and all — into the one-line `Bash(...)` tool-call label. That label only truncates by the *widest line's* width and never flattens the newlines, so a multi-line command rendered as a broken, misaligned block. Worse, when a single line overran the width it got mangled, because the width truncation counts `\n` as zero-width and chops everything past the budget. The command was effectively unreadable in the conversation.

Single-line commands were always fine; only multi-line ones broke.

## Change

Give Bash its own rendering path in `RenderToolCalls`:

- **Single-line** commands keep the compact `Bash(cmd)` label (unchanged).
- **Multi-line** commands render the full command as a gutter-marked block below a `● Bash` header, with the optional `description` shown as a dim caption. Every line stays visible in place — no fold, no `ctrl+o` gate.

```
● Bash  Format changed Go files
  │ for f in $(git diff --name-only); do
  │   gofmt -w "$f"
  │ done
```

This mirrors the line-by-line treatment the bash **approval preview** already uses, so the two views read consistently.

## Notes

- Only the default (collapsed) view is touched. The global `ctrl+o` expand path (generic param dump) still shows the full command as before.
- No syntax highlighting — command text renders in the plain Text tone; that can be a follow-up.

## Tests

- `Test_renderBashToolCallSingleLineStaysCompact` — single-line stays `Bash(cmd)`, no block.
- `Test_renderBashToolCallMultiLineShowsEveryLine` — every command line, the description, and the gutter render; the raw command is never crammed into a one-line label.

`go build ./...`, `go vet`, and `go test ./internal/app/conv/ ./internal/tool/` all pass on top of latest `main`.