### PR TITLE
perf(session): cap index preview text and compact the index write

### DIFF
--- a/internal/session/transcript/fs_store.go
+++ b/internal/session/transcript/fs_store.go
@@ -73,6 +73,29 @@ type fileIndexEntry struct {
 	IsSidechain  bool      `json:"isSidechain,omitempty"`
 }
 
+// indexPreviewMaxRunes bounds the Title/LastPrompt copies stored in the index.
+// The index is a derived preview cache for the session picker — the authoritative
+// full text lives in the transcript records (LoadState), and the picker only ever
+// shows the first line truncated to the viewport width. Capping the stored copy
+// therefore loses nothing on screen while stopping a long pasted prompt from
+// bloating an entry that saveIndexLocked re-serializes on every turn.
+const indexPreviewMaxRunes = 200
+
+// indexPreview caps s to indexPreviewMaxRunes runes, cutting on a rune boundary so
+// multibyte (e.g. CJK) text is never split mid-character.
+func indexPreview(s string) string {
+	// Fast path: byte length within the cap ⇒ rune count is too (runes are ≥ 1
+	// byte each), so no []rune allocation is needed for the common short case.
+	if len(s) <= indexPreviewMaxRunes {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= indexPreviewMaxRunes {
+		return s
+	}
+	return string(runes[:indexPreviewMaxRunes])
+}
+
 func NewFileStore(baseDir, projectID string) (*FileStore, error) {
 	if err := os.MkdirAll(filepath.Join(baseDir, "transcripts"), 0o755); err != nil {
 		return nil, fmt.Errorf("create transcripts dir: %w", err)
@@ -201,9 +224,9 @@ func (s *FileStore) AppendMessage(ctx context.Context, cmd AppendMessageCommand)
 		e.MessageCount++
 		if userText != "" {
 			if e.Title == "" {
-				e.Title = userText
+				e.Title = indexPreview(userText)
 			}
-			e.LastPrompt = userText
+			e.LastPrompt = indexPreview(userText)
 		}
 		if emitBranch != "" {
 			e.GitBranch = emitBranch
@@ -260,9 +283,9 @@ func (s *FileStore) PatchState(ctx context.Context, cmd PatchStateCommand) error
 		for _, op := range cmd.Ops {
 			switch op.Path {
 			case PatchPathTitle:
-				e.Title = c.latestState.Title
+				e.Title = indexPreview(c.latestState.Title)
 			case PatchPathLastPrompt:
-				e.LastPrompt = c.latestState.LastPrompt
+				e.LastPrompt = indexPreview(c.latestState.LastPrompt)
 			}
 		}
 	})
@@ -839,7 +862,9 @@ func (s *FileStore) loadIndexLocked() (*fileIndex, error) {
 // sole writer of the index file, so caching here keeps s.cachedIndex coherent
 // with disk. Callers hold the write lock.
 func (s *FileStore) saveIndexLocked(index *fileIndex) error {
-	data, err := json.MarshalIndent(index, "", "  ")
+	// Compact (not indented): the index is a machine-read derived cache rewritten
+	// every turn, so pretty-print whitespace is pure write amplification.
+	data, err := json.Marshal(index)
 	if err != nil {
 		return fmt.Errorf("marshal transcript index: %w", err)
 	}
@@ -913,8 +938,8 @@ func (s *FileStore) rebuildIndexLocked() error {
 			FullPath:     item.FullPath,
 			CreatedAt:    item.CreatedAt,
 			UpdatedAt:    item.UpdatedAt,
-			Title:        item.Title,
-			LastPrompt:   item.LastPrompt,
+			Title:        indexPreview(item.Title),
+			LastPrompt:   indexPreview(item.LastPrompt),
 			MessageCount: item.MessageCount,
 			GitBranch:    item.GitBranch,
 			IsSidechain:  item.IsSidechain,
@@ -968,8 +993,8 @@ func (s *FileStore) refreshIndexLocked(transcriptID string) error {
 		FullPath:     item.FullPath,
 		CreatedAt:    item.CreatedAt,
 		UpdatedAt:    item.UpdatedAt,
-		Title:        item.Title,
-		LastPrompt:   item.LastPrompt,
+		Title:        indexPreview(item.Title),
+		LastPrompt:   indexPreview(item.LastPrompt),
 		MessageCount: item.MessageCount,
 		GitBranch:    item.GitBranch,
 		IsSidechain:  item.IsSidechain,

--- a/internal/session/transcript/fs_store_impl_test.go
+++ b/internal/session/transcript/fs_store_impl_test.go
@@ -1,6 +1,7 @@
 package transcript
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"os"
@@ -617,4 +618,72 @@ func freshIndexMessageCount(t *testing.T, dir, id string) int {
 		t.Fatalf("NewFileStore(fresh): %v", err)
 	}
 	return indexMessageCount(t, fresh, id)
+}
+
+// The index is a bounded preview cache rewritten every turn: a long prompt is
+// capped in the persisted Title/LastPrompt (rune-safe, so multibyte text is
+// never split), and the file is compact JSON — while the transcript keeps the
+// full text. This is what stops a big paste from bloating the per-turn rewrite.
+func TestFileStoreIndexCapsPreviewText(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewFileStore(dir, "proj-1")
+	if err != nil {
+		t.Fatalf("NewFileStore(): %v", err)
+	}
+
+	// A prompt well over the cap in multibyte runes: a byte-slice cut would split
+	// a character mid-rune, a rune-slice cut keeps a clean prefix.
+	full := strings.Repeat("码", indexPreviewMaxRunes+50)
+	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+	if err := store.Start(context.Background(), StartCommand{
+		SessionID: "tx-1", Cwd: "/tmp/project", Provider: "openai", Model: "gpt-test", Time: now,
+	}); err != nil {
+		t.Fatalf("Start(): %v", err)
+	}
+	if err := store.AppendMessage(context.Background(), AppendMessageCommand{
+		SessionID: "tx-1",
+		MessageID: "m1",
+		Time:      now.Add(time.Second),
+		Role:      "user",
+		Content:   []ContentBlock{{Type: "text", Text: full}},
+	}); err != nil {
+		t.Fatalf("AppendMessage(): %v", err)
+	}
+	if err := store.FlushIndex(); err != nil {
+		t.Fatalf("FlushIndex(): %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, transcriptIndexFile))
+	if err != nil {
+		t.Fatalf("read index: %v", err)
+	}
+	// Compact marshal ⇒ no pretty-print newlines (JSON escapes any in-string
+	// newline as "\\n", so a raw 0x0A byte can only come from indentation).
+	if bytes.ContainsRune(raw, '\n') {
+		t.Fatalf("index contains newlines; want compact marshal")
+	}
+	var idx fileIndex
+	if err := json.Unmarshal(raw, &idx); err != nil {
+		t.Fatalf("unmarshal index: %v", err)
+	}
+	if len(idx.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(idx.Entries))
+	}
+	want := string([]rune(full)[:indexPreviewMaxRunes])
+	if got := idx.Entries[0].Title; got != want {
+		t.Fatalf("persisted Title = %d runes, want a %d-rune prefix", len([]rune(got)), indexPreviewMaxRunes)
+	}
+	if got := idx.Entries[0].LastPrompt; got != want {
+		t.Fatalf("persisted LastPrompt = %d runes, want a %d-rune prefix", len([]rune(got)), indexPreviewMaxRunes)
+	}
+
+	// The transcript still holds the full, uncapped text — only the index preview
+	// is bounded.
+	tx, err := store.Load(context.Background(), "tx-1")
+	if err != nil {
+		t.Fatalf("Load(): %v", err)
+	}
+	if got := firstTextBlock(tx.Messages[0].Content); got != full {
+		t.Fatalf("transcript text was truncated: %d runes, want %d", len([]rune(got)), len([]rune(full)))
+	}
 }


### PR DESCRIPTION
The transcript index is re-serialized and rewritten in full at every turn boundary; this makes that write ~5× smaller and stops it growing with prompt length.

- `Title`/`LastPrompt` now store a bounded, rune-safe 200-rune preview instead of the full user text. The index is a derived cache — the picker shows only a truncated first line, and the authoritative full text stays in the transcript records.
- The index is marshaled compact instead of pretty-printed (`MarshalIndent` → `Marshal`).
- Measured on a real 328-session project: per-turn index write dropped **811 KB → 160 KB**. Existing index files self-heal on their next write.

Sidechain entries are deliberately kept (the inspector lists them via `IncludeSidechain`); the preview cap already removes their bloat.