### PR TITLE
fix(tracker): window the task list on the newest items

### DIFF
--- a/internal/app/conv/queue_preview.go
+++ b/internal/app/conv/queue_preview.go
@@ -40,9 +40,12 @@ var (
 			Foreground(kit.CurrentTheme.Muted).
 			Italic(true)
 
-	queueOverflowStyle = lipgloss.NewStyle().
-				Foreground(kit.CurrentTheme.Muted).
-				Italic(true)
+	// overflowStyle marks a "+N more" row — a count of what was clipped, not
+	// content. Shared by every panel that windows its rows so the affordance
+	// reads the same wherever it appears.
+	overflowStyle = lipgloss.NewStyle().
+			Foreground(kit.CurrentTheme.Muted).
+			Italic(true)
 )
 
 // RenderQueuePreview renders queued messages as dim shadow prompts above the
@@ -105,10 +108,10 @@ func RenderQueuePreview(items []QueuePreviewItem, selectedIdx, width int) string
 	}
 
 	if endIdx < len(items) {
-		sb.WriteString(queueOverflowStyle.Render(fmt.Sprintf("   +%d more below", len(items)-endIdx)) + "\n")
+		sb.WriteString(overflowStyle.Render(fmt.Sprintf("   +%d more below", len(items)-endIdx)) + "\n")
 	}
 	if startIdx > 0 {
-		return queueOverflowStyle.Render(fmt.Sprintf("   +%d more above", startIdx)) + "\n" + sb.String()
+		return overflowStyle.Render(fmt.Sprintf("   +%d more above", startIdx)) + "\n" + sb.String()
 	}
 
 	return sb.String()

--- a/internal/app/conv/tracker_view.go
+++ b/internal/app/conv/tracker_view.go
@@ -11,6 +11,10 @@ import (
 	"github.com/genai-io/san/internal/todo"
 )
 
+// maxVisibleTasks caps the rows drawn. The window sits on the newest tasks,
+// not the oldest, because the list outlives the turn that filled it (see
+// OnTurnEnd): taking from the front would pin the panel to the turn that
+// stalled and hide the work in flight.
 const maxVisibleTasks = 8
 
 // trackerPulseTicks is the number of spinner frames per ●/◌ swap of an
@@ -22,7 +26,6 @@ const trackerPulseTicks = 3
 // TrackerListParams holds the parameters for rendering a tracker list.
 type TrackerListParams struct {
 	Tasks        []*todo.Task
-	AllDone      bool
 	StreamActive bool
 	Width        int
 	Blockers     func(taskID string) []string
@@ -43,15 +46,21 @@ func RenderTrackerList(params TrackerListParams) string {
 		return ""
 	}
 
-	if params.AllDone && !params.StreamActive {
-		return ""
-	}
-
 	ended := 0
 	for _, t := range params.Tasks {
 		if t.Status == todo.StatusCompleted {
 			ended++
 		}
+	}
+
+	// A fully closed-out list has nothing left to track, so the panel gets out
+	// of the way once the stream is idle. While streaming it stays up: the model
+	// can still add items, and a list that vanished mid-turn would flicker back.
+	//
+	// Derived from the tasks in hand rather than asked of the store: the count
+	// above already answers it, and one snapshot cannot disagree with itself.
+	if ended == len(params.Tasks) && !params.StreamActive {
+		return ""
 	}
 
 	var sb strings.Builder
@@ -61,12 +70,18 @@ func RenderTrackerList(params TrackerListParams) string {
 		mutedStyle.Render(fmt.Sprintf("(%d%%)", ended*100/len(params.Tasks))))
 	sb.WriteString("\n")
 
-	idWidth := taskIDWidth(params.Tasks)
+	visible := params.Tasks[max(0, len(params.Tasks)-maxVisibleTasks):]
+	if hidden := len(params.Tasks) - len(visible); hidden > 0 {
+		// Name the drop; a silent truncation reads as the whole list.
+		sb.WriteString("  " + overflowStyle.Render(fmt.Sprintf("+%d more above", hidden)) + "\n")
+	}
+
+	idWidth := taskIDWidth(visible)
 
 	// Classify only the rows actually drawn. Liveness is the expensive input and
 	// the header above does not need it — progress counts finished work, which
 	// no executor can still be advancing.
-	for _, t := range params.Tasks[:min(len(params.Tasks), maxVisibleTasks)] {
+	for _, t := range visible {
 		phase := phaseOf(t, params.Executing != nil && params.Executing(t))
 		sb.WriteString(renderTask(t, phase, params.Width, idWidth, params.Blockers, params.Blink))
 	}

--- a/internal/app/conv/tracker_view_test.go
+++ b/internal/app/conv/tracker_view_test.go
@@ -2,6 +2,8 @@ package conv
 
 import (
 	"regexp"
+	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -35,7 +37,6 @@ func TestRenderTrackerListShowsTaskStatus(t *testing.T) {
 
 	view := RenderTrackerList(TrackerListParams{
 		Tasks:        todo.Default().List(),
-		AllDone:      false,
 		StreamActive: true,
 		Width:        120,
 		Blockers:     todo.Default().OpenBlockers,
@@ -103,7 +104,6 @@ func TestRenderTrackerListOrdersByID(t *testing.T) {
 
 	view := RenderTrackerList(TrackerListParams{
 		Tasks:        todo.Default().List(),
-		AllDone:      false,
 		StreamActive: true,
 		Width:        120,
 		Executing:    func(*todo.Task) bool { return true },
@@ -112,22 +112,9 @@ func TestRenderTrackerListOrdersByID(t *testing.T) {
 
 	ids := taskIDRe.FindAllString(plain, -1)
 	want := []string{"#1", "#2", "#3"}
-	if !equalSlice(ids, want) {
+	if !slices.Equal(ids, want) {
 		t.Fatalf("task order:\n  got:  %v\n  want: %v\n\nfull output:\n%s", ids, want, plain)
 	}
-}
-
-// equalSlice reports whether two string slices are equal.
-func equalSlice(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }
 
 // A task marked in progress whose executor is gone must render identically on
@@ -144,6 +131,73 @@ func TestRenderTaskHoldsStillWhenStalled(t *testing.T) {
 	}
 	if !strings.Contains(first, "[stalled]") {
 		t.Fatalf("stalled task should be labelled as such, got %q", first)
+	}
+}
+
+// The panel's visibility gate. It hides only once every item is marked
+// completed, so a stalled item — in progress with nothing executing it — is
+// unfinished work and must keep the list on screen. Gating on executors instead
+// would hide exactly the row #342 added to surface.
+func TestRenderTrackerListVisibility(t *testing.T) {
+	stalled := &todo.Task{ID: "1", Subject: "Fix auth module", Status: todo.StatusInProgress}
+	done := &todo.Task{ID: "1", Subject: "Fix auth module", Status: todo.StatusCompleted}
+
+	cases := []struct {
+		name         string
+		tasks        []*todo.Task
+		streamActive bool
+		wantVisible  bool
+	}{
+		{"no tasks", nil, true, false},
+		{"complete and idle", []*todo.Task{done}, false, false},
+		{"complete but still streaming", []*todo.Task{done}, true, true},
+		{"stalled item keeps the list up", []*todo.Task{stalled}, false, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			view := RenderTrackerList(TrackerListParams{
+				Tasks:        tc.tasks,
+				StreamActive: tc.streamActive,
+				Width:        120,
+				Executing:    func(*todo.Task) bool { return false },
+			})
+			if visible := view != ""; visible != tc.wantVisible {
+				t.Fatalf("visible = %v, want %v; rendered:\n%s", visible, tc.wantVisible, stripANSI(view))
+			}
+		})
+	}
+}
+
+// The list outlives the turn that filled it, so windowing from the front would
+// pin the panel to the turn that stalled and hide everything since.
+func TestRenderTrackerListWindowsOnNewestTasks(t *testing.T) {
+	tasks := make([]*todo.Task, 0, maxVisibleTasks+3)
+	for i := 1; i <= maxVisibleTasks+3; i++ {
+		id := strconv.Itoa(i)
+		tasks = append(tasks, &todo.Task{
+			ID:      id,
+			Subject: "Task " + id,
+			Status:  todo.StatusCompleted,
+		})
+	}
+	// The oldest task is the one left open, so it is what keeps the list alive.
+	tasks[0].Status = todo.StatusInProgress
+
+	plain := stripANSI(RenderTrackerList(TrackerListParams{
+		Tasks:        tasks,
+		StreamActive: true,
+		Width:        120,
+		Executing:    func(*todo.Task) bool { return false },
+	}))
+
+	ids := taskIDRe.FindAllString(plain, -1)
+	want := []string{"#4", "#5", "#6", "#7", "#8", "#9", "#10", "#11"}
+	if !slices.Equal(ids, want) {
+		t.Fatalf("visible tasks:\n  got:  %v\n  want: %v\n\nfull output:\n%s", ids, want, plain)
+	}
+	if !strings.Contains(plain, "+3 more above") {
+		t.Fatalf("hidden tasks should be counted, not dropped silently:\n%s", plain)
 	}
 }
 

--- a/internal/app/model_agent_events.go
+++ b/internal/app/model_agent_events.go
@@ -112,7 +112,15 @@ func (m *model) OnToolResult(tr core.ToolResult) *core.ToolResult {
 }
 
 func (m *model) OnTurnEnd(result core.Result) tea.Cmd {
-	if m.services.Tracker.AllDone() {
+	// Only a list the model closed out is safe to discard. An item left open —
+	// pending, or in_progress with nothing executing it — is unfinished work, so
+	// the list survives the turn and stays on screen.
+	//
+	// This is the sole automatic reset, so one item the model never closes keeps
+	// the list alive and growing for the rest of the session. That is why the
+	// tracker windows on its newest rows (see maxVisibleTasks) rather than
+	// assuming it renders a single turn's worth.
+	if m.services.Tracker.AllMarkedCompleted() {
 		m.services.Tracker.Reset()
 	}
 	// The turn reached its end, so whatever failure the copilot was recovering

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -254,14 +254,15 @@ func (m model) renderSelfLearnLive() string {
 	return ""
 }
 
-func (m model) renderTrackerList() string {
+// Pointer receiver: Executing below is a *model method value, so a value
+// receiver would take the address of the copy and force the whole model onto
+// the heap on every frame.
+func (m *model) renderTrackerList() string {
 	if !m.conv.ShowTasks {
 		return ""
 	}
-	tasks := m.services.Tracker.List()
 	return conv.RenderTrackerList(conv.TrackerListParams{
-		Tasks:        tasks,
-		AllDone:      m.services.Tracker.AllDone(),
+		Tasks:        m.services.Tracker.List(),
 		StreamActive: m.conv.Stream.Active,
 		Width:        m.env.Width,
 		Blockers:     m.services.Tracker.OpenBlockers,

--- a/internal/todo/completion_test.go
+++ b/internal/todo/completion_test.go
@@ -1,0 +1,51 @@
+package todo
+
+import "testing"
+
+// AllMarkedCompleted gates two things: whether the tracker panel is drawn, and
+// whether the turn-end reset may discard the list. Both want the same question
+// answered — has the model closed out everything it wrote down — so the cases
+// that must not read as complete are the ones where work was recorded and left
+// open, however it was left open.
+func TestAllMarkedCompleted(t *testing.T) {
+	cases := []struct {
+		name     string
+		statuses []string
+		want     bool
+	}{
+		{"empty store", nil, false},
+		{"all completed", []string{StatusCompleted, StatusCompleted}, true},
+		{"one still pending", []string{StatusCompleted, StatusPending}, false},
+		// The case the tracker used to get wrong elsewhere: an item the model
+		// marked in progress and never closed. No executor is advancing it, but
+		// it is abandoned work rather than finished work, so the list is not
+		// complete and the list stays up showing it as [stalled].
+		{"one left in progress", []string{StatusCompleted, StatusInProgress}, false},
+		{"deleted items do not count as open", []string{StatusCompleted, StatusDeleted}, true},
+		// Tombstones only: the map is not empty, so the emptiness check passes
+		// and the loop skips every entry. The view never sees this — List drops
+		// deleted tasks, so it renders nothing either way.
+		{"only tombstones", []string{StatusDeleted}, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := NewStore()
+			for _, status := range tc.statuses {
+				entry := store.Create("task", "", "", nil)
+				var err error
+				if status == StatusDeleted {
+					err = store.Delete(entry.ID)
+				} else {
+					err = store.Update(entry.ID, WithStatus(status))
+				}
+				if err != nil {
+					t.Fatalf("set task %s to %s: %v", entry.ID, status, err)
+				}
+			}
+			if got := store.AllMarkedCompleted(); got != tc.want {
+				t.Fatalf("AllMarkedCompleted() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -18,9 +18,12 @@ type Service interface {
 	// reaching for it to answer "is work happening right now" get a value that
 	// never goes false on its own. Resolve liveness against the executor —
 	// the stream for plan items, task.Manager.ListRunning for workers.
+	//
+	// AllMarkedCompleted deliberately reads Status: it reports what the list
+	// records, not what is running.
 	IsBlocked(id string) bool
 	OpenBlockers(id string) []string
-	AllDone() bool
+	AllMarkedCompleted() bool
 	FindByMetadata(key, want string) *Task
 
 	// persistence

--- a/internal/todo/store.go
+++ b/internal/todo/store.go
@@ -318,8 +318,16 @@ func (s *Store) Delete(id string) error {
 	return nil
 }
 
-// AllDone reports whether the store has tasks and every one of them is completed.
-func (s *Store) AllDone() bool {
+// AllMarkedCompleted reports whether the store has tasks and every one of them
+// carries StatusCompleted.
+//
+// The question is what the list records about itself — whether the model closed
+// out every item it wrote down — and Status is the only record of that.
+// Deriving it from executors would answer a different question and answer it
+// wrongly: a task left in_progress with no executor is abandoned work, not
+// finished work, and marking it done would wipe the list at turn end and take
+// the [stalled] row down with it.
+func (s *Store) AllMarkedCompleted() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 


### PR DESCRIPTION
Closes #343.

Two problems with one root. The issue found the smell; chasing it down turned up an actual defect behind it.

## The name

The issue offers two options: derive `AllDone()` from live runtime state, or rename it. **Option 1 would be wrong**, so this takes option 2.

`AllDone()` resembles the query #342 deleted — it reads `Status`, drives UI, and sits directly under the interface comment forbidding status-based liveness queries. But it is not a liveness question: it asks whether the model closed out every item it wrote down, and `Status` is the only record of that. No executor knows whether work was *finished*, only whether something is running *right now*.

Deriving it would also break #342. A task left `in_progress` with no executor is abandoned work, not finished work; counting it as done would reset the list at turn end and take down the `[stalled]` row #342 had just added to surface that state.

So the semantics stand and the name moves to `AllMarkedCompleted()` — naming the source (*marked*, the recorded `Status`) and the value checked (`StatusCompleted`), so it can't be misread as asking what is running. The interface comment now says why this one query reads `Status`.

(`PlanComplete()` was considered and dropped — San has no plan mode, so the word would invent a concept.)

## The defect the name was hiding

The list only resets once **every** item is marked completed. So one item the model never closed out keeps it alive for the rest of the session, growing every turn. Meanwhile the render took the **first** `maxVisibleTasks` entries, and `List()` sorts by ascending ID.

Past eight tasks, the panel pins itself to the turn that stalled and hides every task since:

```
turn 1:  #1  #2 (never closed)  #3     → list is now stuck open
turn 2:  +#4 #5 #6                     → 6 items, still fits
turn 3:  +#7 #8 #9                     → #9 truncated
turn 4+: +#10 #11 …                    → new work can never be seen again
```

A progress panel that hides the work in flight in favour of stale work is backwards. The window now sits on the newest items and reports what it clipped, reusing the `+N more above` affordance the queue preview already renders.

## Tests

- `TestAllMarkedCompleted` — empty store, all-completed, one-pending, one-left-in-progress, deleted-only tombstones.
- `TestRenderTrackerListVisibility` — the panel's visibility gate, which had **no coverage at all**.
- `TestRenderTrackerListWindowsOnNewestTasks` — oldest item left open, newest eight visible, hidden count reported.

`go build ./...`, `go vet ./...`, and the full `go test ./...` all pass.

## Incidental

- One shared `overflowStyle` for `+N more` rows, so the tracker's affordance matches the queue preview's instead of adding a third copy of the same style.
- `renderTrackerList` takes a pointer receiver. It passes `m.executingTrackerTask`, a `*model` method value, so a value receiver took the address of the copy and moved the whole ~68 KB model to the heap on every frame — confirmed with `-gcflags=-m` before and after.

## Note on `demoteOrphanedTasks`

The issue suggests deriving would make some of `demoteOrphanedTasks` stop being load-bearing. It wouldn't: that function reconciles records written by a *dead process*, a genuine liveness problem that still needs solving at adoption. Running the same demotion at turn end was considered and rejected — within a live session it would overwrite `in_progress` with `pending` and erase the `[stalled]` distinction #342 exists to draw.
