### PR TITLE
feat: add json version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ BINARY := san
 BINDIR := bin
 SRCDIR := ./cmd/san
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
-LDFLAGS := -ldflags "-s -w -X main.version=$(VERSION)"
+BUILDTIME := $(shell date -u +%Y-%m-%d)
+COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+LDFLAGS := -ldflags "-s -w -X main.version=$(VERSION) -X main.buildTime=$(BUILDTIME) -X main.commit=$(COMMIT)"
 
 # Disable cgo so binaries are statically linked, with no glibc version
 # dependency that would break on older distros.

--- a/cmd/san/main.go
+++ b/cmd/san/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/joho/godotenv"
@@ -33,6 +35,13 @@ import (
 
 var version = "1.21.6"
 
+// buildTime and commit are set at build time via -X ldflags.
+// When built directly with go build (without ldflags), they remain empty.
+var (
+	buildTime string
+	commit    string
+)
+
 // cliOpts holds all CLI flag values in one place.
 var cliOpts struct {
 	print  string // -p/--print: non-interactive print mode
@@ -58,6 +67,9 @@ func init() {
 	rootCmd.Flags().BoolVarP(&cliOpts.resume, "resume", "r", false, "Select and resume a previous session")
 	rootCmd.PersistentFlags().StringVar(&cliOpts.pluginDir, "plugin-dir", "", "Load plugins from a specific directory")
 	rootCmd.Flags().StringVar(&cliOpts.persona, "persona", "", "Activate a persona on startup")
+
+	// Register flags on version subcommand
+	versionCmd.Flags().Bool("json", false, "Output version information in JSON format")
 
 	// Register subcommands
 	rootCmd.AddCommand(versionCmd)
@@ -151,9 +163,28 @@ func readStdin() string {
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Print the version number",
+	Short: "Print version and build information",
 	Run: func(cmd *cobra.Command, args []string) {
+		jsonOutput, _ := cmd.Flags().GetBool("json")
+
+		if jsonOutput {
+			info := map[string]string{
+				"version":    version,
+				"build_time": buildTime,
+				"go_version": runtime.Version(),
+				"commit":     commit,
+			}
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			enc.Encode(info)
+			return
+		}
+
 		fmt.Printf("san version %s\n", version)
+		if buildTime != "" {
+			fmt.Printf("build: %s\n", buildTime)
+		}
+		fmt.Printf("go:    %s\n", runtime.Version())
 	},
 }
 
@@ -211,7 +242,7 @@ Session:
   san --persona <name>       Activate a persona on startup
 
 Commands:
-  version      Print the version number
+  version      Print version and build information
   agent run    Run a headless agent
   update       Check for san updates and install if available
   help         Show this help message

--- a/tests/integration/cli/startup_test.go
+++ b/tests/integration/cli/startup_test.go
@@ -5,6 +5,7 @@
 package cli_test
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -50,8 +51,8 @@ func projectRoot(t *testing.T) string {
 	}
 }
 
-// TestVersionCommand verifies that "san version" prints the version string
-// and exits cleanly without requiring any provider configuration.
+// TestVersionCommand verifies that "san version" prints version and build
+// information and exits cleanly without requiring any provider configuration.
 func TestVersionCommand(t *testing.T) {
 	bin := buildBinary(t)
 
@@ -61,14 +62,61 @@ func TestVersionCommand(t *testing.T) {
 		t.Fatalf("san version exited with error: %v", err)
 	}
 
-	output := strings.TrimSpace(string(out))
-	if !strings.HasPrefix(output, "san version ") {
-		t.Errorf("expected output to start with 'san version ', got: %q", output)
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines of output, got %d:\n%s", len(lines), out)
 	}
-	// Version should not be empty after the prefix.
-	ver := strings.TrimPrefix(output, "san version ")
+
+	// First line: san version <ver>
+	first := strings.TrimSpace(lines[0])
+	if !strings.HasPrefix(first, "san version ") {
+		t.Errorf("expected first line to start with 'san version ', got: %q", first)
+	}
+	ver := strings.TrimPrefix(first, "san version ")
 	if ver == "" {
 		t.Error("version string is empty")
+	}
+
+	// There should be a "go:" line
+	foundGo := false
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "go:") {
+			foundGo = true
+			break
+		}
+	}
+	if !foundGo {
+		t.Errorf("expected output to contain a 'go:' line:\n%s", out)
+	}
+}
+
+// TestVersionCommandJSON verifies that "san version --json" outputs valid JSON
+// with the expected fields.
+func TestVersionCommandJSON(t *testing.T) {
+	bin := buildBinary(t)
+
+	cmd := exec.Command(bin, "version", "--json")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("san version --json exited with error: %v", err)
+	}
+
+	var info map[string]string
+	if err := json.Unmarshal(out, &info); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+
+	for _, key := range []string{"version", "build_time", "go_version", "commit"} {
+		if _, ok := info[key]; !ok {
+			t.Errorf("JSON output missing key %q", key)
+		}
+	}
+	// The hard-coded version (no ldflags) must be present
+	if info["version"] == "" {
+		t.Error("version field is empty")
+	}
+	if info["go_version"] == "" {
+		t.Error("go_version field is empty")
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing! Keep this concise. -->

## What & why

<!-- What does this change and what problem does it solve? -->

https://github.com/genai-io/san/issues/308

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Other:

## Testing

```bash
hchenxa@hchenxa-air san % make build
go build -ldflags "-s -w -X main.version=41ca218 -X main.buildTime=2026-07-18 -X main.commit=41ca218" -o bin/san ./cmd/san
hchenxa@hchenxa-air san % ./bin/san version
san version 41ca218
build: 2026-07-18
go:    go1.26.4
hchenxa@hchenxa-air san % ./bin/san version --json
{
  "build_time": "2026-07-18",
  "commit": "41ca218",
  "go_version": "go1.26.4",
  "version": "41ca218"
}
```

## Checklist

- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, …)
- [ ] All commits signed off (`git commit -s`) — certifies the [DCO](https://developercertificate.org)
- [ ] Tests pass locally
- [ ] Docs updated (if behavior or config changed)
- [ ] Read and follow the [Code of Conduct](CODE_OF_CONDUCT.md)
