### PR TITLE
fix(app): snapshot permission audit input before releasing the gate

### DIFF
--- a/internal/app/update_approval.go
+++ b/internal/app/update_approval.go
@@ -69,20 +69,35 @@ func (m *model) handlePermGateDecision(decision permissionDecision) tea.Cmd {
 			m.env.SessionPermissions.AllowTool(decision.Request.ToolName)
 		}
 	}
+	rec := m.services.Session.Recorder()
+	var auditRecord transcript.PermissionRecord
+	if rec != nil {
+		// Snapshot the request before releasing the permission gate. Agent tools
+		// add runtime callbacks to their input map as soon as the response wakes
+		// them; serializing that shared map afterward can otherwise race the
+		// write and crash the process with concurrent map iteration/write.
+		auditRecord = permissionDecisionRecord(req, decision, reason, m.env.SessionMode())
+	}
 	select {
 	case req.Response <- conv.PermGateResponse{Allow: decision.Approved, Reason: reason}:
 	default:
 	}
-	if rec := m.services.Session.Recorder(); rec != nil {
-		rec.RecordPermissionDecided(transcript.PermissionRecord{
-			RequestID: req.RequestID,
-			Tool:      req.ToolName, Input: marshalPermInput(req.Input),
-			Detail:   permDetail(decision.Request),
-			Decision: permDecisionFor(decision.Approved),
-			Source:   transcript.PermissionSourceUser,
-			Scope:    permScope(decision),
-			Reason:   reason, Mode: m.env.SessionMode(),
-		})
+	if rec != nil {
+		rec.RecordPermissionDecided(auditRecord)
 	}
 	return conv.PollPermGate(m.services.Agent.PermissionGate())
+}
+
+func permissionDecisionRecord(req *conv.PermGateRequest, decision permissionDecision, reason, mode string) transcript.PermissionRecord {
+	return transcript.PermissionRecord{
+		RequestID: req.RequestID,
+		Tool:      req.ToolName,
+		Input:     marshalPermInput(req.Input),
+		Detail:    permDetail(decision.Request),
+		Decision:  permDecisionFor(decision.Approved),
+		Source:    transcript.PermissionSourceUser,
+		Scope:     permScope(decision),
+		Reason:    reason,
+		Mode:      mode,
+	}
 }

--- a/internal/app/update_approval.go
+++ b/internal/app/update_approval.go
@@ -69,26 +69,22 @@ func (m *model) handlePermGateDecision(decision permissionDecision) tea.Cmd {
 			m.env.SessionPermissions.AllowTool(decision.Request.ToolName)
 		}
 	}
-	rec := m.services.Session.Recorder()
-	var auditRecord transcript.PermissionRecord
-	if rec != nil {
-		// Snapshot the request before releasing the permission gate. Agent tools
-		// add runtime callbacks to their input map as soon as the response wakes
-		// them; serializing that shared map afterward can otherwise race the
-		// write and crash the process with concurrent map iteration/write.
-		auditRecord = permissionDecisionRecord(req, decision, reason, m.env.SessionMode())
-	}
+	// Snapshot the request before releasing the permission gate. Agent tools
+	// add runtime callbacks to their input map as soon as the response wakes
+	// them; serializing that shared map afterward can otherwise race the
+	// write and crash the process with concurrent map iteration/write.
+	permRecord := permDecisionRecord(req, decision, reason, m.env.SessionMode())
 	select {
 	case req.Response <- conv.PermGateResponse{Allow: decision.Approved, Reason: reason}:
 	default:
 	}
-	if rec != nil {
-		rec.RecordPermissionDecided(auditRecord)
+	if rec := m.services.Session.Recorder(); rec != nil {
+		rec.RecordPermissionDecided(permRecord)
 	}
 	return conv.PollPermGate(m.services.Agent.PermissionGate())
 }
 
-func permissionDecisionRecord(req *conv.PermGateRequest, decision permissionDecision, reason, mode string) transcript.PermissionRecord {
+func permDecisionRecord(req *conv.PermGateRequest, decision permissionDecision, reason, mode string) transcript.PermissionRecord {
 	return transcript.PermissionRecord{
 		RequestID: req.RequestID,
 		Tool:      req.ToolName,

--- a/internal/app/update_approval_test.go
+++ b/internal/app/update_approval_test.go
@@ -1,0 +1,31 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/genai-io/san/internal/app/conv"
+	"github.com/genai-io/san/internal/tool/perm"
+)
+
+func TestPermissionDecisionRecordSnapshotsInput(t *testing.T) {
+	input := map[string]any{"prompt": "inspect the repository"}
+	req := &conv.PermGateRequest{
+		RequestID: "permission-1",
+		ToolName:  "Agent",
+		Input:     input,
+	}
+
+	record := permissionDecisionRecord(req, permissionDecision{
+		Approved: true,
+		Request:  &perm.PermissionRequest{ToolName: "Agent"},
+	}, "user approved", "normal")
+
+	// Agent execution decorates this same input map after the permission gate
+	// opens. The audit record must already own serialized bytes by then.
+	input["_onActivity"] = func() {}
+	input["prompt"] = "changed after approval"
+
+	if got, want := string(record.Input), `{"prompt":"inspect the repository"}`; got != want {
+		t.Fatalf("permission input snapshot = %s, want %s", got, want)
+	}
+}

--- a/internal/app/update_approval_test.go
+++ b/internal/app/update_approval_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/genai-io/san/internal/tool/perm"
 )
 
-func TestPermissionDecisionRecordSnapshotsInput(t *testing.T) {
+func TestPermDecisionRecordSnapshotsInput(t *testing.T) {
 	input := map[string]any{"prompt": "inspect the repository"}
 	req := &conv.PermGateRequest{
 		RequestID: "permission-1",
@@ -15,13 +15,13 @@ func TestPermissionDecisionRecordSnapshotsInput(t *testing.T) {
 		Input:     input,
 	}
 
-	record := permissionDecisionRecord(req, permissionDecision{
+	record := permDecisionRecord(req, permissionDecision{
 		Approved: true,
 		Request:  &perm.PermissionRequest{ToolName: "Agent"},
 	}, "user approved", "normal")
 
 	// Agent execution decorates this same input map after the permission gate
-	// opens. The audit record must already own serialized bytes by then.
+	// opens. The permission record must already own serialized bytes by then.
 	input["_onActivity"] = func() {}
 	input["prompt"] = "changed after approval"
 


### PR DESCRIPTION
Splits the approval-race crash fix out of #327 (whose version/CHANGELOG/bash-prompt changes already landed via #328) so it can merge on its own.

Agent tools decorate their shared input map with runtime callbacks the moment the permission response wakes them. Serializing that map after the gate is released could race the write and crash the process with `concurrent map iteration and map write`. This snapshots the audit record before sending the response, so the recorder already owns serialized bytes.

Closes #327.