### PR TITLE
fix(input): bind shift+enter, place the real cursor, size the box by wrapping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/mattn/go-runewidth v0.0.23
 	github.com/openai/openai-go/v3 v3.32.0
-	github.com/rivo/uniseg v0.4.7
 	github.com/spf13/cobra v1.8.1
 	go.uber.org/zap v1.27.0
 	golang.org/x/term v0.40.0
@@ -58,6 +57,7 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -44,6 +44,12 @@ func toolResultIcon(isError bool) string {
 	return "⎿"
 }
 
+// InputPrompt marks the input line, in the live textarea and in scrollback
+// alike. Its width doubles as the cursor's horizontal offset into the textarea
+// (see app.inputCursor), so the glyph and that offset stay in step by
+// construction.
+const InputPrompt = "❭ "
+
 var (
 	userMsgStyle = lipgloss.NewStyle()
 
@@ -141,7 +147,7 @@ func RenderAutopilotMark(note string) string {
 // RenderUserMessage renders a user message with prompt and optional images.
 func RenderUserMessage(content, displayContent string, images []core.Image, mdRenderer *MDRenderer, width int) string {
 	var sb strings.Builder
-	prompt := InputPromptStyle.Render("❭ ")
+	prompt := InputPromptStyle.Render(InputPrompt)
 	if displayContent == "" {
 		displayContent = content
 	}

--- a/internal/app/conv/queue_preview.go
+++ b/internal/app/conv/queue_preview.go
@@ -80,9 +80,9 @@ func RenderQueuePreview(items []QueuePreviewItem, selectedIdx, width int) string
 			contentStyle = queueSelectedContentStyle
 		}
 
-		// Budget: gutter(1) + "❭ "(2) + right margin(2), minus the image tag
+		// Budget: gutter(1) + prompt + right margin(2), minus the image tag
 		// and hint when this row carries them.
-		maxContentWidth := width - 5
+		maxContentWidth := width - 3 - lipgloss.Width(InputPrompt)
 		if item.HasImages {
 			maxContentWidth -= lipgloss.Width("[Image] ")
 		}
@@ -95,7 +95,7 @@ func RenderQueuePreview(items []QueuePreviewItem, selectedIdx, width int) string
 			content = PendingImageStyle.Render("[Image] ") + content
 		}
 
-		line := gutter + queuePromptStyle.Render("❭ ") + content
+		line := gutter + queuePromptStyle.Render(InputPrompt) + content
 		if i == hintIdx {
 			if pad := width - lipgloss.Width(line) - lipgloss.Width(hint) - 1; pad >= 2 {
 				line += strings.Repeat(" ", pad) + queueHintStyle.Render(hint)

--- a/internal/app/input/model.go
+++ b/internal/app/input/model.go
@@ -3,6 +3,7 @@ package input
 import (
 	"time"
 
+	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/textarea"
 	"charm.land/lipgloss/v2"
 
@@ -172,7 +173,38 @@ func newTextarea(width int) textarea.Model {
 	ta := newChromelessTextarea()
 	ta.Focus()
 	ta.SetWidth(width)
-	ta.SetHeight(minTextareaHeight)
+
+	// Let the textarea size itself: it counts soft-wrapped rows through the
+	// same memoized wrap its renderer uses, so the box can't disagree with what
+	// gets drawn — including CJK, where one rune occupies two columns.
+	ta.DynamicHeight = true
+	ta.MinHeight = minTextareaHeight
+	ta.MaxHeight = defaultMaxHeight
+	// MaxHeight caps the viewport, and with MaxContentHeight left at zero it
+	// would also stop accepting input at that many lines. Set the content guard
+	// separately so the buffer stays scrollable well past what's on screen.
+	ta.MaxContentHeight = maxContentRows
+
+	// Drive the terminal's own cursor instead of painting a reverse-video block
+	// into the frame: the block leaves the real cursor parked wherever the last
+	// paint ended (out in the streamed output), which is what the user's eye and
+	// the terminal's own IME follow. View() positions it — see model.inputCursor.
+	// Only the composer does this; the overlay editors built from
+	// newChromelessTextarea keep their virtual cursors, since View reports no
+	// cursor position for the layouts they appear in.
+	ta.SetVirtualCursor(false)
+
+	// Enter submits (see handleTextareaShortcut), so a newline needs its own
+	// keys. shift+enter is the one users reach for, but a terminal only reports
+	// it separately once key disambiguation is on (Kitty protocol: Ghostty,
+	// Kitty, WezTerm, iTerm2); elsewhere it arrives as a bare "enter" and
+	// submits. alt+enter and ctrl+j come through everywhere, so they stay as the
+	// portable fallbacks.
+	ta.KeyMap.InsertNewline = key.NewBinding(
+		key.WithKeys("shift+enter", "alt+enter", "ctrl+j"),
+		key.WithHelp("shift+enter", "insert newline"),
+	)
+
 	styles := ta.Styles()
 	styles.Blurred.Base = lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
 	ta.SetStyles(styles)

--- a/internal/app/input/model.go
+++ b/internal/app/input/model.go
@@ -1,6 +1,7 @@
 package input
 
 import (
+	"math"
 	"time"
 
 	"charm.land/bubbles/v2/key"
@@ -37,7 +38,7 @@ type Model struct {
 	LastCtrlO        time.Time
 	LastCtrlC        time.Time
 	Images           ImageState
-	TerminalHeight   int
+	terminalHeight   int // set via SetTerminalHeight, which also re-caps the box
 	PastedChunks     []PastedChunk
 	Queue            Queue
 
@@ -181,17 +182,19 @@ func newTextarea(width int) textarea.Model {
 	ta.MinHeight = minTextareaHeight
 	ta.MaxHeight = defaultMaxHeight
 	// MaxHeight caps the viewport, and with MaxContentHeight left at zero it
-	// would also stop accepting input at that many lines. Set the content guard
-	// separately so the buffer stays scrollable well past what's on screen.
-	ta.MaxContentHeight = maxContentRows
+	// would also stop accepting input at that many lines. Setting it separately
+	// keeps the buffer scrollable past what's on screen; MaxInt means "no limit
+	// of ours" — the textarea already stops at its own 10000-line guard, and any
+	// tighter number here silently trims a large paste before the placeholder
+	// logic ever sees it.
+	ta.MaxContentHeight = math.MaxInt
 
 	// Drive the terminal's own cursor instead of painting a reverse-video block
 	// into the frame: the block leaves the real cursor parked wherever the last
 	// paint ended (out in the streamed output), which is what the user's eye and
 	// the terminal's own IME follow. View() positions it — see model.inputCursor.
-	// Only the composer does this; the overlay editors built from
-	// newChromelessTextarea keep their virtual cursors, since View reports no
-	// cursor position for the layouts they appear in.
+	// Composer only; TestOverlayEditorsKeepVirtualCursor covers why the overlay
+	// editors built from newChromelessTextarea must not follow.
 	ta.SetVirtualCursor(false)
 
 	// Enter submits (see handleTextareaShortcut), so a newline needs its own

--- a/internal/app/input/on_queue.go
+++ b/internal/app/input/on_queue.go
@@ -193,7 +193,6 @@ func (m *Model) ExitQueueSelection() {
 	m.Queue.ResetSelection()
 	m.Textarea.SetValue(stashed)
 	m.Textarea.CursorEnd()
-	m.UpdateHeight()
 }
 
 // SaveCurrentQueueEdit writes the current textarea content back to the
@@ -219,5 +218,4 @@ func (m *Model) LoadQueueItemIntoTextarea() {
 	}
 	m.Textarea.SetValue(item.Content)
 	m.Textarea.CursorEnd()
-	m.UpdateHeight()
 }

--- a/internal/app/input/on_textarea.go
+++ b/internal/app/input/on_textarea.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/rivo/uniseg"
 
 	"github.com/genai-io/san/internal/app/kit/history"
 	"github.com/genai-io/san/internal/app/kit/suggest"
@@ -22,6 +21,10 @@ const (
 	defaultMaxHeight     = 10
 	fixedChromeLines     = 6 // separators(2) + status(1) + prompt overhead(2) + image/warning(1)
 	maxHeightScreenRatio = 2 // use up to 1/2 of terminal height
+	// maxContentRows bounds the buffer itself, not the visible box — a sanity
+	// stop far past any message someone types by hand, since long text arrives
+	// by paste and collapses to a placeholder.
+	maxContentRows = 1000
 )
 
 // imageRefPattern matches @path/to/image.ext references (case-insensitive extension).
@@ -48,23 +51,12 @@ func (m *Model) maxTextareaHeight() int {
 	return dynMax
 }
 
-// UpdateHeight adjusts textarea height based on content line count, accounting
-// for double-width characters (e.g. CJK) via uniseg.StringWidth.
-func (m *Model) UpdateHeight() {
-	content := m.Textarea.Value()
-	lines := strings.Count(content, "\n") + 1
-	width := m.Textarea.Width()
-	if width <= 0 {
-		width = 1
-	}
-	for _, line := range strings.Split(content, "\n") {
-		displayWidth := max(uniseg.StringWidth(line), 1)
-		lines += (displayWidth - 1) / width
-	}
-
-	newHeight := max(min(lines, m.maxTextareaHeight()), minTextareaHeight)
-
-	m.Textarea.SetHeight(newHeight)
+// SetTerminalHeight records the terminal size and re-caps the input box, which
+// is allowed half the screen. Growing and shrinking to fit the content is the
+// textarea's own job (DynamicHeight); this only moves its ceiling.
+func (m *Model) SetTerminalHeight(height int) {
+	m.TerminalHeight = height
+	m.Textarea.MaxHeight = m.maxTextareaHeight()
 }
 
 // imageLabel returns the display label for a pending image token.
@@ -196,7 +188,6 @@ func (m *Model) RemoveImageToken(match ImageTokenMatch, cursor int) {
 	m.Images.RemoveAt(match.PendingIdx)
 	m.Images.Selection = ImageSelection{}
 	m.SetCursorIndex(cursor)
-	m.UpdateHeight()
 }
 
 // ExtractInlineImages removes inline image tokens from content and returns the
@@ -261,7 +252,6 @@ func (m *Model) HistoryUp() {
 	}
 	m.Textarea.SetValue(m.History.Items[m.History.Index])
 	m.Textarea.CursorEnd()
-	m.UpdateHeight()
 }
 
 // HistoryDown navigates to the next history entry.
@@ -277,7 +267,6 @@ func (m *Model) HistoryDown() {
 		m.Textarea.SetValue(m.History.Stashed)
 	}
 	m.Textarea.CursorEnd()
-	m.UpdateHeight()
 }
 
 // ProcessImageRefs extracts @image.png references from input.
@@ -343,8 +332,7 @@ func (m *Model) ClearPaste() {
 }
 
 func (m *Model) Reset() {
-	m.Textarea.Reset()
-	m.Textarea.SetHeight(minTextareaHeight)
+	m.Textarea.Reset() // shrinks back to MinHeight on its own
 	m.ClearPaste()
 	m.ClearImages()
 	m.Queue.ResetSelection()
@@ -387,7 +375,6 @@ func (m *Model) ReturnToTextarea(content string, images []core.Image) {
 	m.Textarea.SetValue(content)
 	m.Textarea.CursorEnd()
 	m.RestoreImages(images)
-	m.UpdateHeight()
 }
 
 func (m *Model) HasContent() bool {
@@ -440,7 +427,6 @@ func (m *Model) HandleTextareaUpdate(msg tea.Msg) (tea.Cmd, bool) {
 
 	changed := m.Textarea.Value() != prevValue
 	if changed {
-		m.UpdateHeight()
 		m.Suggestions.UpdateSuggestions(m.Textarea.Value())
 	}
 

--- a/internal/app/input/on_textarea.go
+++ b/internal/app/input/on_textarea.go
@@ -21,10 +21,6 @@ const (
 	defaultMaxHeight     = 10
 	fixedChromeLines     = 6 // separators(2) + status(1) + prompt overhead(2) + image/warning(1)
 	maxHeightScreenRatio = 2 // use up to 1/2 of terminal height
-	// maxContentRows bounds the buffer itself, not the visible box — a sanity
-	// stop far past any message someone types by hand, since long text arrives
-	// by paste and collapses to a placeholder.
-	maxContentRows = 1000
 )
 
 // imageRefPattern matches @path/to/image.ext references (case-insensitive extension).
@@ -41,10 +37,10 @@ type ImageTokenMatch struct {
 
 // maxTextareaHeight returns the dynamic max height based on terminal size.
 func (m *Model) maxTextareaHeight() int {
-	if m.TerminalHeight <= 0 {
+	if m.terminalHeight <= 0 {
 		return defaultMaxHeight
 	}
-	dynMax := m.TerminalHeight/maxHeightScreenRatio - fixedChromeLines
+	dynMax := m.terminalHeight/maxHeightScreenRatio - fixedChromeLines
 	if dynMax < defaultMaxHeight {
 		return defaultMaxHeight
 	}
@@ -55,7 +51,7 @@ func (m *Model) maxTextareaHeight() int {
 // is allowed half the screen. Growing and shrinking to fit the content is the
 // textarea's own job (DynamicHeight); this only moves its ceiling.
 func (m *Model) SetTerminalHeight(height int) {
-	m.TerminalHeight = height
+	m.terminalHeight = height
 	m.Textarea.MaxHeight = m.maxTextareaHeight()
 }
 

--- a/internal/app/input/on_textarea_test.go
+++ b/internal/app/input/on_textarea_test.go
@@ -30,15 +30,15 @@ func TestTextareaGrowsToFitWrappedContent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := New("", tt.width, nil, SelectorDeps{})
-			m.Textarea.SetValue(tt.value)
+			ta := newTextarea(tt.width)
+			ta.SetValue(tt.value)
 
 			// Soft wrapping inserts row breaks, so compare with all
 			// whitespace squeezed out of both sides.
-			shown := strings.Join(strings.Fields(xansi.Strip(m.Textarea.View())), "")
+			shown := strings.Join(strings.Fields(xansi.Strip(ta.View())), "")
 			want := strings.Join(strings.Fields(tt.value), "")
 			if !strings.Contains(shown, want) {
-				t.Fatalf("height %d clips content:\n shown %q\n want  %q", m.Textarea.Height(), shown, want)
+				t.Fatalf("height %d clips content:\n shown %q\n want  %q", ta.Height(), shown, want)
 			}
 		})
 	}
@@ -47,15 +47,15 @@ func TestTextareaGrowsToFitWrappedContent(t *testing.T) {
 // A newline at the end opens a row the cursor sits on but no text occupies yet;
 // the box still has to grow to show it.
 func TestTextareaKeepsCursorRowVisible(t *testing.T) {
-	m := New("", 20, nil, SelectorDeps{})
-	m.Textarea.SetValue("first\n")
+	ta := newTextarea(20)
+	ta.SetValue("first\n")
 
-	cursor := m.Textarea.Cursor()
+	cursor := ta.Cursor()
 	if cursor == nil {
 		t.Fatal("focused composer reported no cursor")
 	}
-	if m.Textarea.Height() <= cursor.Position.Y {
-		t.Fatalf("height %d hides cursor row %d", m.Textarea.Height(), cursor.Position.Y)
+	if ta.Height() <= cursor.Position.Y {
+		t.Fatalf("height %d hides cursor row %d", ta.Height(), cursor.Position.Y)
 	}
 }
 
@@ -79,37 +79,31 @@ func TestTextareaAcceptsInputPastVisibleHeight(t *testing.T) {
 // Newlines are the composer's own binding, not a case in the key router, so the
 // keys users press have to actually reach it and split the line.
 func TestNewlineKeysInsertNewline(t *testing.T) {
-	keys := map[string]tea.KeyPressMsg{
-		"shift+enter": {Code: tea.KeyEnter, Mod: tea.ModShift},
-		"alt+enter":   {Code: tea.KeyEnter, Mod: tea.ModAlt},
-		"ctrl+j":      {Code: 'j', Mod: tea.ModCtrl},
+	tests := []struct {
+		name string
+		msg  tea.KeyPressMsg
+		want string
+	}{
+		{"shift+enter", tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModShift}, "first\n"},
+		{"alt+enter", tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModAlt}, "first\n"},
+		{"ctrl+j", tea.KeyPressMsg{Code: 'j', Mod: tea.ModCtrl}, "first\n"},
+		// Enter belongs to the key router, which submits before the textarea sees it.
+		{"enter", tea.KeyPressMsg{Code: tea.KeyEnter}, "first"},
 	}
 
-	for name, msg := range keys {
-		t.Run(name, func(t *testing.T) {
-			m := New("", 40, nil, SelectorDeps{})
-			m.Textarea.SetValue("first")
-			m.Textarea.CursorEnd()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ta := newTextarea(40)
+			ta.SetValue("first")
+			ta.CursorEnd()
 
-			m.Textarea, _ = m.Textarea.Update(msg)
+			ta, _ = ta.Update(tt.msg)
 
-			if got := m.Textarea.Value(); got != "first\n" {
-				t.Fatalf("%s (%q) gave %q, want %q", name, msg.String(), got, "first\n")
+			if got := ta.Value(); got != tt.want {
+				t.Fatalf("%s (%q) gave %q, want %q", tt.name, tt.msg.String(), got, tt.want)
 			}
 		})
 	}
-
-	t.Run("plain enter stays reserved for submit", func(t *testing.T) {
-		m := New("", 40, nil, SelectorDeps{})
-		m.Textarea.SetValue("first")
-		m.Textarea.CursorEnd()
-
-		m.Textarea, _ = m.Textarea.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-
-		if got := m.Textarea.Value(); got != "first" {
-			t.Fatalf("plain enter modified the buffer: %q", got)
-		}
-	})
 }
 
 // The /autopilot and /evolve editors share newChromelessTextarea but appear in

--- a/internal/app/input/on_textarea_test.go
+++ b/internal/app/input/on_textarea_test.go
@@ -1,23 +1,126 @@
 package input
 
 import (
+	"strings"
 	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	xansi "github.com/charmbracelet/x/ansi"
 
 	"github.com/genai-io/san/internal/core"
 )
 
-func TestUpdateHeightUsesExplicitAndWrappedLines(t *testing.T) {
-	m := New("", 10, nil, SelectorDeps{})
-	m.Textarea.SetValue("first\nsecond")
-	m.UpdateHeight()
-	if got := m.Textarea.Height(); got != 2 {
-		t.Fatalf("height for explicit multiline input = %d, want 2", got)
+// The box has to cover every row the textarea actually draws, or the viewport
+// silently clips the overflow. Predicting that by counting characters is what
+// the textarea's own soft-wrap already does exactly — including word-wrap
+// breaks and CJK, where one rune occupies two columns — so this asserts the
+// thing that matters: nothing typed goes missing on screen.
+func TestTextareaGrowsToFitWrappedContent(t *testing.T) {
+	tests := []struct {
+		name  string
+		width int
+		value string
+	}{
+		{"explicit newlines", 10, "first\nsecond"},
+		{"wrapped ascii", 10, "12345678901"},
+		{"word wrap near the edge", 12, "aaa aaa aaa aaa"},
+		{"wrapped cjk", 74, strings.Repeat("中", 40) + "\n" + strings.Repeat("文", 40)},
+		{"mixed width", 20, "hello 世界你好吗今天天气很好"},
 	}
 
-	m.Textarea.SetValue("12345678901")
-	m.UpdateHeight()
-	if got := m.Textarea.Height(); got != 2 {
-		t.Fatalf("height for wrapped input = %d, want 2", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := New("", tt.width, nil, SelectorDeps{})
+			m.Textarea.SetValue(tt.value)
+
+			// Soft wrapping inserts row breaks, so compare with all
+			// whitespace squeezed out of both sides.
+			shown := strings.Join(strings.Fields(xansi.Strip(m.Textarea.View())), "")
+			want := strings.Join(strings.Fields(tt.value), "")
+			if !strings.Contains(shown, want) {
+				t.Fatalf("height %d clips content:\n shown %q\n want  %q", m.Textarea.Height(), shown, want)
+			}
+		})
+	}
+}
+
+// A newline at the end opens a row the cursor sits on but no text occupies yet;
+// the box still has to grow to show it.
+func TestTextareaKeepsCursorRowVisible(t *testing.T) {
+	m := New("", 20, nil, SelectorDeps{})
+	m.Textarea.SetValue("first\n")
+
+	cursor := m.Textarea.Cursor()
+	if cursor == nil {
+		t.Fatal("focused composer reported no cursor")
+	}
+	if m.Textarea.Height() <= cursor.Position.Y {
+		t.Fatalf("height %d hides cursor row %d", m.Textarea.Height(), cursor.Position.Y)
+	}
+}
+
+// The box tops out at half the screen, but the buffer behind it must keep
+// accepting input and scroll — MaxHeight alone would refuse keystrokes there.
+func TestTextareaAcceptsInputPastVisibleHeight(t *testing.T) {
+	m := New("", 40, nil, SelectorDeps{})
+	m.SetTerminalHeight(24)
+
+	value := strings.TrimSuffix(strings.Repeat("line\n", 40), "\n")
+	m.Textarea.SetValue(value)
+
+	if got := m.Textarea.Value(); got != value {
+		t.Fatalf("buffer truncated: got %d lines, want 40", strings.Count(got, "\n")+1)
+	}
+	if h := m.Textarea.Height(); h > m.maxTextareaHeight() {
+		t.Fatalf("visible height %d exceeds cap %d", h, m.maxTextareaHeight())
+	}
+}
+
+// Newlines are the composer's own binding, not a case in the key router, so the
+// keys users press have to actually reach it and split the line.
+func TestNewlineKeysInsertNewline(t *testing.T) {
+	keys := map[string]tea.KeyPressMsg{
+		"shift+enter": {Code: tea.KeyEnter, Mod: tea.ModShift},
+		"alt+enter":   {Code: tea.KeyEnter, Mod: tea.ModAlt},
+		"ctrl+j":      {Code: 'j', Mod: tea.ModCtrl},
+	}
+
+	for name, msg := range keys {
+		t.Run(name, func(t *testing.T) {
+			m := New("", 40, nil, SelectorDeps{})
+			m.Textarea.SetValue("first")
+			m.Textarea.CursorEnd()
+
+			m.Textarea, _ = m.Textarea.Update(msg)
+
+			if got := m.Textarea.Value(); got != "first\n" {
+				t.Fatalf("%s (%q) gave %q, want %q", name, msg.String(), got, "first\n")
+			}
+		})
+	}
+
+	t.Run("plain enter stays reserved for submit", func(t *testing.T) {
+		m := New("", 40, nil, SelectorDeps{})
+		m.Textarea.SetValue("first")
+		m.Textarea.CursorEnd()
+
+		m.Textarea, _ = m.Textarea.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+		if got := m.Textarea.Value(); got != "first" {
+			t.Fatalf("plain enter modified the buffer: %q", got)
+		}
+	})
+}
+
+// The /autopilot and /evolve editors share newChromelessTextarea but appear in
+// overlays, where View reports no cursor position — so they must keep painting
+// their own.
+func TestOverlayEditorsKeepVirtualCursor(t *testing.T) {
+	if ta := newChromelessTextarea(); !ta.VirtualCursor() {
+		t.Fatal("overlay editors lost their virtual cursor; they would render none")
+	}
+	if ta := newTextarea(40); ta.VirtualCursor() {
+		t.Fatal("composer should drive the real terminal cursor")
 	}
 }
 

--- a/internal/app/update_input_effects.go
+++ b/internal/app/update_input_effects.go
@@ -73,7 +73,6 @@ func (m *model) pasteImageFromClipboard() (tea.Cmd, bool) {
 	label := m.userInput.AddPendingImage(*imgData)
 	m.userInput.Images.Selection = input.ImageSelection{}
 	m.userInput.Textarea.InsertString(label)
-	m.userInput.UpdateHeight()
 	return nil, true
 }
 

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -177,11 +177,9 @@ func (m *model) handleTextareaShortcut(msg tea.KeyMsg) (tea.Cmd, bool) {
 
 	case "enter":
 		return m.handleSubmit(), true
-
-	case "alt+enter":
-		m.userInput.Textarea.InsertString("\n")
-		return nil, true
 	}
+	// Newline keys deliberately fall through to the textarea, which owns them
+	// via KeyMap.InsertNewline — see newTextarea.
 
 	return nil, false
 }

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -180,7 +180,6 @@ func (m *model) handleTextareaShortcut(msg tea.KeyMsg) (tea.Cmd, bool) {
 
 	case "alt+enter":
 		m.userInput.Textarea.InsertString("\n")
-		m.userInput.UpdateHeight()
 		return nil, true
 	}
 

--- a/internal/app/update_resize.go
+++ b/internal/app/update_resize.go
@@ -12,7 +12,7 @@ import (
 func (m *model) handleWindowResize(msg tea.WindowSizeMsg) tea.Cmd {
 	m.env.Width = msg.Width
 	m.env.Height = msg.Height
-	m.userInput.TerminalHeight = msg.Height
+	m.userInput.SetTerminalHeight(msg.Height)
 	if ov, ok := m.activeOverlay(); ok {
 		if resizable, ok := ov.(resizableOverlay); ok {
 			resizable.Resize(msg.Width, msg.Height)

--- a/internal/app/update_submit.go
+++ b/internal/app/update_submit.go
@@ -182,7 +182,6 @@ func (m *model) drainInputQueueWhileIdle() tea.Cmd {
 	if draft != "" && m.userInput.Textarea.Value() == "" {
 		m.userInput.Textarea.SetValue(draft)
 		m.userInput.Textarea.CursorEnd()
-		m.userInput.UpdateHeight()
 	}
 	return cmd
 }

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -87,13 +87,9 @@ func (m *model) renderNormalView(separator, trackerView string) (string, *tea.Cu
 	// Render the footer first so we can measure how many lines it consumes
 	// and cap the chat section to the remaining terminal height.
 	footer, inputRow := m.renderFooter(separator)
-	bottomLines := strings.Count(footer, "\n")
-
-	maxContentHeight := 0
-	// Only truncate when there's room for at least one line of content.
-	if m.env.Height > bottomLines {
-		maxContentHeight = m.env.Height - bottomLines
-	}
+	// A non-positive result means the footer already fills the screen; tailLines
+	// reads that as "no room" and drops the chat section entirely.
+	maxContentHeight := m.env.Height - strings.Count(footer, "\n")
 
 	activeContent := conv.RenderActiveContent(m.messageRenderParams())
 	chatSection := tailLines(m.renderChatSection(activeContent, trackerView), maxContentHeight)
@@ -121,7 +117,8 @@ func (m *model) inputCursor(baseRow int) *tea.Cursor {
 // height. s is returned unchanged when it already fits.
 func tailLines(s string, maxLines int) string {
 	// No room at all — the footer already fills the screen. Returning s here
-	// would push the frame past the terminal height and make it scroll.
+	// would push the frame past the terminal height, and the renderer resolves
+	// that by dropping rows off the top, which eats into the input strip.
 	if maxLines <= 0 {
 		return ""
 	}

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -28,18 +28,24 @@ var ghostTextStyle = lipgloss.NewStyle().Foreground(kit.CurrentTheme.TextDim)
 // source the key router uses — so the panel that owns the keyboard is always
 // the one drawn on screen.
 func (m *model) View() tea.View {
-	return tea.NewView(m.viewString())
+	content, cursor := m.viewString()
+	v := tea.NewView(content)
+	v.Cursor = cursor
+	return v
 }
 
 // viewString renders the UI to a styled string; View wraps it in a tea.View.
-func (m *model) viewString() string {
+// The second return is where the terminal's cursor belongs in that frame, or
+// nil for the layouts that show no composer — overlays own the keyboard there,
+// and their own editors paint a virtual cursor instead.
+func (m *model) viewString() (string, *tea.Cursor) {
 	if !m.env.Ready {
-		return "\n  " + brandMark() + ghostTextStyle.Render("  ·  Loading…")
+		return "\n  " + brandMark() + ghostTextStyle.Render("  ·  Loading…"), nil
 	}
 
 	ov, hasOverlay := m.activeOverlay()
 	if hasOverlay && !isDockedModal(ov) {
-		return ov.Render() // fullscreen slash-command picker
+		return ov.Render(), nil // fullscreen slash-command picker
 	}
 
 	separator := conv.SeparatorStyle.Render(strings.Repeat("─", m.env.Width))
@@ -50,7 +56,7 @@ func (m *model) viewString() string {
 		if trackerView != "" {
 			trackerPrefix = "\n" + strings.TrimSuffix(trackerView, "\n") + "\n"
 		}
-		return trackerPrefix + separator + "\n" + ov.Render()
+		return trackerPrefix + separator + "\n" + ov.Render(), nil
 	}
 	return m.renderNormalView(separator, trackerView)
 }
@@ -77,10 +83,10 @@ func isDockedModal(ov overlayPanel) bool {
 // the space above the input area, its last lines (the latest content) are
 // shown and earlier lines scroll off — the full message lands in native
 // scrollback at turn end, which the terminal scrolls back through natively.
-func (m *model) renderNormalView(separator, trackerView string) string {
+func (m *model) renderNormalView(separator, trackerView string) (string, *tea.Cursor) {
 	// Render the footer first so we can measure how many lines it consumes
 	// and cap the chat section to the remaining terminal height.
-	footer := m.renderFooter(separator)
+	footer, inputRow := m.renderFooter(separator)
 	bottomLines := strings.Count(footer, "\n")
 
 	maxContentHeight := 0
@@ -90,17 +96,34 @@ func (m *model) renderNormalView(separator, trackerView string) string {
 	}
 
 	activeContent := conv.RenderActiveContent(m.messageRenderParams())
-	chatSection := m.renderChatSection(activeContent, trackerView)
+	chatSection := tailLines(m.renderChatSection(activeContent, trackerView), maxContentHeight)
 
-	return tailLines(chatSection, maxContentHeight) + footer
+	// The footer's row offsets are relative to its own first line; the chat
+	// section above it shifts them all down.
+	return chatSection + footer, m.inputCursor(strings.Count(chatSection, "\n") + inputRow)
+}
+
+// inputCursor returns where the terminal cursor belongs inside the composer.
+// baseRow is the frame row the textarea's first line lands on; the textarea
+// reports its cursor relative to that, and the prompt shifts it right.
+func (m *model) inputCursor(baseRow int) *tea.Cursor {
+	cursor := m.userInput.Textarea.Cursor()
+	if cursor == nil { // textarea is blurred
+		return nil
+	}
+	cursor.Position.X += lipgloss.Width(conv.InputPrompt)
+	cursor.Position.Y += baseRow
+	return cursor
 }
 
 // tailLines returns the last maxLines newline-delimited lines of s, keeping the
 // latest content visible when the live tail is taller than the available
-// height. s is returned unchanged when maxLines <= 0 or it already fits.
+// height. s is returned unchanged when it already fits.
 func tailLines(s string, maxLines int) string {
+	// No room at all — the footer already fills the screen. Returning s here
+	// would push the frame past the terminal height and make it scroll.
 	if maxLines <= 0 {
-		return s
+		return ""
 	}
 	lines := strings.Split(s, "\n")
 	if len(lines) <= maxLines {
@@ -111,8 +134,10 @@ func tailLines(s string, maxLines int) string {
 
 // renderFooter renders everything below the chat section (separators, queue
 // preview, input area, suggestions, status line) into a single string so its
-// line count can be measured.
-func (m *model) renderFooter(separator string) string {
+// line count can be measured. It also reports the row the input area starts on,
+// which View needs to place the cursor: the queue preview above the composer is
+// variable-height, so the offset can't be a constant.
+func (m *model) renderFooter(separator string) (string, int) {
 	var b strings.Builder
 	// Queued messages sit above the input separator: they are already
 	// submitted — on their way into the conversation — so they read as part
@@ -125,6 +150,7 @@ func (m *model) renderFooter(separator string) string {
 	b.WriteString("\n")
 	b.WriteString(separator)
 	b.WriteString("\n")
+	inputRow := strings.Count(b.String(), "\n")
 	b.WriteString(m.renderInputView())
 	if suggestions := m.userInput.Suggestions.Render(m.env.Width); suggestions != "" {
 		b.WriteString("\n")
@@ -138,11 +164,11 @@ func (m *model) renderFooter(separator string) string {
 	} else {
 		b.WriteString(" ")
 	}
-	return b.String()
+	return b.String(), inputRow
 }
 
 func (m model) renderInputView() string {
-	prompt := conv.InputPromptStyle.Render("❭ ")
+	prompt := conv.InputPromptStyle.Render(conv.InputPrompt)
 	if m.userInput.PromptSuggestion.Text != "" && m.userInput.Textarea.Value() == "" &&
 		!m.conv.Stream.Active && !m.userInput.Suggestions.IsVisible() {
 		return prompt + ghostTextStyle.Render(m.userInput.PromptSuggestion.Text)

--- a/internal/app/view_test.go
+++ b/internal/app/view_test.go
@@ -14,8 +14,8 @@ func TestTailLines(t *testing.T) {
 		maxLines int
 		want     string
 	}{
-		{"non-positive returns input", five, 0, five},
-		{"negative returns input", five, -3, five},
+		{"no room drops content", five, 0, ""},
+		{"negative room drops content", five, -3, ""},
 		{"fewer lines than max returns input", "a\nb", 5, "a\nb"},
 		{"exact fit returns input", five, 5, five},
 		{"truncates to last N (latest)", five, 2, "L3\nL4"},


### PR DESCRIPTION
Three independent defects in the composer, reported together while typing a multi-line Chinese message.

## The terminal cursor never moved to the input box

`View()` returned `tea.NewView(m.viewString())` and never set `View.Cursor`, while the textarea painted a reverse-video block into the frame. So the real cursor stayed wherever the last paint ended — out in the streamed output, which is what the eye and the terminal's IME follow.

`renderFooter` now reports the row the input area starts on, so `View` can offset the textarea's own `Cursor()` by the chat height and the prompt width. The offset can't be a constant because the queue preview above the composer is variable-height.

Only the composer switches to the real cursor. `/autopilot` and `/evolve` build their editors from the same `newChromelessTextarea`, but they appear in overlays where `viewString` reports no cursor position — turning off their virtual cursor would leave them with none at all. There's a test pinning that.

## shift+enter did nothing

Enter submits, so a newline needs its own key, and only `alt+enter` was bound. `shift+enter` fell through to the textarea, whose `InsertNewline` binding is `enter`/`ctrl+m` — no match either.

`InsertNewline` is now rebound to `shift+enter`, `alt+enter`, `ctrl+j`, so the widget owns newline insertion and its content guard applies. Note that only terminals with key disambiguation (Kitty protocol — Ghostty, Kitty, WezTerm, iTerm2) report `shift+enter` distinctly; elsewhere it arrives as a bare CR and submits, which is what the two fallbacks are for.

## Wrapped lines could still be clipped

`UpdateHeight` predicted the row count with ceiling division over the display width. That assumes hard wrapping, but the textarea word-wraps — a run wider than the box breaks to its own row:

```
hello 世界你好吗今天天气很好    at width 20
  predicted: 2 rows
  actual:    3 rows   -> the tail was clipped
```

Pure-CJK input was already correct after the `uniseg.StringWidth` fix; mixed content was not.

Rather than re-deriving the wrap a third time, this hands the job to the textarea's `DynamicHeight`, which counts soft-wrapped rows via the same memoized wrap its renderer uses — so the box cannot disagree with what gets drawn. The prediction and all nine of its call sites go away, replaced by `SetTerminalHeight` on resize.

One trap worth flagging for review: `MaxContentHeight` has to be set alongside `MaxHeight`. Left at zero, the textarea's content guard falls back to refusing input past `MaxHeight` *lines*, which would have capped the buffer at the visible box (10 rows on a small terminal). Test coverage for that is in `TestTextareaAcceptsInputPastVisibleHeight`.

## Also

`tailLines` returned its input unchanged when `maxLines <= 0`. That case means the footer already fills the screen, so returning the untrimmed chat section pushed the frame well past the terminal height.

The prompt glyph moves to `conv.InputPrompt`, shared with scrollback rendering, since the cursor's X offset is derived from its width.

## Testing

`go build ./...`, `go vet ./internal/...` and `go test ./...` all pass. New tests cover wrapped/CJK/mixed-width sizing, the cursor row on a trailing newline, input past the visible height, all three newline keys plus plain enter staying reserved for submit, and the overlay editors keeping their virtual cursors.

Not yet verified by hand in a real terminal — the cursor placement in particular deserves a look on a Kitty-protocol terminal and a non-Kitty one.
