### PR TITLE
refactor(llm): unify the provider response type onto core.InferResponse

### DIFF
--- a/internal/app/agent_restart_test.go
+++ b/internal/app/agent_restart_test.go
@@ -24,7 +24,7 @@ func (p *restartStubProvider) Stream(_ context.Context, opts llm.CompletionOptio
 		Type: llm.ChunkTypeDone,
 		Response: &llm.CompletionResponse{
 			Content:    "ok",
-			StopReason: string(core.StopEndTurn),
+			StopReason: core.StopEndTurn,
 		},
 	}
 	close(ch)

--- a/internal/core/llm.go
+++ b/internal/core/llm.go
@@ -1,6 +1,10 @@
 package core
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"strings"
+)
 
 // StopReason describes why the LLM stopped generating.
 type StopReason string
@@ -52,6 +56,29 @@ type InferResponse struct {
 // whenever prompt caching is active.
 func (r InferResponse) TotalInputTokens() int {
 	return r.InputTokens + r.CacheCreationInputTokens + r.CacheReadInputTokens
+}
+
+// Logging accessors — satisfy the duck-typed responseLoggable interface in the
+// log package so log depends on neither core nor llm (foundation-layer
+// contract). Defined here because llm.CompletionResponse aliases this type.
+func (r InferResponse) LogStopReason() string { return string(r.StopReason) }
+func (r InferResponse) LogContent() string    { return r.Content }
+func (r InferResponse) LogThinking() string   { return r.Thinking }
+func (r InferResponse) LogInputTokens() int   { return r.InputTokens }
+func (r InferResponse) LogOutputTokens() int  { return r.OutputTokens }
+func (r InferResponse) LogRawToolCalls() any  { return r.ToolCalls }
+func (r InferResponse) LogRawUsage() any      { return r.Usage }
+
+func (r InferResponse) LogToolCallSummary(escaper func(string) string) string {
+	if len(r.ToolCalls) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "    ToolCalls(%d):\n", len(r.ToolCalls))
+	for _, tc := range r.ToolCalls {
+		fmt.Fprintf(&sb, "      [%s] %s(%s)\n", tc.ID, tc.Name, escaper(tc.Input))
+	}
+	return sb.String()
 }
 
 // Chunk is one piece of a streaming LLM response.

--- a/internal/llm/anthropic/client.go
+++ b/internal/llm/anthropic/client.go
@@ -217,7 +217,6 @@ func (c *Client) Stream(ctx context.Context, opts llm.CompletionOptions) <-chan 
 					currentToolID = block.ContentBlock.ID
 					currentToolName = block.ContentBlock.Name
 					currentToolInput.Reset()
-					state.EmitToolStart(ctx, ch, currentToolID, currentToolName)
 				}
 
 			case "content_block_delta":
@@ -232,7 +231,6 @@ func (c *Client) Stream(ctx context.Context, opts llm.CompletionOptions) <-chan 
 						state.Response.ThinkingSignature += delta.Delta.Signature
 					}
 				case "input_json_delta":
-					state.EmitToolInput(ctx, ch, currentToolID, delta.Delta.PartialJSON)
 					currentToolInput.WriteString(delta.Delta.PartialJSON)
 				}
 
@@ -251,7 +249,7 @@ func (c *Client) Stream(ctx context.Context, opts llm.CompletionOptions) <-chan 
 
 			case "message_delta":
 				msgDelta := event.AsMessageDelta()
-				state.Response.StopReason = string(msgDelta.Delta.StopReason)
+				state.Response.StopReason = core.StopReason(msgDelta.Delta.StopReason)
 				// Anthropic populates only OutputTokens here; some Anthropic-compatible
 				// providers (e.g. SenseNova) emit InputTokens in message_delta rather
 				// than message_start. UpdateUsage is a no-op when the value is 0, so

--- a/internal/llm/google/client.go
+++ b/internal/llm/google/client.go
@@ -233,9 +233,6 @@ func (c *Client) Stream(ctx context.Context, opts llm.CompletionOptions) <-chan 
 						fc := part.FunctionCall
 						argsJSON, _ := json.Marshal(fc.Args)
 
-						state.EmitToolStart(ctx, ch, fc.ID, fc.Name)
-						state.EmitToolInput(ctx, ch, fc.ID, string(argsJSON))
-
 						state.Response.ToolCalls = append(state.Response.ToolCalls, core.ToolCall{
 							ID:               fc.ID,
 							Name:             fc.Name,
@@ -249,11 +246,11 @@ func (c *Client) Stream(ctx context.Context, opts llm.CompletionOptions) <-chan 
 				if candidate.FinishReason != "" {
 					switch candidate.FinishReason {
 					case "STOP":
-						state.Response.StopReason = "end_turn"
+						state.Response.StopReason = core.StopEndTurn
 					case "MAX_TOKENS":
-						state.Response.StopReason = "max_tokens"
+						state.Response.StopReason = core.StopMaxTokens
 					default:
-						state.Response.StopReason = string(candidate.FinishReason)
+						state.Response.StopReason = core.StopReason(candidate.FinishReason)
 					}
 				}
 			}

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -115,7 +115,7 @@ func (l *Client) Infer(ctx context.Context, req core.InferRequest) (<-chan core.
 					return
 				}
 			case ChunkTypeDone:
-				if !send(core.Chunk{Done: true, Response: toInferResponse(sc.Response)}) {
+				if !send(core.Chunk{Done: true, Response: sc.Response}) {
 					return
 				}
 			case ChunkTypeError:
@@ -383,20 +383,4 @@ func toProviderMessages(msgs []core.Message) []core.Message {
 		}
 	}
 	return out
-}
-
-// toInferResponse converts a CompletionResponse to an InferResponse.
-func toInferResponse(r *CompletionResponse) *core.InferResponse {
-	if r == nil {
-		return nil
-	}
-	return &core.InferResponse{
-		Content:           r.Content,
-		Thinking:          r.Thinking,
-		ThinkingSignature: r.ThinkingSignature,
-		Reasoning:         r.Reasoning,
-		ToolCalls:         r.ToolCalls,
-		StopReason:        core.StopReason(r.StopReason),
-		Usage:             r.Usage,
-	}
 }

--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -220,14 +220,12 @@ func (c *Client) streamResponses(ctx context.Context, opts llm.CompletionOptions
 						ID:   funcCall.CallID,
 						Name: funcCall.Name,
 					}
-					state.EmitToolStart(ctx, ch, funcCall.CallID, funcCall.Name)
 				}
 
 			case "response.function_call_arguments.delta":
 				delta := event.AsResponseFunctionCallArgumentsDelta()
 				if tc, ok := toolCalls[delta.ItemID]; ok {
 					tc.Input += delta.Delta
-					state.EmitToolInput(ctx, ch, tc.ID, delta.Delta)
 				}
 
 			case "response.completed":
@@ -252,12 +250,12 @@ func (c *Client) streamResponses(ctx context.Context, opts llm.CompletionOptions
 				switch resp.Status {
 				case responses.ResponseStatusCompleted:
 					if hasToolCalls {
-						state.Response.StopReason = "tool_use"
+						state.Response.StopReason = core.StopToolUse
 					} else {
-						state.Response.StopReason = "end_turn"
+						state.Response.StopReason = core.StopEndTurn
 					}
 				case responses.ResponseStatusIncomplete:
-					state.Response.StopReason = "max_tokens"
+					state.Response.StopReason = core.StopMaxTokens
 				case responses.ResponseStatusFailed:
 					errMsg := "response failed"
 					if resp.Error.Message != "" {
@@ -266,7 +264,7 @@ func (c *Client) streamResponses(ctx context.Context, opts llm.CompletionOptions
 					state.Fail(ctx, ch, fmt.Errorf("responses API failed: %s", errMsg))
 					return
 				default:
-					state.Response.StopReason = string(resp.Status)
+					state.Response.StopReason = core.StopReason(resp.Status)
 				}
 
 			case "error":

--- a/internal/llm/openaicompat/convert.go
+++ b/internal/llm/openaicompat/convert.go
@@ -213,16 +213,16 @@ func ConvertTools(tools []llm.ToolSchema) []openai.ChatCompletionToolUnionParam 
 //	"tool_calls" → "tool_use"
 //	"length"     → "max_tokens"
 //	anything else is returned as-is
-func MapFinishReason(reason string) string {
+func MapFinishReason(reason string) core.StopReason {
 	switch reason {
 	case "stop":
-		return "end_turn"
+		return core.StopEndTurn
 	case "tool_calls":
-		return "tool_use"
+		return core.StopToolUse
 	case "length":
-		return "max_tokens"
+		return core.StopMaxTokens
 	default:
-		return reason
+		return core.StopReason(reason)
 	}
 }
 

--- a/internal/llm/openaicompat/stream.go
+++ b/internal/llm/openaicompat/stream.go
@@ -76,11 +76,9 @@ func StreamChatCompletions(ctx context.Context, cfg ChatStreamConfig) <-chan llm
 					idx := int(tc.Index)
 					if _, exists := toolCalls[idx]; !exists {
 						toolCalls[idx] = &core.ToolCall{ID: tc.ID, Name: tc.Function.Name}
-						state.EmitToolStart(ctx, ch, tc.ID, tc.Function.Name)
 					}
 					if tc.Function.Arguments != "" {
 						toolCalls[idx].Input += tc.Function.Arguments
-						state.EmitToolInput(ctx, ch, toolCalls[idx].ID, tc.Function.Arguments)
 					}
 				}
 

--- a/internal/llm/stream/stream.go
+++ b/internal/llm/stream/stream.go
@@ -70,27 +70,6 @@ func (s *State) EmitThinking(ctx context.Context, ch chan<- llm.StreamChunk, tex
 	s.thinkingBuf.WriteString(text)
 }
 
-// EmitToolStart forwards a tool start event.
-func (s *State) EmitToolStart(ctx context.Context, ch chan<- llm.StreamChunk, toolID, toolName string) {
-	send(ctx, ch, llm.StreamChunk{
-		Type:     llm.ChunkTypeToolStart,
-		ToolID:   toolID,
-		ToolName: toolName,
-	})
-}
-
-// EmitToolInput forwards a tool input delta.
-func (s *State) EmitToolInput(ctx context.Context, ch chan<- llm.StreamChunk, toolID, text string) {
-	if text == "" {
-		return
-	}
-	send(ctx, ch, llm.StreamChunk{
-		Type:   llm.ChunkTypeToolInput,
-		ToolID: toolID,
-		Text:   text,
-	})
-}
-
 // UpdateUsage updates the tracked usage values when the provider emits them.
 func (s *State) UpdateUsage(inputTokens, outputTokens int) {
 	if inputTokens > 0 {
@@ -128,7 +107,7 @@ func (s *State) AddToolCallsByKey(toolCalls map[string]*core.ToolCall) {
 // EnsureToolUseStopReason infers tool_use when tool calls exist but no stop reason was set.
 func (s *State) EnsureToolUseStopReason() {
 	if len(s.Response.ToolCalls) > 0 && s.Response.StopReason == "" {
-		s.Response.StopReason = "tool_use"
+		s.Response.StopReason = core.StopToolUse
 	}
 }
 

--- a/internal/llm/stream/stream_test.go
+++ b/internal/llm/stream/stream_test.go
@@ -15,22 +15,15 @@ func TestStateEmitsAndAccumulatesChunks(t *testing.T) {
 
 	state.EmitText(context.Background(), ch, "hello")
 	state.EmitThinking(context.Background(), ch, "thinking")
-	state.EmitToolStart(context.Background(), ch, "tool-1", "Read")
-	state.EmitToolInput(context.Background(), ch, "tool-1", `{"path":"a.go"}`)
 
-	// Verify streaming chunks emitted in order
-	msgs := []llm.StreamChunk{<-ch, <-ch, <-ch, <-ch}
+	// Verify streaming chunks emitted in order. Tool-call deltas are not
+	// streamed as chunks — completed calls ride in the final Response.
+	msgs := []llm.StreamChunk{<-ch, <-ch}
 	if msgs[0].Type != llm.ChunkTypeText || msgs[0].Text != "hello" {
 		t.Fatalf("unexpected text chunk: %#v", msgs[0])
 	}
 	if msgs[1].Type != llm.ChunkTypeThinking || msgs[1].Text != "thinking" {
 		t.Fatalf("unexpected thinking chunk: %#v", msgs[1])
-	}
-	if msgs[2].Type != llm.ChunkTypeToolStart || msgs[2].ToolID != "tool-1" || msgs[2].ToolName != "Read" {
-		t.Fatalf("unexpected tool start chunk: %#v", msgs[2])
-	}
-	if msgs[3].Type != llm.ChunkTypeToolInput || msgs[3].ToolID != "tool-1" || msgs[3].Text != `{"path":"a.go"}` {
-		t.Fatalf("unexpected tool input chunk: %#v", msgs[3])
 	}
 
 	// Content and thinking accumulate in internal buffers and flush on Finish.

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -241,38 +241,12 @@ type CompletionOptions struct {
 
 // --- Completion Response Types ---
 
-// CompletionResponse represents a completion response from an LLM provider.
-type CompletionResponse struct {
-	Content           string               `json:"content,omitempty"`
-	Thinking          string               `json:"thinking,omitempty"`
-	ThinkingSignature string               `json:"thinking_signature,omitempty"`
-	Reasoning         []core.ReasoningItem `json:"reasoning,omitempty"`
-	ToolCalls         []core.ToolCall      `json:"tool_calls,omitempty"`
-	StopReason        string               `json:"stop_reason"`
-	Usage             Usage                `json:"usage"`
-}
-
-// Logging accessors — satisfy duck-typed interfaces in the log package so
-// log does not need to import llm (foundation-layer contract).
-func (r CompletionResponse) LogStopReason() string { return r.StopReason }
-func (r CompletionResponse) LogContent() string    { return r.Content }
-func (r CompletionResponse) LogThinking() string   { return r.Thinking }
-func (r CompletionResponse) LogInputTokens() int   { return r.Usage.InputTokens }
-func (r CompletionResponse) LogOutputTokens() int  { return r.Usage.OutputTokens }
-func (r CompletionResponse) LogRawToolCalls() any  { return r.ToolCalls }
-func (r CompletionResponse) LogRawUsage() any      { return r.Usage }
-
-func (r CompletionResponse) LogToolCallSummary(escaper func(string) string) string {
-	if len(r.ToolCalls) == 0 {
-		return ""
-	}
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "    ToolCalls(%d):\n", len(r.ToolCalls))
-	for _, tc := range r.ToolCalls {
-		fmt.Fprintf(&sb, "      [%s] %s(%s)\n", tc.ID, tc.Name, escaper(tc.Input))
-	}
-	return sb.String()
-}
+// CompletionResponse is the provider-facing completion result. It aliases
+// core.InferResponse: the provider streaming layer and the agent loop exchange
+// one response type, so there is no field-for-field conversion between them and
+// no way for the two to drift. The logging accessors (LogStopReason, …) live on
+// core.InferResponse.
+type CompletionResponse = core.InferResponse
 
 // Usage is an alias for core.Usage — token accounting is defined once in the
 // foundation layer so the provider response and core.InferResponse share it.
@@ -284,20 +258,18 @@ type Usage = core.Usage
 type ChunkType string
 
 const (
-	ChunkTypeText      ChunkType = "text"
-	ChunkTypeThinking  ChunkType = "thinking"
-	ChunkTypeToolStart ChunkType = "tool_start"
-	ChunkTypeToolInput ChunkType = "tool_input"
-	ChunkTypeDone      ChunkType = "done"
-	ChunkTypeError     ChunkType = "error"
+	ChunkTypeText     ChunkType = "text"
+	ChunkTypeThinking ChunkType = "thinking"
+	ChunkTypeDone     ChunkType = "done"
+	ChunkTypeError    ChunkType = "error"
 )
 
 // StreamChunk represents a chunk in a streaming response from a provider.
+// Tool-call deltas are not streamed as chunks; completed tool calls ride in the
+// final Response on the done chunk.
 type StreamChunk struct {
 	Type     ChunkType
-	Text     string              // For text chunks
-	ToolID   string              // For tool_start chunks
-	ToolName string              // For tool_start chunks
+	Text     string              // For text/thinking chunks
 	Response *CompletionResponse // For done chunks
 	Error    error               // For error chunks
 }
@@ -338,8 +310,6 @@ func Complete(ctx context.Context, provider Provider, opts CompletionOptions) (C
 		switch chunk.Type {
 		case ChunkTypeText:
 			response.Content += chunk.Text
-		case ChunkTypeToolStart, ChunkTypeToolInput:
-			// Tool calls are accumulated in the done chunk
 		case ChunkTypeDone:
 			if chunk.Response != nil {
 				return *chunk.Response, nil


### PR DESCRIPTION
`llm.CompletionResponse` was a field-for-field twin of `core.InferResponse`, bridged by `toInferResponse` on every inference. This collapses the duplicate at the agent↔provider seam:

- **One response type.** `CompletionResponse` now aliases `core.InferResponse`; `toInferResponse` is gone. The provider streaming layer and the agent loop share one type with no conversion. The logging accessors move onto `core.InferResponse`.
- **Typed `StopReason` at the boundary.** Previously a bare `string` cast unchecked into the agent loop (which gates max-tokens recovery on it). Providers now set the `core.Stop*` constants, with a typed passthrough for provider-native values (e.g. Anthropic's `stop_sequence`).
- **Removes a dead streaming mechanism.** `ChunkTypeToolStart`/`ChunkTypeToolInput` and `StreamChunk.ToolID`/`ToolName` were emitted by all four streaming engines but read by nobody — completed tool calls ride in the final `Response`. Deleted the emits, the chunk types, and the fields.

No behavior change: `StopReason` values and response fields are identical, and the removed chunks had no consumer. Net −56 lines; full build, vet, and test suite pass.

Follow-up (not in this PR): the remaining twins at the same seam — `StreamChunk`↔`core.Chunk` and `CompletionOptions`↔`InferRequest` — would change `Provider.Stream`'s signature across all 14 providers, so they're left for a separate change.