### PR TITLE
fix(subagent): inherit parent reasoning effort so Codex subagents don't 400

### DIFF
--- a/.san/personas/software-engineer/skills/simplify/SKILL.md
+++ b/.san/personas/software-engineer/skills/simplify/SKILL.md
@@ -32,9 +32,13 @@ in this conversation.
 
 ## Phase 2: Review across three lenses (in parallel)
 
-Use the Agent tool to launch three reviewers concurrently in one message
-(foreground). Give each the full diff. Each returns a short list of concrete,
-located findings.
+Use the Agent tool to launch three reviewers concurrently in one message. Each
+call must use `subagent_type: "code-reviewer"`, `mode: "explore"`, and foreground
+execution (omit `run_in_background` or set it to `false`). Omit `model` so
+reviewers inherit the parent model. Subagents always share the current working
+directory; do not request worktree isolation. Tell each reviewer to inspect the
+complete `git diff HEAD` directly, and wait for all three results before changing
+any file. Each returns a short list of concrete, located findings.
 
 - **Reuse.** New code that duplicates an existing helper or utility; hand-rolled
   logic (string munging, path handling, env checks, type guards) that the

--- a/.san/skills/simplify/SKILL.md
+++ b/.san/skills/simplify/SKILL.md
@@ -22,7 +22,7 @@ Run `git diff` (or `git diff HEAD` if there are staged changes) to see what chan
 
 ## Phase 2: Launch Three Review Agents in Parallel
 
-Use the Agent tool to launch all three agents concurrently in a single message (foreground — do NOT set `run_in_background`). Pass each agent the full diff so it has the complete context. All three agents run in parallel and return their results in the same turn.
+Use the Agent tool to launch all three agents concurrently in a single message. Each call must use `subagent_type: "code-reviewer"`, `mode: "explore"`, and foreground execution (omit `run_in_background` or set it to `false`). Omit `model` so reviewers inherit the parent model. Subagents always share the current working directory; do not request worktree isolation. Tell each reviewer to inspect the complete `git diff HEAD` directly. Wait for all three results before changing any file.
 
 ### Agent 1: Code Reuse Review
 

--- a/docs/guides/writing-a-subagent.md
+++ b/docs/guides/writing-a-subagent.md
@@ -26,9 +26,8 @@ Project overrides user overrides Claude-compat by `name`.
 ---
 name: test-runner
 description: Run the test suite and surface failures
-allowed-tools: [Bash, Read, Grep]
-permission-mode: bypass
-isolation: none
+allow_tools: [Bash, Read, Grep]
+mode: bypassPermissions
 ---
 
 You are a test runner. Your job is to:
@@ -47,10 +46,9 @@ Be terse. No code suggestions — that is the parent agent's job.
 |---|---|---|
 | `name` | yes | Subagent type identifier; used in `Agent` tool's `agent_type` field. |
 | `description` | yes | Shown in selectors and used by the foreground model to decide when to spawn this agent. |
-| `allowed-tools` | no | Restrict the subagent's tool set. Default = same as parent. |
-| `permission-mode` | no | One of `default`, `acceptEdits`, `bypassPermissions`, `plan`. Default = parent. |
-| `isolation` | no | `none` (default) or `worktree` — see below. |
-| `model` | no | Pin a model for this subagent; otherwise inherits the parent's. An alias (`opus`/`sonnet`/`haiku`) or bare id uses the parent's provider; `vendor/model` (e.g. `deepseek/deepseek-v4`) routes to another **connected** provider. |
+| `allow_tools` | no | Restrict the subagent's tool set. Default = same as parent. |
+| `mode` | no | One of `default`, `explore`, `acceptEdits`, `bypassPermissions`, `dontAsk`, or `auto`. Default = `default`. |
+| `model` | no | Pin a model for this subagent; otherwise inherits the parent's. Claude aliases (`opus`/`sonnet`/`haiku`) apply only on an Anthropic parent; on other providers they inherit the parent model. A bare id uses the parent's provider; `vendor/model` routes to another **connected** provider. |
 
 ## Cross-Provider Models
 
@@ -67,8 +65,10 @@ routes the agent to another **connected** provider:
 `model:` accepts:
 
 - `inherit` (or empty) — the parent conversation's model.
-- an alias (`opus` / `sonnet` / `haiku`) or a bare id — served by the parent's
-  provider.
+- an alias (`opus` / `sonnet` / `haiku`) — resolved on an Anthropic parent;
+  otherwise it inherits the parent model. Use `anthropic/model` to route
+  explicitly from another provider.
+- a bare id — served by the parent's provider.
 - `vendor/model` (e.g. `deepseek/deepseek-v4`) — routed to another **connected**
   provider.
 
@@ -95,16 +95,12 @@ controls what happens when a tool call would normally `ask`:
 See [`concepts/permission-model.md`](../concepts/permission-model.md) for
 the full decision pipeline.
 
-## Worktree Isolation
+## Workspace Coordination
 
-`isolation: worktree` creates a `git worktree` under
-`<project>/.git/agent-worktrees/<random>/` and runs the subagent there.
-The parent's working tree is untouched until the subagent finishes; the
-worktree is removed on success.
-
-Use this when you want a subagent to run experiments that may dirty the
-tree (build artifacts, codegen, refactors) without polluting the
-foreground session.
+Subagents share the parent conversation's working directory. Use read-only
+permission modes for parallel reviewers, wait for all reviewers to finish,
+then let one agent apply the aggregated changes. Do not run multiple writing
+subagents concurrently against the same files.
 
 ## How the Parent Spawns It
 
@@ -142,8 +138,6 @@ San:
   run anything.
 - **`bypassPermissions` on a write-class subagent.** Verify carefully
   — the subagent has no human in the loop.
-- **`isolation: worktree` without git.** Fails silently for non-git
-  projects. The subagent runs in the parent's cwd as fallback.
 
 ## See Also
 

--- a/docs/packages/2-feature/subagent.md
+++ b/docs/packages/2-feature/subagent.md
@@ -15,9 +15,9 @@ main agent's tool loop.
 Where [`packages/agent.md`](agent.md) owns the *foreground* agent session,
 this package owns the *background* agents the foreground spawns via the
 Agent tool. Each background agent runs in its own goroutine with its own
-inbox/outbox, isolated work tree (optional), and isolated tool/permission
-set; its final result flows back into the foreground conversation as a
-tool result.
+inbox/outbox and isolated tool/permission set while sharing the parent's
+working directory; its final result flows back into the foreground
+conversation as a tool result.
 
 ## Contract
 
@@ -109,5 +109,4 @@ internal/subagent/scenarios_test.go     — common invocation shapes.
 - Code: `internal/subagent/`
 - Parent agent: [`packages/agent.md`](agent.md)
 - Spawning tool: [`packages/tool.md`](tool.md) (the Agent tool)
-- Worktree isolation: [`packages/worktree.md`](worktree.md)
 - Layer: `feature`

--- a/docs/packages/2-feature/worktree.md
+++ b/docs/packages/2-feature/worktree.md
@@ -6,16 +6,16 @@ layer: feature
 # worktree
 
 Thin wrapper over `git worktree add/remove` that produces an isolated
-workspace under `<cwd>/.git/agent-worktrees/<slug>/` plus a cleanup
-closure. Used by the standalone `EnterWorktree` tool and by the Agent
-tool's `isolation: "worktree"` mode.
+workspace under the repository's common Git directory at
+`agent-worktrees/<slug>/`, plus a cleanup closure. Used by the main
+conversation's standalone `EnterWorktree` and `ExitWorktree` tools.
+Subagents share the current working directory and do not create worktrees.
 
 ## Purpose
 
-Subagents may need a clean git workspace separate from the main session's
-working directory — e.g. an "explore" subagent running long-shot
-experiments that must not pollute the parent's tree. This package gives
-each such invocation its own worktree and the closure to clean it up.
+The main conversation may need a clean git workspace for an experiment
+that must not pollute its current tree. This package creates that workspace
+and returns the closure that cleans it up.
 
 ## Contract
 
@@ -73,5 +73,5 @@ internal/worktree/hooks_test.go       — hook firing.
 ## See Also
 
 - Code: `internal/worktree/`
-- Callers: [`packages/tool.md`](tool.md) (EnterWorktree tool), [`packages/subagent.md`](subagent.md) (isolation mode)
+- Caller: [`packages/tool.md`](tool.md) (EnterWorktree and ExitWorktree tools)
 - Layer: `feature`

--- a/docs/packages/index.md
+++ b/docs/packages/index.md
@@ -56,7 +56,7 @@ visible right next to its original. Every page follows [`TEMPLATE.md`](TEMPLATE.
 | [`subagent`](2-feature/subagent.md) | Subagent registry + `Executor` that spawns background `core.Agent` instances. |
 | [`task`](2-feature/task.md) | Background task manager (bash and agent tasks). |
 | [`tool`](2-feature/tool.md) | Tool registry, schemas, permission gate, side-effect store. |
-| [`worktree`](2-feature/worktree.md) | Thin wrapper over `git worktree add/remove` for subagent isolation. |
+| [`worktree`](2-feature/worktree.md) | Thin wrapper over `git worktree add/remove` for main-conversation workspace isolation. |
 
 ## 3 · core
 

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -577,14 +577,24 @@ func (m *model) preparePermissionRequest(req *conv.PermGateRequest) *perm.Permis
 	}
 }
 
+func (m *model) SetThinkingEffort(effort string) {
+	previous := m.env.EffectiveThinkingEffort()
+	m.env.SetThinkingEffort(effort)
+	if m.env.EffectiveThinkingEffort() != previous {
+		m.ReconfigureAgentTool()
+	}
+}
+
 func (m *model) ReconfigureAgentTool() {
-	if m.env.LLMProvider == nil {
+	if m.env.LLMProvider == nil || m.services.LLM == nil {
 		return
 	}
 	m.ensureMemoryContextLoaded()
 
+	store := m.services.LLM.Store()
 	executor := subagent.NewExecutor(m.env.LLMProvider, m.env.CWD, m.env.GetModelID(), m.services.Hook)
-	executor.SetResolver(llm.NewProviderPool(m.services.LLM.Store()))
+	executor.SetResolver(llm.NewProviderPool(store))
+	executor.SetModelStore(store)
 	executor.SetParentThinkingEffort(m.env.EffectiveThinkingEffort())
 	if m.services.Session.GetStore() != nil && m.services.Session.ID() != "" {
 		executor.SetSessionStore(m.services.Session.GetStore(), m.services.Session.ID())

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -585,6 +585,7 @@ func (m *model) ReconfigureAgentTool() {
 
 	executor := subagent.NewExecutor(m.env.LLMProvider, m.env.CWD, m.env.GetModelID(), m.services.Hook)
 	executor.SetResolver(llm.NewProviderPool(m.services.LLM.Store()))
+	executor.SetParentThinkingEffort(m.env.EffectiveThinkingEffort())
 	if m.services.Session.GetStore() != nil && m.services.Session.ID() != "" {
 		executor.SetSessionStore(m.services.Session.GetStore(), m.services.Session.ID())
 	}

--- a/internal/app/env.go
+++ b/internal/app/env.go
@@ -200,11 +200,12 @@ func (m *env) ApplyBypassPermissions() {
 	m.SessionPermissions.Mode = setting.ModeBypassPermissions
 }
 
-func (m *env) DetectThinkingKeywords(input string) {
+func (m *env) DetectThinkingKeywords(input string) bool {
+	previous := m.EffectiveThinkingEffort()
 	lower := strings.ToLower(input)
 	efforts := m.ThinkingEfforts()
 	if len(efforts) == 0 {
-		return
+		return false
 	}
 
 	if strings.Contains(lower, "ultrathink") ||
@@ -212,7 +213,7 @@ func (m *env) DetectThinkingKeywords(input string) {
 		strings.Contains(lower, "think super hard") ||
 		strings.Contains(lower, "maximum thinking") {
 		m.ThinkingEffort = efforts[len(efforts)-1]
-		return
+		return m.EffectiveThinkingEffort() != previous
 	}
 
 	if strings.Contains(lower, "think harder") ||
@@ -222,8 +223,10 @@ func (m *env) DetectThinkingKeywords(input string) {
 		if len(efforts) >= 2 {
 			m.ThinkingEffort = efforts[len(efforts)-2]
 		}
-		return
+		return m.EffectiveThinkingEffort() != previous
 	}
+
+	return false
 }
 
 func (m *env) ApplyModePermissions(cwd string) {

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -140,7 +140,7 @@ func formatAsyncHookContinuationContext(result hook.AsyncHookResult, reason stri
 func runPrint(userMessage, personaName string) error {
 	ctx := context.Background()
 
-	llmProvider, modelID, err := resolveProvider(ctx)
+	llmProvider, modelID, _, err := resolveProvider(ctx)
 	if err != nil {
 		return err
 	}
@@ -206,20 +206,20 @@ func runPrint(userMessage, personaName string) error {
 // concrete model id. It shares llm.ResolveProvider's resolution order with the
 // interactive startup path; when resolution falls back to a connection without
 // a saved current model, it fills that provider's default model id.
-func resolveProvider(ctx context.Context) (llm.Provider, string, error) {
+func resolveProvider(ctx context.Context) (llm.Provider, string, *llm.Store, error) {
 	store, err := llm.NewStore()
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to load store: %w", err)
+		return nil, "", nil, fmt.Errorf("failed to load store: %w", err)
 	}
 	resolved, ok := llm.ResolveProvider(ctx, store)
 	if !ok {
-		return nil, "", fmt.Errorf("no provider connected. Run 'san' and use /model to connect")
+		return nil, "", nil, fmt.Errorf("no provider connected. Run 'san' and use /model to connect")
 	}
 	modelID := resolved.ModelID
 	if modelID == "" {
 		modelID = setting.DefaultModel(resolved.Provider.Name(), string(resolved.AuthMethod))
 	}
-	return resolved.Provider, modelID, nil
+	return resolved.Provider, modelID, store, nil
 }
 
 // validatePersona ensures the named persona exists on disk, early in startup,

--- a/internal/app/run_agent.go
+++ b/internal/app/run_agent.go
@@ -44,12 +44,9 @@ func RunAgent(opts AgentRunOptions) error {
 		cancel()
 	}()
 
-	provider, modelID, err := resolveProvider(ctx)
+	provider, parentModelID, store, err := resolveProvider(ctx)
 	if err != nil {
 		return err
-	}
-	if opts.Model != "" {
-		modelID = opts.Model
 	}
 
 	cwd, _ := os.Getwd()
@@ -65,8 +62,9 @@ func RunAgent(opts AgentRunOptions) error {
 	// Run through the full subagent pipeline so headless invocations get the
 	// same permission gate (deny_tools / bypass-immune / allow_tools / mode)
 	// as TUI-spawned subagents.
-	executor := subagent.NewExecutor(provider, cwd, modelID, nil)
-	executor.SetResolver(llm.NewProviderPool(llm.Default().Store()))
+	executor := subagent.NewExecutor(provider, cwd, parentModelID, nil)
+	executor.SetResolver(llm.NewProviderPool(store))
+	executor.SetModelStore(store)
 	executor.SetContext(setting.IsGitRepo(cwd))
 
 	fmt.Printf("Agent: %s\n", opts.Type)

--- a/internal/app/update_command.go
+++ b/internal/app/update_command.go
@@ -35,8 +35,8 @@ func (m *model) slashCommandEnv() input.SlashCommandEnv {
 
 		// Env callbacks
 		GetThinkingEffort: func() string { return m.env.EffectiveThinkingEffort() },
-		SetThinkingEffort: m.env.SetThinkingEffort,
-		ResetTokens:       m.env.ResetTokens,
+		SetThinkingEffort: m.SetThinkingEffort,
+		ResetTokens: m.env.ResetTokens,
 
 		// Model actions
 		CommitMessages:          m.CommitMessages,

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -195,7 +195,7 @@ func (m *model) cycleThinkingEffort() tea.Cmd {
 		return kit.StatusTimer(3*time.Second, token)
 	}
 
-	m.env.SetThinkingEffort(next)
+	m.SetThinkingEffort(next)
 	status := "thinking: " + next
 	if current != "" && current == next {
 		status += " (only supported)"

--- a/internal/app/update_submit.go
+++ b/internal/app/update_submit.go
@@ -205,7 +205,9 @@ func (m *model) SubmitToAgent(content string, images []core.Image) tea.Cmd {
 		return tea.Batch(m.CommitMessages()...)
 	}
 
-	m.env.DetectThinkingKeywords(content)
+	if m.env.DetectThinkingKeywords(content) {
+		m.ReconfigureAgentTool()
+	}
 
 	sendCmd := m.sendToAgent(content, images)
 	if startCmd != nil {

--- a/internal/core/agent_impl.go
+++ b/internal/core/agent_impl.go
@@ -507,11 +507,28 @@ func executeToolTask(ctx context.Context, t agentToolTask) (result toolTaskOutpu
 
 func canExecuteToolBatchInParallel(tasks []agentToolTask) bool {
 	for _, t := range tasks {
-		if !isReadOnlyToolCall(t.call.Name) {
+		if !isReadOnlyToolTask(t) {
 			return false
 		}
 	}
 	return true
+}
+
+func isReadOnlyToolTask(task agentToolTask) bool {
+	if isReadOnlyToolCall(task.call.Name) {
+		return true
+	}
+	if task.call.Name != "Agent" {
+		return false
+	}
+	params, err := ParseToolInput(task.call.Input)
+	if err != nil {
+		return false
+	}
+	agentType, _ := params["subagent_type"].(string)
+	mode, _ := params["mode"].(string)
+	background, _ := params["run_in_background"].(bool)
+	return agentType == "code-reviewer" && mode == "explore" && !background
 }
 
 func isReadOnlyToolCall(name string) bool {

--- a/internal/core/agent_impl_test.go
+++ b/internal/core/agent_impl_test.go
@@ -354,6 +354,30 @@ func TestCanExecuteToolBatchInParallelOnlyAllowsReadOnlyTools(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "explore code reviewers run in parallel",
+			tasks: []agentToolTask{
+				{call: ToolCall{Name: "Agent", Input: `{"subagent_type":"code-reviewer","mode":"explore"}`}},
+				{call: ToolCall{Name: "Agent", Input: `{"subagent_type":"code-reviewer","mode":"explore"}`}},
+			},
+			want: true,
+		},
+		{
+			name: "writing agents serialize batch",
+			tasks: []agentToolTask{
+				{call: ToolCall{Name: "Agent", Input: `{"subagent_type":"general-purpose","mode":"acceptEdits"}`}},
+				{call: ToolCall{Name: "Agent", Input: `{"subagent_type":"general-purpose","mode":"acceptEdits"}`}},
+			},
+			want: false,
+		},
+		{
+			name: "background reviewers serialize launch",
+			tasks: []agentToolTask{
+				{call: ToolCall{Name: "Agent", Input: `{"subagent_type":"code-reviewer","mode":"explore","run_in_background":true}`}},
+				{call: ToolCall{Name: "Agent", Input: `{"subagent_type":"code-reviewer","mode":"explore","run_in_background":true}`}},
+			},
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/subagent/executor.go
+++ b/internal/subagent/executor.go
@@ -18,7 +18,6 @@ import (
 	"github.com/genai-io/san/internal/task"
 	"github.com/genai-io/san/internal/tool"
 	"github.com/genai-io/san/internal/tool/perm"
-	"github.com/genai-io/san/internal/worktree"
 	"go.uber.org/zap"
 )
 
@@ -34,9 +33,10 @@ type ProviderResolver interface {
 type Executor struct {
 	provider        llm.Provider
 	resolver        ProviderResolver // resolves "vendor/model" overrides; nil = same-provider only
+	modelStore      *llm.Store       // optional live model capabilities for target-model effort resolution
 	cwd             string
 	parentModelID   string // Parent conversation's model ID (used when inheriting)
-	parentEffort    string // Parent's reasoning/thinking effort, applied to same-provider subagents
+	parentEffort    string // Parent's reasoning/thinking effort, applied when inheriting the exact parent model
 	hooks           hook.Handler
 	sessionStore    SubagentSessionStore // Optional: when set, subagent sessions are persisted
 	parentSessionID string               // Parent session ID for linking subagent sessions
@@ -53,14 +53,14 @@ type SubagentSessionStore interface {
 }
 
 type runConfig struct {
-	config           *AgentConfig
-	provider         llm.Provider // provider this run talks to (parent's, or a routed vendor)
-	modelID          string
-	onParentProvider bool // true when provider is the parent's (inherit/alias), not a routed vendor
-	maxSteps         int
-	displayName      string
-	brief            system.SubagentBrief // identity/charter for this run; immutable
-	permMode         PermissionMode
+	config              *AgentConfig
+	provider            llm.Provider // provider this run talks to (parent's, or a routed vendor)
+	modelID             string
+	inheritsParentModel bool // true only when the request uses the parent's exact model
+	maxSteps            int
+	displayName         string
+	brief               system.SubagentBrief // identity/charter for this run; immutable
+	permMode            PermissionMode
 }
 
 // NewExecutor creates a new agent executor. parentModelID is used for model
@@ -81,12 +81,9 @@ func (e *Executor) SetContext(isGit bool) {
 	e.isGit = isGit
 }
 
-// SetParentThinkingEffort records the parent conversation's reasoning effort so
-// same-provider subagents run at the same effort. This matters for backends that
-// require a reasoning field (the ChatGPT Codex subscription rejects a
-// reasoning-less request with 400); without it, an inheriting subagent would
-// send no effort and fail. Cross-provider-routed subagents do not receive it —
-// the parent's effort may be invalid for a different vendor's model.
+// SetParentThinkingEffort records the parent conversation's reasoning effort.
+// It is used only when a subagent inherits the parent's exact model; model
+// overrides resolve the target model's own default effort.
 func (e *Executor) SetParentThinkingEffort(effort string) {
 	e.parentEffort = effort
 }
@@ -97,6 +94,12 @@ func (e *Executor) SetParentThinkingEffort(effort string) {
 // silently fall back to the parent.
 func (e *Executor) SetResolver(r ProviderResolver) {
 	e.resolver = r
+}
+
+// SetModelStore enables provider/auth-scoped model capability lookup when a
+// subagent overrides the parent's model. Without it, provider defaults apply.
+func (e *Executor) SetModelStore(store *llm.Store) {
+	e.modelStore = store
 }
 
 // SetCapabilities provides skills and agents prompt sections so subagents
@@ -133,8 +136,6 @@ func (e *Executor) Run(ctx context.Context, req tool.AgentExecRequest) (*AgentRe
 	if err != nil {
 		return nil, err
 	}
-	defer run.close()
-
 	ctx = e.attachRunContext(ctx, run.cfg.displayName)
 	e.logRunStart(run)
 	e.fireSubagentStart(run.req, run.hookID)
@@ -143,6 +144,7 @@ func (e *Executor) Run(ctx context.Context, req tool.AgentExecRequest) (*AgentRe
 	if err != nil && shouldRetryWithParentModel(err, run.cfg.modelID, e.parentModelID) {
 		run.cfg.provider = e.provider
 		run.cfg.modelID = e.parentModelID
+		run.cfg.inheritsParentModel = true
 		result, err = e.executePreparedRun(ctx, run)
 	}
 	if err != nil {
@@ -216,18 +218,6 @@ func (e *Executor) validateRequest(req tool.AgentExecRequest) error {
 	return nil
 }
 
-func (e *Executor) prepareWorkspace(req tool.AgentExecRequest) (string, func(), error) {
-	if req.Isolation != "worktree" {
-		return e.cwd, func() {}, nil
-	}
-
-	result, cleanup, err := worktree.Create(e.cwd, "")
-	if err != nil {
-		return "", nil, fmt.Errorf("failed to create worktree: %w", err)
-	}
-	return result.Path, cleanup, nil
-}
-
 func (e *Executor) prepareRunConfig(ctx context.Context, req tool.AgentExecRequest) (*runConfig, error) {
 	config, ok := defaultRegistry.Get(req.Agent)
 	if !ok {
@@ -246,20 +236,20 @@ func (e *Executor) prepareRunConfig(ctx context.Context, req tool.AgentExecReque
 		maxSteps = defaultMaxSteps
 	}
 
-	provider, modelID, onParentProvider, err := e.resolveModel(ctx, req.Model, config.Model)
+	provider, modelID, inheritsParentModel, err := e.resolveModel(ctx, req.Model, config.Model)
 	if err != nil {
 		return nil, err
 	}
 
 	return &runConfig{
-		config:           config,
-		provider:         provider,
-		modelID:          modelID,
-		onParentProvider: onParentProvider,
-		maxSteps:         maxSteps,
-		displayName:      displayName,
-		brief:            e.buildBrief(config, permMode),
-		permMode:         permMode,
+		config:              config,
+		provider:            provider,
+		modelID:             modelID,
+		inheritsParentModel: inheritsParentModel,
+		maxSteps:            maxSteps,
+		displayName:         displayName,
+		brief:               e.buildBrief(config, permMode),
+		permMode:            permMode,
 	}, nil
 }
 
@@ -338,13 +328,18 @@ func (e *Executor) buildAgent(ctx context.Context, rc *runConfig, agentCwd strin
 	coreTools = tool.WithPermission(coreTools, permFn)
 
 	client := llm.NewClient(rc.provider, rc.modelID, 0)
-	if rc.onParentProvider {
-		// Inherit the parent's reasoning effort: it is valid for this provider's
-		// model, and some backends (the ChatGPT Codex subscription) reject a
-		// reasoning-less request with 400. Routed subagents keep the empty
-		// default — the parent's effort may be invalid for another vendor.
-		client.SetThinkingEffort(e.parentEffort)
+	effort := ""
+	if rc.inheritsParentModel && e.parentEffort != "" {
+		effort = e.parentEffort
+	} else {
+		providerName, authMethod := providerIdentity(rc.provider)
+		effort = llm.ResolveThinkingEffortForModel(rc.provider, e.modelStore, &llm.CurrentModelInfo{
+			Provider:   providerName,
+			AuthMethod: authMethod,
+			ModelID:    rc.modelID,
+		}, "")
 	}
+	client.SetThinkingEffort(effort)
 
 	ag = core.NewAgent(core.Config{
 		LLM:       client,
@@ -433,10 +428,9 @@ func (e *Executor) fireSubagentStop(req tool.AgentExecRequest, agentHookID, agen
 // alias, a bare model id, or "inherit" — stays on the parent's provider,
 // preserving prior behavior.
 //
-// The returned onParentProvider flag is true for those parent-provider forms
-// and false for a routed vendor; it gates parent-effort propagation, since the
-// parent's reasoning effort is only known-valid for its own provider's models.
-func (e *Executor) resolveModel(ctx context.Context, requestModel, configModel string) (provider llm.Provider, modelID string, onParentProvider bool, err error) {
+// The returned inheritsParentModel flag is true only when the run uses the
+// parent's exact model. Model overrides resolve their own default effort.
+func (e *Executor) resolveModel(ctx context.Context, requestModel, configModel string) (provider llm.Provider, modelID string, inheritsParentModel bool, err error) {
 	ref := requestModel
 	if ref == "" {
 		ref = configModel
@@ -454,7 +448,24 @@ func (e *Executor) resolveModel(ctx context.Context, requestModel, configModel s
 		}
 		return p, routedModel, false, nil
 	}
-	return e.provider, resolveModelAlias(ref), true, nil
+	if _, isClaudeAlias := modelAliases[ref]; isClaudeAlias && !isAnthropicProvider(e.provider) {
+		return e.provider, e.parentModelID, true, nil
+	}
+	modelID = resolveModelAlias(ref)
+	return e.provider, modelID, modelID == e.parentModelID, nil
+}
+
+func isAnthropicProvider(provider llm.Provider) bool {
+	name, _ := providerIdentity(provider)
+	return name == llm.Anthropic
+}
+
+func providerIdentity(provider llm.Provider) (llm.Name, llm.AuthMethod) {
+	if provider == nil {
+		return "", ""
+	}
+	name, auth, _ := strings.Cut(provider.Name(), ":")
+	return llm.Name(name), llm.AuthMethod(auth)
 }
 
 func shouldRetryWithParentModel(err error, modelID, parentModelID string) bool {

--- a/internal/subagent/executor.go
+++ b/internal/subagent/executor.go
@@ -36,6 +36,7 @@ type Executor struct {
 	resolver        ProviderResolver // resolves "vendor/model" overrides; nil = same-provider only
 	cwd             string
 	parentModelID   string // Parent conversation's model ID (used when inheriting)
+	parentEffort    string // Parent's reasoning/thinking effort, applied to same-provider subagents
 	hooks           hook.Handler
 	sessionStore    SubagentSessionStore // Optional: when set, subagent sessions are persisted
 	parentSessionID string               // Parent session ID for linking subagent sessions
@@ -52,13 +53,14 @@ type SubagentSessionStore interface {
 }
 
 type runConfig struct {
-	config      *AgentConfig
-	provider    llm.Provider // provider this run talks to (parent's, or a routed vendor)
-	modelID     string
-	maxSteps    int
-	displayName string
-	brief       system.SubagentBrief // identity/charter for this run; immutable
-	permMode    PermissionMode
+	config           *AgentConfig
+	provider         llm.Provider // provider this run talks to (parent's, or a routed vendor)
+	modelID          string
+	onParentProvider bool // true when provider is the parent's (inherit/alias), not a routed vendor
+	maxSteps         int
+	displayName      string
+	brief            system.SubagentBrief // identity/charter for this run; immutable
+	permMode         PermissionMode
 }
 
 // NewExecutor creates a new agent executor. parentModelID is used for model
@@ -77,6 +79,16 @@ func NewExecutor(llmProvider llm.Provider, cwd string, parentModelID string, hoo
 // instructions) is intentionally not propagated — see collectSubagentReminders.
 func (e *Executor) SetContext(isGit bool) {
 	e.isGit = isGit
+}
+
+// SetParentThinkingEffort records the parent conversation's reasoning effort so
+// same-provider subagents run at the same effort. This matters for backends that
+// require a reasoning field (the ChatGPT Codex subscription rejects a
+// reasoning-less request with 400); without it, an inheriting subagent would
+// send no effort and fail. Cross-provider-routed subagents do not receive it —
+// the parent's effort may be invalid for a different vendor's model.
+func (e *Executor) SetParentThinkingEffort(effort string) {
+	e.parentEffort = effort
 }
 
 // SetResolver enables cross-provider routing: a subagent whose model is an
@@ -234,19 +246,20 @@ func (e *Executor) prepareRunConfig(ctx context.Context, req tool.AgentExecReque
 		maxSteps = defaultMaxSteps
 	}
 
-	provider, modelID, err := e.resolveModel(ctx, req.Model, config.Model)
+	provider, modelID, onParentProvider, err := e.resolveModel(ctx, req.Model, config.Model)
 	if err != nil {
 		return nil, err
 	}
 
 	return &runConfig{
-		config:      config,
-		provider:    provider,
-		modelID:     modelID,
-		maxSteps:    maxSteps,
-		displayName: displayName,
-		brief:       e.buildBrief(config, permMode),
-		permMode:    permMode,
+		config:           config,
+		provider:         provider,
+		modelID:          modelID,
+		onParentProvider: onParentProvider,
+		maxSteps:         maxSteps,
+		displayName:      displayName,
+		brief:            e.buildBrief(config, permMode),
+		permMode:         permMode,
 	}, nil
 }
 
@@ -324,8 +337,17 @@ func (e *Executor) buildAgent(ctx context.Context, rc *runConfig, agentCwd strin
 	permFn := subagentPermissionFunc(rc.permMode, rc.config.AllowTools, rc.config.DenyTools)
 	coreTools = tool.WithPermission(coreTools, permFn)
 
+	client := llm.NewClient(rc.provider, rc.modelID, 0)
+	if rc.onParentProvider {
+		// Inherit the parent's reasoning effort: it is valid for this provider's
+		// model, and some backends (the ChatGPT Codex subscription) reject a
+		// reasoning-less request with 400. Routed subagents keep the empty
+		// default — the parent's effort may be invalid for another vendor.
+		client.SetThinkingEffort(e.parentEffort)
+	}
+
 	ag = core.NewAgent(core.Config{
-		LLM:       llm.NewClient(rc.provider, rc.modelID, 0),
+		LLM:       client,
 		System:    sys,
 		Tools:     coreTools,
 		AgentType: rc.config.Name,
@@ -410,25 +432,29 @@ func (e *Executor) fireSubagentStop(req tool.AgentExecRequest, agentHookID, agen
 // resolver, erroring if the vendor is not connected. Every other form — an
 // alias, a bare model id, or "inherit" — stays on the parent's provider,
 // preserving prior behavior.
-func (e *Executor) resolveModel(ctx context.Context, requestModel, configModel string) (llm.Provider, string, error) {
+//
+// The returned onParentProvider flag is true for those parent-provider forms
+// and false for a routed vendor; it gates parent-effort propagation, since the
+// parent's reasoning effort is only known-valid for its own provider's models.
+func (e *Executor) resolveModel(ctx context.Context, requestModel, configModel string) (provider llm.Provider, modelID string, onParentProvider bool, err error) {
 	ref := requestModel
 	if ref == "" {
 		ref = configModel
 	}
 	if ref == "" || ref == "inherit" {
-		return e.provider, e.parentModelID, nil
+		return e.provider, e.parentModelID, true, nil
 	}
-	if vendor, modelID, ok := llm.ParseVendorModel(ref); ok {
+	if vendor, routedModel, ok := llm.ParseVendorModel(ref); ok {
 		if e.resolver == nil {
-			return nil, "", fmt.Errorf("model %q routes to provider %q, but cross-provider routing is unavailable", ref, vendor)
+			return nil, "", false, fmt.Errorf("model %q routes to provider %q, but cross-provider routing is unavailable", ref, vendor)
 		}
 		p, err := e.resolver.Resolve(ctx, vendor)
 		if err != nil {
-			return nil, "", fmt.Errorf("model %q: %w", ref, err)
+			return nil, "", false, fmt.Errorf("model %q: %w", ref, err)
 		}
-		return p, modelID, nil
+		return p, routedModel, false, nil
 	}
-	return e.provider, resolveModelAlias(ref), nil
+	return e.provider, resolveModelAlias(ref), true, nil
 }
 
 func shouldRetryWithParentModel(err error, modelID, parentModelID string) bool {

--- a/internal/subagent/executor_run.go
+++ b/internal/subagent/executor_run.go
@@ -13,21 +13,14 @@ import (
 )
 
 type preparedRun struct {
-	req              tool.AgentExecRequest
-	cfg              *runConfig
-	cwd              string
-	startedAt        time.Time
-	hookID           string
-	activity         []string
-	inputTokens      int
-	outputTokens     int
-	cleanupWorkspace func()
-}
-
-func (r *preparedRun) close() {
-	if r != nil && r.cleanupWorkspace != nil {
-		r.cleanupWorkspace()
-	}
+	req          tool.AgentExecRequest
+	cfg          *runConfig
+	cwd          string
+	startedAt    time.Time
+	hookID       string
+	activity     []string
+	inputTokens  int
+	outputTokens int
 }
 
 func (r *preparedRun) sendActivity(msg string) {
@@ -53,25 +46,18 @@ func (e *Executor) prepareRun(ctx context.Context, req tool.AgentExecRequest) (*
 		return nil, err
 	}
 
-	agentCwd, cleanupWorkspace, err := e.prepareWorkspace(req)
-	if err != nil {
-		return nil, err
-	}
-
 	cfg, err := e.prepareRunConfig(ctx, req)
 	if err != nil {
-		cleanupWorkspace()
 		return nil, err
 	}
 
 	return &preparedRun{
-		req:              req,
-		cfg:              cfg,
-		cwd:              agentCwd,
-		startedAt:        time.Now(),
-		hookID:           "a" + generateShortID(),
-		activity:         make([]string, 0, 16),
-		cleanupWorkspace: cleanupWorkspace,
+		req:       req,
+		cfg:       cfg,
+		cwd:       e.cwd,
+		startedAt: time.Now(),
+		hookID:    "a" + generateShortID(),
+		activity:  make([]string, 0, 16),
 	}, nil
 }
 

--- a/internal/subagent/executor_test.go
+++ b/internal/subagent/executor_test.go
@@ -98,17 +98,33 @@ func TestPrepareRunConfigDoesNotLowerBuiltinMaxSteps(t *testing.T) {
 }
 
 func TestResolveModelUsesConfigBeforeParent(t *testing.T) {
-	executor := &Executor{parentModelID: "parent-model"}
+	executor := &Executor{
+		provider:      &thinkingProvider{name: string(llm.Anthropic)},
+		parentModelID: "parent-model",
+	}
 	ctx := context.Background()
 
-	if _, got, onParent, _ := executor.resolveModel(ctx, "", "sonnet"); got != "claude-sonnet-4-20250514" || !onParent {
-		t.Fatalf("config alias = %q onParent=%v, want sonnet alias on parent provider", got, onParent)
+	if _, got, inheritsParent, _ := executor.resolveModel(ctx, "", "sonnet"); got != "claude-sonnet-4-20250514" || inheritsParent {
+		t.Fatalf("config alias = %q inheritsParent=%v, want a model override", got, inheritsParent)
 	}
-	if _, got, onParent, _ := executor.resolveModel(ctx, "", "inherit"); got != "parent-model" || !onParent {
-		t.Fatalf("inherit model = %q onParent=%v, want parent on parent provider", got, onParent)
+	if _, got, inheritsParent, _ := executor.resolveModel(ctx, "", "inherit"); got != "parent-model" || !inheritsParent {
+		t.Fatalf("inherit model = %q inheritsParent=%v, want the exact parent model", got, inheritsParent)
 	}
 	if _, got, _, _ := executor.resolveModel(ctx, "override-model", "sonnet"); got != "override-model" {
 		t.Fatalf("request override = %q, want override", got)
+	}
+}
+
+func TestResolveModelDoesNotSendClaudeAliasToOpenAI(t *testing.T) {
+	parent := &thinkingProvider{name: "openai:subscription"}
+	executor := &Executor{provider: parent, parentModelID: "gpt-parent"}
+
+	provider, modelID, inheritsParent, err := executor.resolveModel(context.Background(), "haiku", "")
+	if err != nil {
+		t.Fatalf("resolveModel() error: %v", err)
+	}
+	if provider != parent || modelID != "gpt-parent" || !inheritsParent {
+		t.Fatalf("resolveModel() = (%v, %q, %v), want OpenAI parent model", provider, modelID, inheritsParent)
 	}
 }
 
@@ -128,7 +144,7 @@ func TestResolveModelRoutesQualifiedRefToResolver(t *testing.T) {
 	stub := &stubResolver{}
 	executor := &Executor{parentModelID: "parent-model", resolver: stub}
 
-	_, modelID, onParent, err := executor.resolveModel(context.Background(), "deepseek/deepseek-v4", "")
+	_, modelID, inheritsParent, err := executor.resolveModel(context.Background(), "deepseek/deepseek-v4", "")
 	if err != nil {
 		t.Fatalf("resolveModel() error: %v", err)
 	}
@@ -138,8 +154,166 @@ func TestResolveModelRoutesQualifiedRefToResolver(t *testing.T) {
 	if modelID != "deepseek-v4" {
 		t.Fatalf("modelID = %q, want deepseek-v4", modelID)
 	}
-	if onParent {
-		t.Fatal("a routed vendor/model must not be flagged as on the parent provider")
+	if inheritsParent {
+		t.Fatal("a routed vendor/model must not inherit the parent model")
+	}
+}
+
+type thinkingProvider struct {
+	name        string
+	defaults    map[string]string
+	options     []llm.CompletionOptions
+	streamError error
+}
+
+func (p *thinkingProvider) Stream(_ context.Context, opts llm.CompletionOptions) <-chan llm.StreamChunk {
+	p.options = append(p.options, opts)
+	ch := make(chan llm.StreamChunk, 1)
+	if p.streamError != nil {
+		ch <- llm.StreamChunk{Type: llm.ChunkTypeError, Error: p.streamError}
+	} else {
+		resp := llm.CompletionResponse{Content: "ok", StopReason: "end_turn"}
+		ch <- llm.StreamChunk{Type: llm.ChunkTypeDone, Response: &resp}
+	}
+	close(ch)
+	return ch
+}
+
+func (p *thinkingProvider) ListModels(context.Context) ([]llm.ModelInfo, error) { return nil, nil }
+func (p *thinkingProvider) Name() string                                        { return p.name }
+func (p *thinkingProvider) ThinkingEfforts(model string) []string {
+	if effort := p.defaults[model]; effort != "" {
+		return []string{effort}
+	}
+	return nil
+}
+func (p *thinkingProvider) DefaultThinkingEffort(model string) string {
+	return p.defaults[model]
+}
+
+func TestRunResolvesThinkingEffortForFinalModel(t *testing.T) {
+	tests := []struct {
+		name         string
+		parentEffort string
+		requestModel string
+		wantEffort   string
+	}{
+		{name: "inherits selected parent effort", parentEffort: "high", wantEffort: "high"},
+		{name: "headless inheritance uses model default", wantEffort: "medium"},
+		{name: "model override uses target default", parentEffort: "high", requestModel: "child-model", wantEffort: "low"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &thinkingProvider{
+				name:     string(llm.OpenAI),
+				defaults: map[string]string{"parent-model": "medium", "child-model": "low"},
+			}
+			executor := NewExecutor(provider, t.TempDir(), "parent-model", nil)
+			executor.SetParentThinkingEffort(tt.parentEffort)
+
+			_, err := executor.Run(context.Background(), tool.AgentExecRequest{
+				Agent:  "general-purpose",
+				Prompt: "review",
+				Model:  tt.requestModel,
+			})
+			if err != nil {
+				t.Fatalf("Run() error: %v", err)
+			}
+			if len(provider.options) != 1 {
+				t.Fatalf("completion calls = %d, want 1", len(provider.options))
+			}
+			if got := provider.options[0].ThinkingEffort; got != tt.wantEffort {
+				t.Fatalf("ThinkingEffort = %q, want %q", got, tt.wantEffort)
+			}
+		})
+	}
+}
+
+func TestRunRoutedModelUsesTargetDefaultThinkingEffort(t *testing.T) {
+	parent := &thinkingProvider{name: string(llm.OpenAI), defaults: map[string]string{"parent-model": "high"}}
+	target := &thinkingProvider{name: string(llm.DeepSeek), defaults: map[string]string{"deepseek-v4": "low"}}
+	executor := NewExecutor(parent, t.TempDir(), "parent-model", nil)
+	executor.SetParentThinkingEffort("high")
+	executor.SetResolver(&stubResolver{provider: target})
+
+	_, err := executor.Run(context.Background(), tool.AgentExecRequest{
+		Agent:  "general-purpose",
+		Prompt: "review",
+		Model:  "deepseek/deepseek-v4",
+	})
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if len(target.options) != 1 || target.options[0].ThinkingEffort != "low" {
+		t.Fatalf("routed options = %#v, want target effort low", target.options)
+	}
+}
+
+func TestRunModelOverrideUsesCachedTargetThinkingEffort(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	store, err := llm.NewStore()
+	if err != nil {
+		t.Fatalf("NewStore() error: %v", err)
+	}
+	if err := store.Connect(llm.OpenAI, llm.AuthSubscription); err != nil {
+		t.Fatalf("Connect() error: %v", err)
+	}
+	if err := store.CacheModels(llm.OpenAI, llm.AuthSubscription, []llm.ModelInfo{{
+		ID:        "dynamic-model",
+		Reasoning: llm.NewReasoningCapability([]string{"low", "ultra"}, "ultra"),
+	}}); err != nil {
+		t.Fatalf("CacheModels() error: %v", err)
+	}
+
+	provider := &thinkingProvider{name: "openai:subscription"}
+	executor := NewExecutor(provider, t.TempDir(), "parent-model", nil)
+	executor.SetParentThinkingEffort("high")
+	executor.SetModelStore(store)
+
+	_, err = executor.Run(context.Background(), tool.AgentExecRequest{
+		Agent:  "general-purpose",
+		Prompt: "review",
+		Model:  "dynamic-model",
+	})
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if len(provider.options) != 1 || provider.options[0].ThinkingEffort != "ultra" {
+		t.Fatalf("override options = %#v, want cached target effort ultra", provider.options)
+	}
+}
+
+func TestResolveModelExplicitParentKeepsParentEffort(t *testing.T) {
+	provider := &thinkingProvider{name: "openai:subscription"}
+	executor := &Executor{provider: provider, parentModelID: "gpt-parent"}
+
+	_, modelID, inheritsParent, err := executor.resolveModel(context.Background(), "gpt-parent", "")
+	if err != nil {
+		t.Fatalf("resolveModel() error: %v", err)
+	}
+	if modelID != "gpt-parent" || !inheritsParent {
+		t.Fatalf("resolveModel() = (%q, %v), want explicit parent model to inherit effort", modelID, inheritsParent)
+	}
+}
+
+func TestRunModelFallbackRestoresParentThinkingEffort(t *testing.T) {
+	parent := &thinkingProvider{name: string(llm.OpenAI), defaults: map[string]string{"parent-model": "medium"}}
+	target := &thinkingProvider{name: string(llm.DeepSeek), streamError: errors.New("model_not_found")}
+	executor := NewExecutor(parent, t.TempDir(), "parent-model", nil)
+	executor.SetParentThinkingEffort("high")
+	executor.SetResolver(&stubResolver{provider: target})
+
+	_, err := executor.Run(context.Background(), tool.AgentExecRequest{
+		Agent:  "general-purpose",
+		Prompt: "review",
+		Model:  "deepseek/missing-model",
+	})
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if len(parent.options) != 1 || parent.options[0].ThinkingEffort != "high" {
+		t.Fatalf("fallback options = %#v, want selected parent effort high", parent.options)
 	}
 }
 

--- a/internal/subagent/executor_test.go
+++ b/internal/subagent/executor_test.go
@@ -101,13 +101,13 @@ func TestResolveModelUsesConfigBeforeParent(t *testing.T) {
 	executor := &Executor{parentModelID: "parent-model"}
 	ctx := context.Background()
 
-	if _, got, _ := executor.resolveModel(ctx, "", "sonnet"); got != "claude-sonnet-4-20250514" {
-		t.Fatalf("config model = %q, want sonnet alias", got)
+	if _, got, onParent, _ := executor.resolveModel(ctx, "", "sonnet"); got != "claude-sonnet-4-20250514" || !onParent {
+		t.Fatalf("config alias = %q onParent=%v, want sonnet alias on parent provider", got, onParent)
 	}
-	if _, got, _ := executor.resolveModel(ctx, "", "inherit"); got != "parent-model" {
-		t.Fatalf("inherit model = %q, want parent", got)
+	if _, got, onParent, _ := executor.resolveModel(ctx, "", "inherit"); got != "parent-model" || !onParent {
+		t.Fatalf("inherit model = %q onParent=%v, want parent on parent provider", got, onParent)
 	}
-	if _, got, _ := executor.resolveModel(ctx, "override-model", "sonnet"); got != "override-model" {
+	if _, got, _, _ := executor.resolveModel(ctx, "override-model", "sonnet"); got != "override-model" {
 		t.Fatalf("request override = %q, want override", got)
 	}
 }
@@ -128,7 +128,7 @@ func TestResolveModelRoutesQualifiedRefToResolver(t *testing.T) {
 	stub := &stubResolver{}
 	executor := &Executor{parentModelID: "parent-model", resolver: stub}
 
-	_, modelID, err := executor.resolveModel(context.Background(), "deepseek/deepseek-v4", "")
+	_, modelID, onParent, err := executor.resolveModel(context.Background(), "deepseek/deepseek-v4", "")
 	if err != nil {
 		t.Fatalf("resolveModel() error: %v", err)
 	}
@@ -138,12 +138,15 @@ func TestResolveModelRoutesQualifiedRefToResolver(t *testing.T) {
 	if modelID != "deepseek-v4" {
 		t.Fatalf("modelID = %q, want deepseek-v4", modelID)
 	}
+	if onParent {
+		t.Fatal("a routed vendor/model must not be flagged as on the parent provider")
+	}
 }
 
 func TestResolveModelQualifiedRefWithoutResolverErrors(t *testing.T) {
 	executor := &Executor{parentModelID: "parent-model"} // no resolver wired
 
-	if _, _, err := executor.resolveModel(context.Background(), "deepseek/deepseek-v4", ""); err == nil {
+	if _, _, _, err := executor.resolveModel(context.Background(), "deepseek/deepseek-v4", ""); err == nil {
 		t.Fatal("expected an error when an explicit vendor/model ref has no resolver")
 	}
 }
@@ -152,7 +155,7 @@ func TestResolveModelPropagatesResolverError(t *testing.T) {
 	stub := &stubResolver{err: errors.New("provider \"deepseek\" is not connected")}
 	executor := &Executor{parentModelID: "parent-model", resolver: stub}
 
-	if _, _, err := executor.resolveModel(context.Background(), "deepseek/deepseek-v4", ""); err == nil {
+	if _, _, _, err := executor.resolveModel(context.Background(), "deepseek/deepseek-v4", ""); err == nil {
 		t.Fatal("expected the resolver error to propagate")
 	}
 }

--- a/internal/subagent/types.go
+++ b/internal/subagent/types.go
@@ -290,8 +290,9 @@ type AgentConfig struct {
 	WhenToUse   string `yaml:"when-to-use,omitempty" json:"when_to_use,omitempty"`
 	// Model selects the model for this agent. Accepted forms:
 	//   - "inherit" or empty — use the parent conversation's model
-	//   - an alias ("opus", "sonnet", "haiku") or a bare model id served by the
-	//     parent's provider
+	//   - a Claude alias ("opus", "sonnet", "haiku") on an Anthropic parent;
+	//     other providers inherit their parent model for these aliases
+	//   - a bare model id served by the parent's provider
 	//   - "vendor/model" (e.g. "deepseek/deepseek-v4") to route to another
 	//     connected provider; the named vendor must be connected
 	Model string `yaml:"model" json:"model"`

--- a/internal/tool/agent.go
+++ b/internal/tool/agent.go
@@ -74,7 +74,6 @@ type AgentExecRequest struct {
 	MaxSteps    int
 	Mode        string
 	ResumeID    string
-	Isolation   string
 	OnActivity  ActivityFunc
 	OnQuestion  AskQuestionFunc
 }

--- a/internal/tool/agent/agent.go
+++ b/internal/tool/agent/agent.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/genai-io/san/internal/tool"
@@ -15,6 +16,7 @@ const backgroundLaunchSuffix = "\n\nThe agent is working in the background. You 
 // AgentTool spawns subagents to handle complex tasks.
 // It implements PermissionAwareTool to require user confirmation.
 type AgentTool struct {
+	mu       sync.RWMutex
 	executor tool.AgentExecutor
 }
 
@@ -34,7 +36,15 @@ func (t *AgentTool) RequiresPermission() bool {
 
 // SetExecutor sets the agent executor
 func (t *AgentTool) SetExecutor(executor tool.AgentExecutor) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.executor = executor
+}
+
+func (t *AgentTool) getExecutor() tool.AgentExecutor {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.executor
 }
 
 // PreparePermission prepares a permission request with agent metadata
@@ -58,12 +68,13 @@ func (t *AgentTool) PreparePermission(ctx context.Context, params map[string]any
 	requestModel := tool.GetString(params, "model")
 
 	// Check if executor is configured
-	if t.executor == nil {
+	executor := t.getExecutor()
+	if executor == nil {
 		return nil, fmt.Errorf("agent executor not configured")
 	}
 
 	// Get agent config
-	config, ok := t.executor.GetAgentConfig(agentType)
+	config, ok := executor.GetAgentConfig(agentType)
 	if !ok {
 		return nil, fmt.Errorf("unknown agent type: %s", agentType)
 	}
@@ -74,7 +85,7 @@ func (t *AgentTool) PreparePermission(ctx context.Context, params map[string]any
 		effectiveModel = config.Model
 	}
 	if effectiveModel == "" {
-		effectiveModel = t.executor.GetParentModelID()
+		effectiveModel = executor.GetParentModelID()
 	}
 	if effectiveModel == "" {
 		effectiveModel = "claude-sonnet-4-20250514" // fallback
@@ -143,7 +154,6 @@ func (t *AgentTool) execute(ctx context.Context, params map[string]any, cwd stri
 	model := tool.GetString(params, "model")
 	mode := tool.GetString(params, "mode")
 	resumeID := tool.GetString(params, "resume")
-	isolation := tool.GetString(params, "isolation")
 
 	var onActivity tool.ActivityFunc
 	if cb, ok := params["_onActivity"].(tool.ActivityFunc); ok {
@@ -157,7 +167,8 @@ func (t *AgentTool) execute(ctx context.Context, params map[string]any, cwd stri
 	maxSteps := tool.GetInt(params, "max_steps", 0)
 
 	// Check executor
-	if t.executor == nil {
+	executor := t.getExecutor()
+	if executor == nil {
 		return toolresult.NewErrorResult(t.Name(), "agent executor not configured")
 	}
 
@@ -173,14 +184,13 @@ func (t *AgentTool) execute(ctx context.Context, params map[string]any, cwd stri
 		MaxSteps:    maxSteps,
 		Mode:        mode,
 		ResumeID:    resumeID,
-		Isolation:   isolation,
 		OnActivity:  onActivity,
 		OnQuestion:  onQuestion,
 	}
 
 	// Handle background execution
 	if runBackground {
-		taskInfo, err := t.executor.RunBackground(req)
+		taskInfo, err := executor.RunBackground(req)
 		if err != nil {
 			return toolresult.NewErrorResult(t.Name(), fmt.Sprintf("failed to start background agent: %v", err))
 		}
@@ -210,7 +220,7 @@ func (t *AgentTool) execute(ctx context.Context, params map[string]any, cwd stri
 	}
 
 	// Foreground execution
-	result, err := t.executor.Run(ctx, req)
+	result, err := executor.Run(ctx, req)
 	if err != nil {
 		return toolresult.NewErrorResult(t.Name(), fmt.Sprintf("agent execution failed: %v", err))
 	}

--- a/internal/tool/agent/sendmessage.go
+++ b/internal/tool/agent/sendmessage.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/genai-io/san/internal/task"
@@ -14,6 +15,7 @@ import (
 // SendMessageTool sends a follow-up message to an existing worker.
 // Running workers do not support live injection yet.
 type SendMessageTool struct {
+	mu       sync.RWMutex
 	executor tool.AgentExecutor
 }
 
@@ -29,7 +31,15 @@ func (t *SendMessageTool) Icon() string             { return tool.IconAgent }
 func (t *SendMessageTool) RequiresPermission() bool { return true }
 
 func (t *SendMessageTool) SetExecutor(executor tool.AgentExecutor) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.executor = executor
+}
+
+func (t *SendMessageTool) getExecutor() tool.AgentExecutor {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.executor
 }
 
 func (t *SendMessageTool) PreparePermission(ctx context.Context, params map[string]any, cwd string) (*perm.PermissionRequest, error) {
@@ -38,7 +48,8 @@ func (t *SendMessageTool) PreparePermission(ctx context.Context, params map[stri
 	if err != nil {
 		return nil, err
 	}
-	if t.executor == nil {
+	executor := t.getExecutor()
+	if executor == nil {
 		return nil, fmt.Errorf("agent executor not configured")
 	}
 
@@ -52,7 +63,7 @@ func (t *SendMessageTool) PreparePermission(ctx context.Context, params map[stri
 		}
 	}
 
-	config, ok := t.executor.GetAgentConfig(target.agentType)
+	config, ok := executor.GetAgentConfig(target.agentType)
 	if !ok {
 		return nil, fmt.Errorf("unknown agent type: %s", target.agentType)
 	}
@@ -68,7 +79,7 @@ func (t *SendMessageTool) PreparePermission(ctx context.Context, params map[stri
 		effectiveModel = config.Model
 	}
 	if effectiveModel == "" {
-		effectiveModel = t.executor.GetParentModelID()
+		effectiveModel = executor.GetParentModelID()
 	}
 	if effectiveModel == "" {
 		effectiveModel = "claude-sonnet-4-20250514"
@@ -118,7 +129,8 @@ func (t *SendMessageTool) execute(ctx context.Context, params map[string]any, cw
 	}
 	ctx = tool.WithAgentDepth(ctx, currentDepth+1)
 
-	if t.executor == nil {
+	executor := t.getExecutor()
+	if executor == nil {
 		return toolresult.NewErrorResult(t.Name(), "agent executor not configured")
 	}
 
@@ -174,13 +186,12 @@ func (t *SendMessageTool) execute(ctx context.Context, params map[string]any, cw
 		MaxSteps:    tool.GetInt(normalized, "max_steps", 0),
 		Mode:        tool.GetString(normalized, "mode"),
 		ResumeID:    target.agentID,
-		Isolation:   tool.GetString(normalized, "isolation"),
 		OnActivity:  onActivity,
 		OnQuestion:  onQuestion,
 	}
 
 	if req.Background {
-		taskInfo, err := t.executor.RunBackground(req)
+		taskInfo, err := executor.RunBackground(req)
 		if err != nil {
 			return toolresult.NewErrorResult(t.Name(), fmt.Sprintf("failed to send background message to agent: %v", err))
 		}
@@ -209,7 +220,7 @@ func (t *SendMessageTool) execute(ctx context.Context, params map[string]any, cw
 		}
 	}
 
-	result, err := t.executor.Run(ctx, req)
+	result, err := executor.Run(ctx, req)
 	if err != nil {
 		return toolresult.NewErrorResult(t.Name(), fmt.Sprintf("agent message failed: %v", err))
 	}

--- a/internal/tool/schema_agent.go
+++ b/internal/tool/schema_agent.go
@@ -25,7 +25,7 @@ func agentToolSchema(directory string) core.ToolSchema {
 	sb.WriteString("Use direct tools instead for simple reads, narrow searches, or tasks that only need 1-2 tool calls.\n\n")
 	sb.WriteString("Usage notes:\n")
 	sb.WriteString("- Always include a short description (3-5 words) summarizing what the agent will do\n")
-	sb.WriteString("- Launch multiple agents concurrently whenever possible; to do that, use a single message with multiple Agent calls\n")
+	sb.WriteString("- Parallelize only read-only code-reviewer agents in explore mode; all subagents share the current working directory, so run writing agents sequentially\n")
 	sb.WriteString("- Each agent has isolated context; summarize important results back to the user yourself\n")
 	sb.WriteString("- Use foreground by default when you need the result before continuing\n")
 	sb.WriteString("- Use run_in_background only for genuinely independent work; you will be notified when it completes\n")
@@ -63,8 +63,7 @@ var agentToolParameters = map[string]any{
 		},
 		"model": map[string]any{
 			"type":        "string",
-			"description": "Optional model override. If omitted, inherits from parent conversation.",
-			"enum":        []string{"sonnet", "opus", "haiku"},
+			"description": "Optional model override. Omit unless a different model was explicitly requested; use vendor/model for cross-provider routing.",
 		},
 		"max_steps": map[string]any{
 			"type":        "number",
@@ -77,12 +76,7 @@ var agentToolParameters = map[string]any{
 		"mode": map[string]any{
 			"type":        "string",
 			"description": "Permission mode for spawned agent.",
-			"enum":        []string{"explore", "edit", "default"},
-		},
-		"isolation": map[string]any{
-			"type":        "string",
-			"description": "Isolation mode for the agent.",
-			"enum":        []string{"worktree"},
+			"enum":        []string{"explore", "acceptEdits", "default"},
 		},
 	},
 	"required": []string{"description", "prompt"},
@@ -133,8 +127,7 @@ Notes:
 			},
 			"model": map[string]any{
 				"type":        "string",
-				"description": "Optional model override. If omitted, inherits from parent conversation.",
-				"enum":        []string{"sonnet", "opus", "haiku"},
+				"description": "Optional model override. Omit unless a different model was explicitly requested; use vendor/model for cross-provider routing.",
 			},
 			"max_steps": map[string]any{
 				"type":        "number",
@@ -143,12 +136,7 @@ Notes:
 			"mode": map[string]any{
 				"type":        "string",
 				"description": "Permission mode for the resumed worker.",
-				"enum":        []string{"explore", "edit", "default"},
-			},
-			"isolation": map[string]any{
-				"type":        "string",
-				"description": "Isolation mode for the resumed worker.",
-				"enum":        []string{"worktree"},
+				"enum":        []string{"explore", "acceptEdits", "default"},
 			},
 		},
 		"required": []string{"prompt", "description"},

--- a/internal/tool/schema_agent_test.go
+++ b/internal/tool/schema_agent_test.go
@@ -32,6 +32,27 @@ func TestAgentToolSchemaOmitsDirectoryWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestSubagentSchemasDoNotExposeWorktreeIsolation(t *testing.T) {
+	for _, schema := range []core.ToolSchema{agentToolSchema(""), sendMessageToolSchema} {
+		params := schema.Parameters.(map[string]any)
+		properties := params["properties"].(map[string]any)
+		if _, ok := properties["isolation"]; ok {
+			t.Fatalf("%s schema must not let subagents create worktrees", schema.Name)
+		}
+	}
+}
+
+func TestSubagentSchemasDoNotSuggestProviderSpecificModelAliases(t *testing.T) {
+	for _, schema := range []core.ToolSchema{agentToolSchema(""), sendMessageToolSchema} {
+		params := schema.Parameters.(map[string]any)
+		properties := params["properties"].(map[string]any)
+		model := properties["model"].(map[string]any)
+		if _, ok := model["enum"]; ok {
+			t.Fatalf("%s model override must not suggest provider-specific aliases", schema.Name)
+		}
+	}
+}
+
 func TestGetToolSchemasUsesDirectoryGetter(t *testing.T) {
 	schemas := GetToolSchemasWith(SchemaOptions{
 		AgentDirectory: func() string {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -1,6 +1,5 @@
-// Package worktree provides git worktree creation and management.
-// Used by both the standalone EnterWorktree tool (main conversation)
-// and the Agent tool's isolation mode (subagents).
+// Package worktree provides git worktree creation and management for the
+// main conversation's EnterWorktree and ExitWorktree tools.
 package worktree
 
 import (
@@ -24,7 +23,7 @@ type Result struct {
 	Branch string // branch name (empty for detached HEAD)
 }
 
-// Create creates a git worktree under baseCwd/.git/agent-worktrees/<slug>.
+// Create creates a git worktree under the repository's common git directory.
 // If slug is empty, a random short ID is used.
 // Returns the worktree path and a cleanup function that removes it.
 func Create(baseCwd, slug string) (*Result, func(), error) {
@@ -41,7 +40,11 @@ func Create(baseCwd, slug string) (*Result, func(), error) {
 		return nil, nil, fmt.Errorf("invalid worktree slug: must not contain path separators or '..'")
 	}
 
-	worktreePath := filepath.Join(baseCwd, ".git", worktreeDir, slug)
+	commonDir, err := gitCommonDir(baseCwd)
+	if err != nil {
+		return nil, nil, err
+	}
+	worktreePath := filepath.Join(commonDir, worktreeDir, slug)
 
 	cmd := exec.Command("git", "worktree", "add", "--detach", worktreePath)
 	cmd.Dir = baseCwd
@@ -59,6 +62,20 @@ func Create(baseCwd, slug string) (*Result, func(), error) {
 	fireWorktreeCreated(slug, worktreePath)
 
 	return &Result{Path: worktreePath}, cleanup, nil
+}
+
+func gitCommonDir(baseCwd string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
+	cmd.Dir = baseCwd
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("resolve git common dir: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	dir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(dir) {
+		dir = filepath.Join(baseCwd, dir)
+	}
+	return filepath.Clean(dir), nil
 }
 
 // Remove force-removes a git worktree.

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -75,8 +75,29 @@ func TestCreateRequiresGitRepo(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected Create() to fail outside a git repo")
 	}
-	if !strings.Contains(err.Error(), "git worktree add failed") {
+	if !strings.Contains(err.Error(), "resolve git common dir") {
 		t.Fatalf("expected git worktree failure, got %v", err)
+	}
+}
+
+func TestCreateFromLinkedWorktree(t *testing.T) {
+	repo := makeRepo(t)
+	linked := filepath.Join(t.TempDir(), "linked")
+	runGit(t, repo, "worktree", "add", "--detach", linked)
+
+	result, cleanup, err := Create(linked, "from-linked")
+	if err != nil {
+		t.Fatalf("Create() error: %v", err)
+	}
+	defer cleanup()
+
+	commonDir := runGit(t, linked, "rev-parse", "--git-common-dir")
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(linked, commonDir)
+	}
+	wantPath := filepath.Join(filepath.Clean(commonDir), worktreeDir, "from-linked")
+	if result.Path != wantPath {
+		t.Fatalf("worktree path = %q, want %q", result.Path, wantPath)
 	}
 }
 


### PR DESCRIPTION
## Problem

Subagents launched against a ChatGPT subscription (Codex) provider failed with:

```
agent execution failed: LLM completion failed: infer:
POST "https://chatgpt.com/backend-api/codex/responses": 400 Bad Request
```

It's not auth (that would be 401/403) — a subagent inherits the parent's
provider instance and its OAuth token. The cause is request shape.

## Root cause

A subagent builds its client with `llm.NewClient(provider, modelID, 0)`
(`subagent/executor.go`) and nothing ever calls `SetThinkingEffort` on it, so
`ThinkingEffort == ""`. The OpenAI request builder only sends a `reasoning`
field when the effort is non-empty (`openai/client.go`). Codex models are
reasoning-only, and the `/codex/responses` endpoint rejects a reasoning-less
request with **400**. The main agent works because it sets
`EffectiveThinkingEffort()` on its client (`app/agent.go`).

## Fix

Propagate the parent's effective thinking effort to **same-provider** subagents:

- `resolveModel` now also returns `onParentProvider` (true for inherit/alias,
  false for a routed vendor).
- `buildAgent` applies the parent effort only when the run stays on the parent's
  provider — a routed subagent keeps the empty default, since the parent's
  effort may be invalid for a different vendor's model.
- `SetParentThinkingEffort` is wired from the TUI (`app/agent.go`).

Model-resolution priority is unchanged: `req.Model` → `config.Model` → inherit
the parent session's model.

## Tests

`resolveModel` tests now assert the `onParentProvider` flag (inherit/alias →
true, routed vendor → false). `go build ./...`, `go vet`, and the
`internal/subagent` / `internal/llm` / `internal/app` suites pass.
