### PR TITLE
fix(tracker): derive in-progress state from live executors

### DIFF
--- a/internal/app/conv/tracker_view.go
+++ b/internal/app/conv/tracker_view.go
@@ -25,8 +25,12 @@ type TrackerListParams struct {
 	AllDone      bool
 	StreamActive bool
 	Width        int
-	SpinnerView  string
 	Blockers     func(taskID string) []string
+	// Executing reports whether the executor behind a task is running right
+	// now. An in_progress task only animates when Executing says so: the
+	// status field records intent and outlives the process that wrote it, so
+	// it cannot by itself justify a moving pixel.
+	Executing func(t *todo.Task) bool
 	// Blink is the shared frame-tick counter (see FrameClock.Frame) that
 	// drives the in-progress pulse via trackerPulseTicks.
 	Blink int
@@ -43,54 +47,100 @@ func RenderTrackerList(params TrackerListParams) string {
 		return ""
 	}
 
-	counts := countTaskStatuses(params.Tasks)
-	completed := counts.done + counts.failed
+	ended := 0
+	for _, t := range params.Tasks {
+		if t.Status == todo.StatusCompleted {
+			ended++
+		}
+	}
 
 	var sb strings.Builder
 	headerStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.TextDim).Bold(true)
 	mutedStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
-	pct := 0
-	if len(params.Tasks) > 0 {
-		pct = completed * 100 / len(params.Tasks)
-	}
-	sb.WriteString("  " + headerStyle.Render("Tasks") + " " + mutedStyle.Render(fmt.Sprintf("(%d%%)", pct)))
+	sb.WriteString("  " + headerStyle.Render("Tasks") + " " +
+		mutedStyle.Render(fmt.Sprintf("(%d%%)", ended*100/len(params.Tasks))))
 	sb.WriteString("\n")
 
 	idWidth := taskIDWidth(params.Tasks)
 
-	rendered := 0
-	for _, t := range params.Tasks {
-		if rendered >= maxVisibleTasks {
-			break
-		}
-		sb.WriteString(renderTask(t, params.Width, idWidth, params.Blockers, params.Blink))
-		rendered++
+	// Classify only the rows actually drawn. Liveness is the expensive input and
+	// the header above does not need it — progress counts finished work, which
+	// no executor can still be advancing.
+	for _, t := range params.Tasks[:min(len(params.Tasks), maxVisibleTasks)] {
+		phase := phaseOf(t, params.Executing != nil && params.Executing(t))
+		sb.WriteString(renderTask(t, phase, params.Width, idWidth, params.Blockers, params.Blink))
 	}
 
 	return sb.String()
 }
 
-func renderTask(t *todo.Task, width, idWidth int, blockers func(string) []string, blink int) string {
+// taskPhase is how a task reads to the user. It collapses the recorded status,
+// how a finished task ended, and whether an executor is actually running it
+// into one exhaustive set, so each render branch answers to exactly one phase.
+type taskPhase int
+
+const (
+	taskWaiting  taskPhase = iota // nothing has started it
+	taskRunning                   // in progress, with a live executor
+	taskStalled                   // marked in progress, but nothing is executing it
+	taskAborted                   // ended without finishing its work
+	taskFinished                  // ended having done its work
+)
+
+// phaseOf classifies a task. executing answers whether its executor is running;
+// it only distinguishes taskRunning from taskStalled, since a task that already
+// reached a terminal status has no executor left to ask about.
+func phaseOf(t *todo.Task, executing bool) taskPhase {
+	switch t.Status {
+	case todo.StatusCompleted:
+		if todo.EndedAbnormally(t) {
+			return taskAborted
+		}
+		return taskFinished
+	case todo.StatusInProgress:
+		if executing {
+			return taskRunning
+		}
+		return taskStalled
+	default:
+		return taskWaiting
+	}
+}
+
+// activeText prefers the task's active phrasing ("Auditing deps") over its
+// subject ("Audit deps") while it is the one being worked on.
+func activeText(t *todo.Task, maxTextLen int) string {
+	text := t.ActiveForm
+	if text == "" {
+		text = t.Subject
+	}
+	return kit.TruncateText(text, maxTextLen)
+}
+
+func renderTask(t *todo.Task, phase taskPhase, width, idWidth int, blockers func(string) []string, blink int) string {
 	indent := "  "
 	idTag := fmt.Sprintf("%-*s", idWidth, "#"+t.ID)
 	maxTextLen := max(width-len(indent)-idWidth-8, 12)
 	subject := kit.TruncateText(t.Subject, maxTextLen)
 	mutedStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
-	statusDetail := kit.MapString(t.Metadata, "background_status_detail")
 
-	switch t.Status {
-	case todo.StatusCompleted:
-		if statusDetail == "failed" || statusDetail == "killed" {
-			failedStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Error)
-			return renderTaskLine(indent, failedStyle.Render("!"), idTag, subject, mutedStyle.Render("["+statusDetail+"]"))
-		}
+	switch phase {
+	case taskAborted:
+		abortedStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Error)
+		detail := mutedStyle.Render("[" + todo.BackgroundStatusDetail(t) + "]")
+		return renderTaskLine(indent, abortedStyle.Render("!"), idTag, subject, detail)
+
+	case taskFinished:
 		return renderTaskLine(indent, trackerCompletedStyle.Render("●"), idTag, subject, "")
 
-	case todo.StatusInProgress:
-		displayText := subject
-		if t.ActiveForm != "" {
-			displayText = kit.TruncateText(t.ActiveForm, maxTextLen)
-		}
+	case taskStalled:
+		// Nothing is executing this task, so draw it at rest. Reaching here
+		// means the status outlived its executor within a live session — the
+		// model marked an item in_progress and moved on without closing it.
+		// Animating would claim work that isn't happening.
+		return renderTaskLine(indent, mutedStyle.Render("◌"), idTag, activeText(t, maxTextLen), mutedStyle.Render("[stalled]"))
+
+	case taskRunning:
 		// Pulse on the shared frame tick (a true ~360ms clock; see FrameClock)
 		// rather than the wall clock, which only sampled on redraws and so
 		// flickered irregularly.
@@ -104,7 +154,7 @@ func renderTask(t *todo.Task, width, idWidth int, blockers func(string) []string
 		if elapsed := formatElapsedTime(t.StatusChangedAt); elapsed != "" {
 			detail = mutedStyle.Render(elapsed)
 		}
-		return renderTaskLine(indent, activeStyle.Render(activeIcon), idTag, displayText, detail)
+		return renderTaskLine(indent, activeStyle.Render(activeIcon), idTag, activeText(t, maxTextLen), detail)
 
 	default:
 		detail := ""
@@ -128,31 +178,6 @@ func renderTaskLine(indent, icon, id, subject, detail string) string {
 		line += "  " + detail
 	}
 	return line + "\n"
-}
-
-type taskStatusCounts struct {
-	done   int
-	active int
-	todo   int
-	failed int
-}
-
-func countTaskStatuses(tasks []*todo.Task) taskStatusCounts {
-	var counts taskStatusCounts
-	for _, t := range tasks {
-		statusDetail := kit.MapString(t.Metadata, "background_status_detail")
-		switch {
-		case t.Status == todo.StatusCompleted && (statusDetail == "failed" || statusDetail == "killed" || statusDetail == "stopped"):
-			counts.failed++
-		case t.Status == todo.StatusCompleted:
-			counts.done++
-		case t.Status == todo.StatusInProgress:
-			counts.active++
-		default:
-			counts.todo++
-		}
-	}
-	return counts
 }
 
 func taskIDWidth(tasks []*todo.Task) int {

--- a/internal/app/conv/tracker_view_test.go
+++ b/internal/app/conv/tracker_view_test.go
@@ -38,8 +38,8 @@ func TestRenderTrackerListShowsTaskStatus(t *testing.T) {
 		AllDone:      false,
 		StreamActive: true,
 		Width:        120,
-		SpinnerView:  "•",
 		Blockers:     todo.Default().OpenBlockers,
+		Executing:    func(*todo.Task) bool { return true },
 	})
 	plain := stripANSI(view)
 
@@ -70,7 +70,7 @@ func TestRenderTaskAnimatesInProgressItem(t *testing.T) {
 	// both the solid (●) and dim (◌) phases.
 	var hasSolid, hasDim bool
 	for blink := range 4 * trackerPulseTicks {
-		frame := stripANSI(renderTask(task, 80, 2, nil, blink))
+		frame := stripANSI(renderTask(task, taskRunning, 80, 2, nil, blink))
 		if strings.Contains(frame, "●") {
 			hasSolid = true
 		}
@@ -106,7 +106,7 @@ func TestRenderTrackerListOrdersByID(t *testing.T) {
 		AllDone:      false,
 		StreamActive: true,
 		Width:        120,
-		SpinnerView:  "•",
+		Executing:    func(*todo.Task) bool { return true },
 	})
 	plain := stripANSI(view)
 
@@ -128,4 +128,60 @@ func equalSlice(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// A task marked in progress whose executor is gone must render identically on
+// every frame. The status field alone used to drive the pulse, so a task the
+// model never closed out kept animating after the turn ended.
+func TestRenderTaskHoldsStillWhenStalled(t *testing.T) {
+	task := &todo.Task{ID: "1", Subject: "Fix auth module", Status: todo.StatusInProgress}
+
+	first := stripANSI(renderTask(task, taskStalled, 80, 2, nil, 0))
+	for blink := range 4 * trackerPulseTicks {
+		if frame := stripANSI(renderTask(task, taskStalled, 80, 2, nil, blink)); frame != first {
+			t.Fatalf("stalled task animated across frames:\n%q\n%q", first, frame)
+		}
+	}
+	if !strings.Contains(first, "[stalled]") {
+		t.Fatalf("stalled task should be labelled as such, got %q", first)
+	}
+}
+
+func TestPhaseOf(t *testing.T) {
+	worker := func(statusDetail string) map[string]any {
+		return map[string]any{
+			"background_task_id":       "bg-1",
+			"background_status_detail": statusDetail,
+		}
+	}
+
+	cases := []struct {
+		name      string
+		status    string
+		metadata  map[string]any
+		executing bool
+		want      taskPhase
+	}{
+		{"pending", todo.StatusPending, nil, false, taskWaiting},
+		{"in progress with executor", todo.StatusInProgress, nil, true, taskRunning},
+		{"in progress without executor", todo.StatusInProgress, nil, false, taskStalled},
+		{"completed", todo.StatusCompleted, nil, false, taskFinished},
+		{"worker finished", todo.StatusCompleted, worker(""), false, taskFinished},
+		{"worker failed", todo.StatusCompleted, worker("failed"), false, taskAborted},
+		{"worker killed", todo.StatusCompleted, worker("killed"), false, taskAborted},
+		{"worker stopped", todo.StatusCompleted, worker("stopped"), false, taskAborted},
+		{"worker orphaned", todo.StatusCompleted, worker(todo.StatusDetailInterrupted), false, taskAborted},
+		// A terminal status wins regardless of what the executor says, so a
+		// stale "still running" answer cannot resurrect a finished task.
+		{"completed despite executor", todo.StatusCompleted, nil, true, taskFinished},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			task := &todo.Task{ID: "1", Subject: "Task", Status: tc.status, Metadata: tc.metadata}
+			if got := phaseOf(task, tc.executing); got != tc.want {
+				t.Fatalf("phaseOf = %v, want %v", got, tc.want)
+			}
+		})
+	}
 }

--- a/internal/app/model_agent_events.go
+++ b/internal/app/model_agent_events.go
@@ -51,7 +51,9 @@ func (m *model) OnTokenUsage(resp *core.InferResponse) {
 	}
 }
 
-func (m *model) HasRunningTasks() bool { return m.services.Tracker.HasInProgress() }
+// HasRunningTasks gates the progress-hub tick's spinner batching. Like
+// needsSpinner it reads live runtime state, not persisted tracker status.
+func (m *model) HasRunningTasks() bool { return m.hasRunningBackgroundTask() }
 
 // OnAgentMessage observes the agent's MessageEvent echoes only. Every path that
 // hands a user message to the agent — idle submit, queue release

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -23,6 +23,7 @@ import (
 	"github.com/genai-io/san/internal/app/kit"
 	"github.com/genai-io/san/internal/app/trigger"
 	"github.com/genai-io/san/internal/log"
+	"github.com/genai-io/san/internal/todo"
 )
 
 // overlayPanel is a UI element that, while active, takes over both the
@@ -312,11 +313,33 @@ func (m *model) routeToSubModel(msg tea.Msg) (tea.Cmd, bool) {
 	return nil, false
 }
 
+// needsSpinner reports whether any animation should still be running.
+//
+// Every term is live in-memory runtime state. Persisted tracker status is
+// deliberately absent: nothing obliges its writer to clear it, so keying the
+// tick loop off it let the loop re-arm itself forever after the turn ended.
 func (m *model) needsSpinner() bool {
 	return m.conv.Stream.Active ||
 		m.conv.Compact.Active ||
 		m.userInput.Provider.FetchingLimits ||
-		m.services.Tracker.HasInProgress()
+		m.hasRunningBackgroundTask()
+}
+
+// hasRunningBackgroundTask reports whether any background task is executing.
+func (m *model) hasRunningBackgroundTask() bool {
+	return m.services.Task.HasRunning()
+}
+
+// executingTrackerTask reports whether the executor behind a tracker entry is
+// running right now. A worker entry names a background task, so todo resolves
+// it against the task manager. A plan item authored by the model has no
+// executor of its own — the main agent loop advances it, so it runs exactly
+// while that loop streams.
+func (m *model) executingTrackerTask(t *todo.Task) bool {
+	if todo.BackgroundTaskID(t) == "" {
+		return m.conv.Stream.Active
+	}
+	return todo.WorkerRunning(t)
 }
 
 func (m *model) updateTextarea(msg tea.Msg) tea.Cmd {

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -264,8 +264,8 @@ func (m model) renderTrackerList() string {
 		AllDone:      m.services.Tracker.AllDone(),
 		StreamActive: m.conv.Stream.Active,
 		Width:        m.env.Width,
-		SpinnerView:  m.conv.Spinner.View(),
 		Blockers:     m.services.Tracker.OpenBlockers,
+		Executing:    m.executingTrackerTask,
 		Blink:        m.conv.Spinner.Frame(),
 	})
 }

--- a/internal/task/agent_task.go
+++ b/internal/task/agent_task.go
@@ -162,26 +162,31 @@ func (t *AgentTask) GetOutput() string {
 // A context.Canceled error records the task as stopped (deliberate cancel),
 // any other error as failed. It is idempotent — a second call is a no-op.
 func (t *AgentTask) Complete(err error) {
+	switch {
+	case err == nil:
+		t.finalize(StatusCompleted, "")
+	case errors.Is(err, context.Canceled):
+		t.finalize(StatusStopped, "stopped before completion")
+	default:
+		t.finalize(StatusFailed, err.Error())
+	}
+}
+
+// markKilled marks the task as killed (internal use).
+func (t *AgentTask) markKilled() { t.finalize(StatusKilled, "") }
+
+// finalize is AgentTask's single terminal transition; see BashTask.finalize for
+// the invariant it enforces and why.
+func (t *AgentTask) finalize(status TaskStatus, errText string) {
 	t.mu.Lock()
 	if t.Status != StatusRunning {
 		t.mu.Unlock()
 		return
 	}
+	t.Status = status
+	t.Error = errText
 	t.EndTime = time.Now()
-
-	switch {
-	case err == nil:
-		t.Status = StatusCompleted
-	case errors.Is(err, context.Canceled):
-		t.Status = StatusStopped
-		t.Error = "stopped before completion"
-	default:
-		t.Status = StatusFailed
-		t.Error = err.Error()
-	}
 	outputFile := t.OutputFile
-	status := t.Status
-	errorText := t.Error
 	t.mu.Unlock()
 
 	// File I/O and done channel outside lock
@@ -189,29 +194,12 @@ func (t *AgentTask) Complete(err error) {
 		Event:  "task.completed",
 		Status: string(status),
 		Metadata: map[string]any{
-			"error": errorText,
+			"error": errText,
 		},
 	})
 
 	t.doneOnce.Do(func() { close(t.done) })
 	notifyTaskCompleted(t.GetStatus())
-}
-
-// markKilled marks the task as killed (internal use).
-// Closes the done channel and subscriber channels so WaitForCompletion unblocks.
-func (t *AgentTask) markKilled() {
-	t.mu.Lock()
-	t.Status = StatusKilled
-	t.EndTime = time.Now()
-	outputFile := t.OutputFile
-	t.mu.Unlock()
-
-	appendOutputFile(outputFile, outputRecord{
-		Event:  "task.completed",
-		Status: string(StatusKilled),
-	})
-
-	t.doneOnce.Do(func() { close(t.done) })
 }
 
 // IsRunning returns true if the task is still running

--- a/internal/task/bash_task.go
+++ b/internal/task/bash_task.go
@@ -102,55 +102,52 @@ func (t *BashTask) GetOutput() string {
 
 // Complete marks the task as completed
 func (t *BashTask) Complete(exitCode int, err error) {
+	status := StatusCompleted
+	errMsg := ""
+	if err != nil {
+		status, errMsg = StatusFailed, err.Error()
+	} else if exitCode != 0 {
+		status = StatusFailed
+	}
+	t.finalize(status, exitCode, errMsg)
+}
+
+// markKilled marks the task as killed (internal use). The exit code follows
+// the shell convention of 128+signal for SIGKILL, so a reader of the output
+// record can't mistake a killed task's code for a successful 0.
+func (t *BashTask) markKilled() { t.finalize(StatusKilled, 128+int(syscall.SIGKILL), "") }
+
+// finalize performs the one and only terminal transition a BashTask can make.
+// Every route out of StatusRunning — clean exit, non-zero exit, error, kill —
+// funnels through here, so it is structurally impossible to add an exit path
+// that forgets to close `done` or to notify the lifecycle handler. A dropped
+// notification used to strand the task's tracker entry in in_progress forever.
+//
+// It is idempotent: a second call after the task has left StatusRunning is a
+// no-op, which is what makes Kill-then-Complete races harmless.
+func (t *BashTask) finalize(status TaskStatus, exitCode int, errMsg string) {
 	t.mu.Lock()
 	if t.status != StatusRunning {
 		t.mu.Unlock()
 		return
 	}
+	t.status = status
 	t.endTime = time.Now()
 	t.exitCode = exitCode
-
-	if err != nil {
-		t.status = StatusFailed
-		t.errMsg = err.Error()
-	} else if exitCode != 0 {
-		t.status = StatusFailed
-	} else {
-		t.status = StatusCompleted
-	}
+	t.errMsg = errMsg
 	outputFile := t.OutputFile
-	status := string(t.status)
-	exitCodeCopy := t.exitCode
-	errCopy := t.errMsg
 	t.mu.Unlock()
 
 	appendOutputFile(outputFile, outputRecord{
 		Event:  "task.completed",
-		Status: status,
+		Status: string(status),
 		Metadata: map[string]any{
-			"exit_code": exitCodeCopy,
-			"error":     errCopy,
+			"exit_code": exitCode,
+			"error":     errMsg,
 		},
 	})
 	t.doneOnce.Do(func() { close(t.done) })
 	notifyTaskCompleted(t.GetStatus())
-}
-
-// markKilled marks the task as killed (internal use).
-// Closes the done channel so WaitForCompletion unblocks.
-func (t *BashTask) markKilled() {
-	t.mu.Lock()
-	t.status = StatusKilled
-	t.endTime = time.Now()
-	outputFile := t.OutputFile
-	t.mu.Unlock()
-
-	appendOutputFile(outputFile, outputRecord{
-		Event:  "task.completed",
-		Status: string(StatusKilled),
-	})
-
-	t.doneOnce.Do(func() { close(t.done) })
 }
 
 // IsRunning returns true if the task is still running

--- a/internal/task/hooks_test.go
+++ b/internal/task/hooks_test.go
@@ -49,3 +49,41 @@ func TestTaskLifecycleHandler(t *testing.T) {
 		t.Fatalf("expected completed status, got %q", observer.completed[0].Status)
 	}
 }
+
+// A killed task is just as terminal as a finished one. It used to skip the
+// notification entirely, which stranded its tracker entry in in_progress —
+// and a stranded entry kept the UI animating long after the turn ended.
+func TestKillNotifiesLifecycleHandler(t *testing.T) {
+	observer := &testTaskObserver{}
+	SetLifecycleHandler(observer)
+	defer SetLifecycleHandler(nil)
+
+	mgr := NewManager()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start command: %v", err)
+	}
+	task := mgr.CreateBashTask(cmd, "sleep 30", "Long task", ctx, cancel)
+
+	_ = task.Kill()
+
+	if len(observer.completed) != 1 {
+		t.Fatalf("expected 1 completed notification after kill, got %d", len(observer.completed))
+	}
+	if observer.completed[0].Status != StatusKilled {
+		t.Fatalf("expected killed status, got %q", observer.completed[0].Status)
+	}
+	if task.IsRunning() {
+		t.Fatal("killed task still reports running")
+	}
+
+	// The terminal transition is idempotent: a Complete racing in behind the
+	// kill must not emit a second, contradictory notification.
+	task.Complete(0, nil)
+	if len(observer.completed) != 1 {
+		t.Fatalf("terminal transition not idempotent: got %d notifications", len(observer.completed))
+	}
+}

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -100,6 +100,27 @@ func (m *Manager) ListRunning() []BackgroundTask {
 	return tasks
 }
 
+// HasRunning reports whether any task is running. Callers that only need the
+// answer should prefer it over len(ListRunning()), which allocates a slice of
+// every running task to be measured and thrown away.
+func (m *Manager) HasRunning() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for _, t := range m.tasks {
+		if t.IsRunning() {
+			return true
+		}
+	}
+	return false
+}
+
+// IsRunning reports whether the task with this ID exists and is running.
+func (m *Manager) IsRunning(id string) bool {
+	t, ok := m.Get(id)
+	return ok && t.IsRunning()
+}
+
 // Kill terminates a task by ID
 func (m *Manager) Kill(id string) error {
 	m.mu.RLock()

--- a/internal/todo/background.go
+++ b/internal/todo/background.go
@@ -11,6 +11,58 @@ const (
 	metaStatusDetail = "background_status_detail"
 )
 
+// StatusDetailInterrupted marks a worker entry whose executor died without
+// reporting a terminal status — process exit, crash, or SIGKILL. Set by
+// demoteOrphanedTasks when a persisted store is adopted into a fresh session.
+const StatusDetailInterrupted = "interrupted"
+
+// BackgroundTaskID returns the background task ID backing this entry, or ""
+// when the entry is a plan item authored by the model rather than a worker.
+// Callers resolve liveness by looking the ID up in the live task manager.
+func BackgroundTaskID(t *Task) string {
+	return metadataString(t, metaTaskID)
+}
+
+// BackgroundStatusDetail returns how a worker entry's executor ended —
+// "failed", "killed", "stopped", or StatusDetailInterrupted. Empty for entries
+// that are not backed by a worker, and for workers that ended normally.
+func BackgroundStatusDetail(t *Task) string {
+	return metadataString(t, metaStatusDetail)
+}
+
+// WorkerRunning reports whether the background task backing this entry is
+// executing right now. False for entries that name no worker, and for workers
+// the manager has no record of — a task it never knew or has forgotten cannot
+// be running.
+//
+// This is the read side of the join TrackWorker writes, and lives here so the
+// metadata key and the entry↔executor correspondence stay in one package.
+func WorkerRunning(t *Task) bool {
+	id := BackgroundTaskID(t)
+	return id != "" && task.Default().IsRunning(id)
+}
+
+// EndedAbnormally reports whether a worker entry reached its terminal state by
+// any route other than finishing its work. The stored detail is written as
+// string(task.TaskStatus) by CompleteWorker, so it is matched against those
+// constants rather than loose literals.
+func EndedAbnormally(t *Task) bool {
+	switch BackgroundStatusDetail(t) {
+	case string(task.StatusFailed), string(task.StatusKilled),
+		string(task.StatusStopped), StatusDetailInterrupted:
+		return true
+	}
+	return false
+}
+
+func metadataString(t *Task, key string) string {
+	if t == nil || t.Metadata == nil {
+		return ""
+	}
+	value, _ := t.Metadata[key].(string)
+	return value
+}
+
 // BackgroundTaskLaunch holds metadata for a newly spawned background task.
 type BackgroundTaskLaunch struct {
 	TaskID      string

--- a/internal/todo/orphan_test.go
+++ b/internal/todo/orphan_test.go
@@ -1,0 +1,117 @@
+package todo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/genai-io/san/internal/task"
+)
+
+// Adopting a store persisted by a process that is now gone must leave nothing
+// claiming to be in progress: whatever was executing those tasks died with that
+// process. Reconciling here rather than at each exit path is what makes the
+// guarantee hold across crashes and SIGKILL, which run no cleanup code at all.
+func TestSetStorageDirDemotesOrphanedTasks(t *testing.T) {
+	dir := t.TempDir()
+
+	writer := NewStore()
+	if err := writer.SetStorageDir(dir); err != nil {
+		t.Fatalf("SetStorageDir: %v", err)
+	}
+	plan := writer.Create("Refactor parser", "", "", nil)
+	worker := writer.Create("Audit deps", "", "", map[string]any{metaTaskID: "bg-1"})
+	for _, id := range []string{plan.ID, worker.ID} {
+		if err := writer.Update(id, WithStatus(StatusInProgress)); err != nil {
+			t.Fatalf("Update %s: %v", id, err)
+		}
+	}
+
+	// A fresh process adopts the same directory.
+	reader := NewStore()
+	if err := reader.SetStorageDir(dir); err != nil {
+		t.Fatalf("SetStorageDir (adopt): %v", err)
+	}
+
+	gotPlan, ok := reader.Get(plan.ID)
+	if !ok {
+		t.Fatalf("plan task %s missing after adopt", plan.ID)
+	}
+	if gotPlan.Status != StatusPending {
+		t.Fatalf("plan task status = %q, want %q", gotPlan.Status, StatusPending)
+	}
+
+	gotWorker, ok := reader.Get(worker.ID)
+	if !ok {
+		t.Fatalf("worker task %s missing after adopt", worker.ID)
+	}
+	if gotWorker.Status != StatusCompleted {
+		t.Fatalf("worker task status = %q, want %q", gotWorker.Status, StatusCompleted)
+	}
+	if detail := BackgroundStatusDetail(gotWorker); detail != StatusDetailInterrupted {
+		t.Fatalf("worker status detail = %q, want %q", detail, StatusDetailInterrupted)
+	}
+	if !EndedAbnormally(gotWorker) {
+		t.Fatal("an interrupted worker should count as having ended abnormally")
+	}
+}
+
+// Adoption also happens mid-session — resuming a session re-points the store
+// while this process's workers keep running. Demotion must ask the task manager
+// rather than assume every caller is a fresh process, or a resume marks live
+// work interrupted with no way back.
+func TestSetStorageDirKeepsRunningWorker(t *testing.T) {
+	dir := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	running := task.NewAgentTask("live-worker", "Explore", "Audit deps", ctx, cancel)
+	task.Default().RegisterTask(running)
+	t.Cleanup(func() { running.Complete(nil) })
+
+	writer := NewStore()
+	if err := writer.SetStorageDir(dir); err != nil {
+		t.Fatalf("SetStorageDir: %v", err)
+	}
+	entry := writer.Create("Audit deps", "", "", map[string]any{metaTaskID: running.ID})
+	if err := writer.Update(entry.ID, WithStatus(StatusInProgress)); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	adopter := NewStore()
+	if err := adopter.SetStorageDir(dir); err != nil {
+		t.Fatalf("SetStorageDir (adopt): %v", err)
+	}
+
+	got, ok := adopter.Get(entry.ID)
+	if !ok {
+		t.Fatalf("entry %s missing after adopt", entry.ID)
+	}
+	if got.Status != StatusInProgress {
+		t.Fatalf("running worker demoted: status = %q, want %q", got.Status, StatusInProgress)
+	}
+}
+
+// ReloadFromDisk exists to pick up writes from other processes mid-session, so
+// it must not reconcile: an in_progress task seen there is genuinely running.
+func TestReloadFromDiskPreservesExecutingTasks(t *testing.T) {
+	dir := t.TempDir()
+
+	store := NewStore()
+	if err := store.SetStorageDir(dir); err != nil {
+		t.Fatalf("SetStorageDir: %v", err)
+	}
+	live := store.Create("Run migration", "", "", nil)
+	if err := store.Update(live.ID, WithStatus(StatusInProgress)); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	store.ReloadFromDisk()
+
+	got, ok := store.Get(live.ID)
+	if !ok {
+		t.Fatalf("task %s missing after reload", live.ID)
+	}
+	if got.Status != StatusInProgress {
+		t.Fatalf("live task demoted by reload: status = %q, want %q", got.Status, StatusInProgress)
+	}
+}

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -12,9 +12,14 @@ type Service interface {
 	List() []*Task
 
 	// query
+	//
+	// Deliberately absent: a "has in-progress work" query. Status records what
+	// the model intended and outlives whatever was executing it, so callers
+	// reaching for it to answer "is work happening right now" get a value that
+	// never goes false on its own. Resolve liveness against the executor —
+	// the stream for plan items, task.Manager.ListRunning for workers.
 	IsBlocked(id string) bool
 	OpenBlockers(id string) []string
-	HasInProgress() bool
 	AllDone() bool
 	FindByMetadata(key, want string) *Task
 

--- a/internal/todo/store.go
+++ b/internal/todo/store.go
@@ -74,8 +74,45 @@ func (s *Store) SetStorageDir(dir string) error {
 		os.WriteFile(lockPath, nil, 0o644)
 	}
 
-	// Load existing tasks from disk
-	return s.loadFromDisk()
+	// Load existing tasks from disk, then reconcile: this is the moment a
+	// fresh process adopts state written by a process that no longer exists.
+	if err := s.loadFromDisk(); err != nil {
+		return err
+	}
+	s.demoteOrphanedTasks()
+	return nil
+}
+
+// demoteOrphanedTasks demotes tasks recorded as in_progress that no executor is
+// advancing any more. Runs where a store is adopted — SetStorageDir and Import —
+// so records written by a process that has since died stop claiming to be live,
+// however that process ended. Must be called with s.mu held.
+//
+// Adoption also happens mid-session (resuming a session re-points the store), so
+// liveness is asked of the task manager rather than assumed from the call site:
+// a worker still executing keeps its status. Plan items have no executor to ask
+// about and fall back to pending, the truthful state of work that was started
+// but never finished.
+//
+// Not called from loadFromDisk — ReloadFromDisk uses that mid-session to pick up
+// cross-process writes, where in_progress is expected and genuine.
+func (s *Store) demoteOrphanedTasks() {
+	for _, entry := range s.tasks {
+		if entry.Status != StatusInProgress || WorkerRunning(entry) {
+			continue
+		}
+		if BackgroundTaskID(entry) != "" {
+			entry.Status = StatusCompleted
+			if entry.Metadata == nil {
+				entry.Metadata = map[string]any{}
+			}
+			entry.Metadata[metaStatusDetail] = StatusDetailInterrupted
+		} else {
+			entry.Status = StatusPending
+		}
+		entry.StatusChangedAt = time.Now()
+		s.persistTask(entry)
+	}
 }
 
 // loadFromDisk reads all {id}.json files from storageDir into memory.
@@ -281,19 +318,6 @@ func (s *Store) Delete(id string) error {
 	return nil
 }
 
-// HasInProgress returns true if any task has in_progress status.
-func (s *Store) HasInProgress() bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	for _, task := range s.tasks {
-		if task.Status == StatusInProgress {
-			return true
-		}
-	}
-	return false
-}
-
 // AllDone reports whether the store has tasks and every one of them is completed.
 func (s *Store) AllDone() bool {
 	s.mu.RLock()
@@ -361,6 +385,7 @@ func (s *Store) Import(tasks []Task) {
 		}
 		s.persistTask(&t)
 	}
+	s.demoteOrphanedTasks()
 }
 
 // GetStorageDir returns the current storage directory.

--- a/internal/tool/tasktools/schema.go
+++ b/internal/tool/tasktools/schema.go
@@ -90,7 +90,8 @@ Status: pending → in_progress → completed. Use "deleted" to remove.
 - ONLY mark completed when FULLY done (not if tests fail or partial)
 - After completing, call TaskList for next task
 - If blocked, keep as in_progress and create a new task for the blocker
-- When you see a <task-reminder>, review and update stale tasks immediately`,
+- Close out every in_progress task before ending your turn; one left open is
+  shown as stalled, since nothing is executing it any more`,
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{


### PR DESCRIPTION
## Problem

The tracker's `●`/`◌` pulse keeps animating after a turn has ended — the todo list blinks at idle with no agent running.

`needsSpinner()` keyed off `todo.Task.Status == in_progress`. But that status records what the model *intended*, and it outlives whatever was executing it: a task can be left open by a kill, a crash, a cancel, or the model simply never closing it out. Nothing was obliged to clear it, so the tick loop re-armed itself indefinitely. A second loop (`HasRunningTasks` → `HandleProgressTick`) hung off the same predicate.

It also survived restarts — tracker state persists per session under `~/.san/tasks/<id>/`, so a stale `in_progress` made a *fresh* session start out blinking.

## Approach

Adding cleanup at each exit point chases an unbounded set of them (turn end, agent stop, cancel, kill, quit, crash, SIGKILL). The invariant instead: **liveness is derived from live runtime state, never read from persisted status.** Runtime state is in-memory and dies with the process, so it cannot leak by construction.

- `needsSpinner` / `HasRunningTasks` now read the stream and `task.Manager.ListRunning()`. Persisted status drives no loop.
- `RenderTrackerList` takes a `Live` predicate; an `in_progress` task with no executor renders static as `[stalled]` instead of claiming to run.
- Stale `in_progress` is reconciled where a store is **adopted** (`SetStorageDir`, `Import`) — the single gate every record from a dead process passes through, however that process ended. Deliberately *not* in `loadFromDisk`, which `ReloadFromDisk` calls mid-session to pick up cross-process writes and where `in_progress` is genuinely live. A test pins that boundary.
- `AgentTask` / `BashTask` funnel every terminal transition through one `finish()`, so no exit path can skip `notifyTaskCompleted`. `markKilled` skipped it, stranding killed workers' tracker entries in `in_progress` forever.
- `HasInProgress` is dropped from the `Service` interface — it read like a liveness query and had no remaining consumer.

Also removes a `TaskUpdate` prompt line telling the model to react to a `<task-reminder>` that nothing in the codebase ever emits.

## Testing

`go build`, `go vet`, and the full `go test ./...` pass. New tests cover the three invariants: a stalled task renders identically across frames, `ReloadFromDisk` does not demote genuinely-live tasks, and `Kill` notifies the lifecycle handler exactly once (idempotent under a racing `Complete`).

Not yet verified by driving the real TUI — worth a manual pass on the two visible cases (turn ends with an open todo; `TaskStop` on a running background task should show a red `!`).
