### PR TITLE
fix(tracker): join worker items to the task lifecycle, not the tool result

### DIFF
--- a/internal/app/conv/tracker_view.go
+++ b/internal/app/conv/tracker_view.go
@@ -11,43 +11,43 @@ import (
 	"github.com/genai-io/san/internal/todo"
 )
 
-// maxVisibleTasks caps the rows drawn. The window sits on the newest tasks,
+// maxVisibleItems caps the rows drawn. The window sits on the newest items,
 // not the oldest, because the list outlives the turn that filled it (see
 // OnTurnEnd): taking from the front would pin the panel to the turn that
 // stalled and hide the work in flight.
-const maxVisibleTasks = 8
+const maxVisibleItems = 8
 
 // trackerPulseTicks is the number of spinner frames per ●/◌ swap of an
-// in-progress task. At ~360ms per frame this gives a ~1.1s breathe — calmer
+// in-progress item. At ~360ms per frame this gives a ~1.1s breathe — calmer
 // than the agent icon's faster blink (cf. agentBlinkTicks in tool_render.go),
 // suiting the tracker's quieter role.
 const trackerPulseTicks = 3
 
 // TrackerListParams holds the parameters for rendering a tracker list.
 type TrackerListParams struct {
-	Tasks        []*todo.Task
+	Items        []*todo.Item
 	StreamActive bool
 	Width        int
-	Blockers     func(taskID string) []string
-	// Executing reports whether the executor behind a task is running right
-	// now. An in_progress task only animates when Executing says so: the
+	Blockers     func(itemID string) []string
+	// Executing reports whether the executor behind an item is running right
+	// now. An in_progress item only animates when Executing says so: the
 	// status field records intent and outlives the process that wrote it, so
 	// it cannot by itself justify a moving pixel.
-	Executing func(t *todo.Task) bool
+	Executing func(t *todo.Item) bool
 	// Blink is the shared frame-tick counter (see FrameClock.Frame) that
 	// drives the in-progress pulse via trackerPulseTicks.
 	Blink int
 }
 
-// RenderTrackerList renders a compact task list above the input area.
-// Returns empty string when there are no tasks or all are completed and idle.
+// RenderTrackerList renders the tracker panel above the input area.
+// Returns empty string when there are no items, or all are completed and idle.
 func RenderTrackerList(params TrackerListParams) string {
-	if len(params.Tasks) == 0 {
+	if len(params.Items) == 0 {
 		return ""
 	}
 
 	ended := 0
-	for _, t := range params.Tasks {
+	for _, t := range params.Items {
 		if t.Status == todo.StatusCompleted {
 			ended++
 		}
@@ -57,9 +57,9 @@ func RenderTrackerList(params TrackerListParams) string {
 	// of the way once the stream is idle. While streaming it stays up: the model
 	// can still add items, and a list that vanished mid-turn would flicker back.
 	//
-	// Derived from the tasks in hand rather than asked of the store: the count
+	// Derived from the items in hand rather than asked of the store: the count
 	// above already answers it, and one snapshot cannot disagree with itself.
-	if ended == len(params.Tasks) && !params.StreamActive {
+	if ended == len(params.Items) && !params.StreamActive {
 		return ""
 	}
 
@@ -67,64 +67,64 @@ func RenderTrackerList(params TrackerListParams) string {
 	headerStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.TextDim).Bold(true)
 	mutedStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
 	sb.WriteString("  " + headerStyle.Render("Tasks") + " " +
-		mutedStyle.Render(fmt.Sprintf("(%d%%)", ended*100/len(params.Tasks))))
+		mutedStyle.Render(fmt.Sprintf("(%d%%)", ended*100/len(params.Items))))
 	sb.WriteString("\n")
 
-	visible := params.Tasks[max(0, len(params.Tasks)-maxVisibleTasks):]
-	if hidden := len(params.Tasks) - len(visible); hidden > 0 {
+	visible := params.Items[max(0, len(params.Items)-maxVisibleItems):]
+	if hidden := len(params.Items) - len(visible); hidden > 0 {
 		// Name the drop; a silent truncation reads as the whole list.
 		sb.WriteString("  " + overflowStyle.Render(fmt.Sprintf("+%d more above", hidden)) + "\n")
 	}
 
-	idWidth := taskIDWidth(visible)
+	idWidth := itemIDWidth(visible)
 
 	// Classify only the rows actually drawn. Liveness is the expensive input and
 	// the header above does not need it — progress counts finished work, which
-	// no executor can still be advancing.
+	// no worker can still be advancing.
 	for _, t := range visible {
 		phase := phaseOf(t, params.Executing != nil && params.Executing(t))
-		sb.WriteString(renderTask(t, phase, params.Width, idWidth, params.Blockers, params.Blink))
+		sb.WriteString(renderItem(t, phase, params.Width, idWidth, params.Blockers, params.Blink))
 	}
 
 	return sb.String()
 }
 
-// taskPhase is how a task reads to the user. It collapses the recorded status,
-// how a finished task ended, and whether an executor is actually running it
+// itemPhase is how an item reads to the user. It collapses the recorded status,
+// how a finished item ended, and whether an executor is actually running it
 // into one exhaustive set, so each render branch answers to exactly one phase.
-type taskPhase int
+type itemPhase int
 
 const (
-	taskWaiting  taskPhase = iota // nothing has started it
-	taskRunning                   // in progress, with a live executor
-	taskStalled                   // marked in progress, but nothing is executing it
-	taskAborted                   // ended without finishing its work
-	taskFinished                  // ended having done its work
+	itemWaiting  itemPhase = iota // nothing has started it
+	itemRunning                   // in progress, with a live executor
+	itemStalled                   // marked in progress, but nothing is executing it
+	itemAborted                   // ended without finishing its work
+	itemFinished                  // ended having done its work
 )
 
-// phaseOf classifies a task. executing answers whether its executor is running;
-// it only distinguishes taskRunning from taskStalled, since a task that already
-// reached a terminal status has no executor left to ask about.
-func phaseOf(t *todo.Task, executing bool) taskPhase {
+// phaseOf classifies an item. executing answers whether its executor is running;
+// it only distinguishes itemRunning from itemStalled, since an item that already
+// reached a terminal status has no worker left to ask about.
+func phaseOf(t *todo.Item, executing bool) itemPhase {
 	switch t.Status {
 	case todo.StatusCompleted:
 		if todo.EndedAbnormally(t) {
-			return taskAborted
+			return itemAborted
 		}
-		return taskFinished
+		return itemFinished
 	case todo.StatusInProgress:
 		if executing {
-			return taskRunning
+			return itemRunning
 		}
-		return taskStalled
+		return itemStalled
 	default:
-		return taskWaiting
+		return itemWaiting
 	}
 }
 
-// activeText prefers the task's active phrasing ("Auditing deps") over its
+// activeText prefers the item's active phrasing ("Auditing deps") over its
 // subject ("Audit deps") while it is the one being worked on.
-func activeText(t *todo.Task, maxTextLen int) string {
+func activeText(t *todo.Item, maxTextLen int) string {
 	text := t.ActiveForm
 	if text == "" {
 		text = t.Subject
@@ -132,7 +132,7 @@ func activeText(t *todo.Task, maxTextLen int) string {
 	return kit.TruncateText(text, maxTextLen)
 }
 
-func renderTask(t *todo.Task, phase taskPhase, width, idWidth int, blockers func(string) []string, blink int) string {
+func renderItem(t *todo.Item, phase itemPhase, width, idWidth int, blockers func(string) []string, blink int) string {
 	indent := "  "
 	idTag := fmt.Sprintf("%-*s", idWidth, "#"+t.ID)
 	maxTextLen := max(width-len(indent)-idWidth-8, 12)
@@ -140,22 +140,22 @@ func renderTask(t *todo.Task, phase taskPhase, width, idWidth int, blockers func
 	mutedStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
 
 	switch phase {
-	case taskAborted:
+	case itemAborted:
 		abortedStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Error)
 		detail := mutedStyle.Render("[" + todo.BackgroundStatusDetail(t) + "]")
-		return renderTaskLine(indent, abortedStyle.Render("!"), idTag, subject, detail)
+		return renderItemLine(indent, abortedStyle.Render("!"), idTag, subject, detail)
 
-	case taskFinished:
-		return renderTaskLine(indent, trackerCompletedStyle.Render("●"), idTag, subject, "")
+	case itemFinished:
+		return renderItemLine(indent, trackerCompletedStyle.Render("●"), idTag, subject, "")
 
-	case taskStalled:
-		// Nothing is executing this task, so draw it at rest. Reaching here
+	case itemStalled:
+		// Nothing is executing this item, so draw it at rest. Reaching here
 		// means the status outlived its executor within a live session — the
 		// model marked an item in_progress and moved on without closing it.
 		// Animating would claim work that isn't happening.
-		return renderTaskLine(indent, mutedStyle.Render("◌"), idTag, activeText(t, maxTextLen), mutedStyle.Render("[stalled]"))
+		return renderItemLine(indent, mutedStyle.Render("◌"), idTag, activeText(t, maxTextLen), mutedStyle.Render("[stalled]"))
 
-	case taskRunning:
+	case itemRunning:
 		// Pulse on the shared frame tick (a true ~360ms clock; see FrameClock)
 		// rather than the wall clock, which only sampled on redraws and so
 		// flickered irregularly.
@@ -169,7 +169,7 @@ func renderTask(t *todo.Task, phase taskPhase, width, idWidth int, blockers func
 		if elapsed := formatElapsedTime(t.StatusChangedAt); elapsed != "" {
 			detail = mutedStyle.Render(elapsed)
 		}
-		return renderTaskLine(indent, activeStyle.Render(activeIcon), idTag, activeText(t, maxTextLen), detail)
+		return renderItemLine(indent, activeStyle.Render(activeIcon), idTag, activeText(t, maxTextLen), detail)
 
 	default:
 		detail := ""
@@ -183,11 +183,11 @@ func renderTask(t *todo.Task, phase taskPhase, width, idWidth int, blockers func
 				detail = blockedStyle.Render("← " + strings.Join(blockerRefs, ", "))
 			}
 		}
-		return renderTaskLine(indent, trackerPendingStyle.Render("○"), idTag, subject, detail)
+		return renderItemLine(indent, trackerPendingStyle.Render("○"), idTag, subject, detail)
 	}
 }
 
-func renderTaskLine(indent, icon, id, subject, detail string) string {
+func renderItemLine(indent, icon, id, subject, detail string) string {
 	line := indent + icon + "  " + id + "  " + subject
 	if detail != "" {
 		line += "  " + detail
@@ -195,9 +195,9 @@ func renderTaskLine(indent, icon, id, subject, detail string) string {
 	return line + "\n"
 }
 
-func taskIDWidth(tasks []*todo.Task) int {
+func itemIDWidth(items []*todo.Item) int {
 	width := 2
-	for _, t := range tasks {
+	for _, t := range items {
 		if n := len("#" + t.ID); n > width {
 			width = n
 		}

--- a/internal/app/conv/tracker_view_test.go
+++ b/internal/app/conv/tracker_view_test.go
@@ -36,11 +36,11 @@ func TestRenderTrackerListShowsTaskStatus(t *testing.T) {
 	_ = todo.Default().Update(pending.ID, todo.WithStatus(todo.StatusPending))
 
 	view := RenderTrackerList(TrackerListParams{
-		Tasks:        todo.Default().List(),
+		Items:        todo.Default().List(),
 		StreamActive: true,
 		Width:        120,
 		Blockers:     todo.Default().OpenBlockers,
-		Executing:    func(*todo.Task) bool { return true },
+		Executing:    func(*todo.Item) bool { return true },
 	})
 	plain := stripANSI(view)
 
@@ -64,14 +64,14 @@ func TestRenderTrackerListShowsTaskStatus(t *testing.T) {
 }
 
 func TestRenderTaskAnimatesInProgressItem(t *testing.T) {
-	task := &todo.Task{ID: "1", Subject: "Fix auth module", Status: todo.StatusInProgress}
+	task := &todo.Item{ID: "1", Subject: "Fix auth module", Status: todo.StatusInProgress}
 
 	// The pulse is driven by the shared Blink tick, not the wall clock, so a
 	// full cadence is deterministic: advancing Blink across one period must show
 	// both the solid (●) and dim (◌) phases.
 	var hasSolid, hasDim bool
 	for blink := range 4 * trackerPulseTicks {
-		frame := stripANSI(renderTask(task, taskRunning, 80, 2, nil, blink))
+		frame := stripANSI(renderItem(task, itemRunning, 80, 2, nil, blink))
 		if strings.Contains(frame, "●") {
 			hasSolid = true
 		}
@@ -103,10 +103,10 @@ func TestRenderTrackerListOrdersByID(t *testing.T) {
 	_ = todo.Default().Update(pending2.ID, todo.WithStatus(todo.StatusPending))
 
 	view := RenderTrackerList(TrackerListParams{
-		Tasks:        todo.Default().List(),
+		Items:        todo.Default().List(),
 		StreamActive: true,
 		Width:        120,
-		Executing:    func(*todo.Task) bool { return true },
+		Executing:    func(*todo.Item) bool { return true },
 	})
 	plain := stripANSI(view)
 
@@ -121,11 +121,11 @@ func TestRenderTrackerListOrdersByID(t *testing.T) {
 // every frame. The status field alone used to drive the pulse, so a task the
 // model never closed out kept animating after the turn ended.
 func TestRenderTaskHoldsStillWhenStalled(t *testing.T) {
-	task := &todo.Task{ID: "1", Subject: "Fix auth module", Status: todo.StatusInProgress}
+	task := &todo.Item{ID: "1", Subject: "Fix auth module", Status: todo.StatusInProgress}
 
-	first := stripANSI(renderTask(task, taskStalled, 80, 2, nil, 0))
+	first := stripANSI(renderItem(task, itemStalled, 80, 2, nil, 0))
 	for blink := range 4 * trackerPulseTicks {
-		if frame := stripANSI(renderTask(task, taskStalled, 80, 2, nil, blink)); frame != first {
+		if frame := stripANSI(renderItem(task, itemStalled, 80, 2, nil, blink)); frame != first {
 			t.Fatalf("stalled task animated across frames:\n%q\n%q", first, frame)
 		}
 	}
@@ -139,28 +139,28 @@ func TestRenderTaskHoldsStillWhenStalled(t *testing.T) {
 // unfinished work and must keep the list on screen. Gating on executors instead
 // would hide exactly the row #342 added to surface.
 func TestRenderTrackerListVisibility(t *testing.T) {
-	stalled := &todo.Task{ID: "1", Subject: "Fix auth module", Status: todo.StatusInProgress}
-	done := &todo.Task{ID: "1", Subject: "Fix auth module", Status: todo.StatusCompleted}
+	stalled := &todo.Item{ID: "1", Subject: "Fix auth module", Status: todo.StatusInProgress}
+	done := &todo.Item{ID: "1", Subject: "Fix auth module", Status: todo.StatusCompleted}
 
 	cases := []struct {
 		name         string
-		tasks        []*todo.Task
+		tasks        []*todo.Item
 		streamActive bool
 		wantVisible  bool
 	}{
 		{"no tasks", nil, true, false},
-		{"complete and idle", []*todo.Task{done}, false, false},
-		{"complete but still streaming", []*todo.Task{done}, true, true},
-		{"stalled item keeps the list up", []*todo.Task{stalled}, false, true},
+		{"complete and idle", []*todo.Item{done}, false, false},
+		{"complete but still streaming", []*todo.Item{done}, true, true},
+		{"stalled item keeps the list up", []*todo.Item{stalled}, false, true},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			view := RenderTrackerList(TrackerListParams{
-				Tasks:        tc.tasks,
+				Items:        tc.tasks,
 				StreamActive: tc.streamActive,
 				Width:        120,
-				Executing:    func(*todo.Task) bool { return false },
+				Executing:    func(*todo.Item) bool { return false },
 			})
 			if visible := view != ""; visible != tc.wantVisible {
 				t.Fatalf("visible = %v, want %v; rendered:\n%s", visible, tc.wantVisible, stripANSI(view))
@@ -172,10 +172,10 @@ func TestRenderTrackerListVisibility(t *testing.T) {
 // The list outlives the turn that filled it, so windowing from the front would
 // pin the panel to the turn that stalled and hide everything since.
 func TestRenderTrackerListWindowsOnNewestTasks(t *testing.T) {
-	tasks := make([]*todo.Task, 0, maxVisibleTasks+3)
-	for i := 1; i <= maxVisibleTasks+3; i++ {
+	tasks := make([]*todo.Item, 0, maxVisibleItems+3)
+	for i := 1; i <= maxVisibleItems+3; i++ {
 		id := strconv.Itoa(i)
-		tasks = append(tasks, &todo.Task{
+		tasks = append(tasks, &todo.Item{
 			ID:      id,
 			Subject: "Task " + id,
 			Status:  todo.StatusCompleted,
@@ -185,10 +185,10 @@ func TestRenderTrackerListWindowsOnNewestTasks(t *testing.T) {
 	tasks[0].Status = todo.StatusInProgress
 
 	plain := stripANSI(RenderTrackerList(TrackerListParams{
-		Tasks:        tasks,
+		Items:        tasks,
 		StreamActive: true,
 		Width:        120,
-		Executing:    func(*todo.Task) bool { return false },
+		Executing:    func(*todo.Item) bool { return false },
 	}))
 
 	ids := taskIDRe.FindAllString(plain, -1)
@@ -214,25 +214,25 @@ func TestPhaseOf(t *testing.T) {
 		status    string
 		metadata  map[string]any
 		executing bool
-		want      taskPhase
+		want      itemPhase
 	}{
-		{"pending", todo.StatusPending, nil, false, taskWaiting},
-		{"in progress with executor", todo.StatusInProgress, nil, true, taskRunning},
-		{"in progress without executor", todo.StatusInProgress, nil, false, taskStalled},
-		{"completed", todo.StatusCompleted, nil, false, taskFinished},
-		{"worker finished", todo.StatusCompleted, worker(""), false, taskFinished},
-		{"worker failed", todo.StatusCompleted, worker("failed"), false, taskAborted},
-		{"worker killed", todo.StatusCompleted, worker("killed"), false, taskAborted},
-		{"worker stopped", todo.StatusCompleted, worker("stopped"), false, taskAborted},
-		{"worker orphaned", todo.StatusCompleted, worker(todo.StatusDetailInterrupted), false, taskAborted},
+		{"pending", todo.StatusPending, nil, false, itemWaiting},
+		{"in progress with executor", todo.StatusInProgress, nil, true, itemRunning},
+		{"in progress without executor", todo.StatusInProgress, nil, false, itemStalled},
+		{"completed", todo.StatusCompleted, nil, false, itemFinished},
+		{"worker finished", todo.StatusCompleted, worker(""), false, itemFinished},
+		{"worker failed", todo.StatusCompleted, worker("failed"), false, itemAborted},
+		{"worker killed", todo.StatusCompleted, worker("killed"), false, itemAborted},
+		{"worker stopped", todo.StatusCompleted, worker("stopped"), false, itemAborted},
+		{"worker orphaned", todo.StatusCompleted, worker(todo.StatusDetailInterrupted), false, itemAborted},
 		// A terminal status wins regardless of what the executor says, so a
 		// stale "still running" answer cannot resurrect a finished task.
-		{"completed despite executor", todo.StatusCompleted, nil, true, taskFinished},
+		{"completed despite executor", todo.StatusCompleted, nil, true, itemFinished},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			task := &todo.Task{ID: "1", Subject: "Task", Status: tc.status, Metadata: tc.metadata}
+			task := &todo.Item{ID: "1", Subject: "Task", Status: tc.status, Metadata: tc.metadata}
 			if got := phaseOf(task, tc.executing); got != tc.want {
 				t.Fatalf("phaseOf = %v, want %v", got, tc.want)
 			}

--- a/internal/app/model_lifecycle.go
+++ b/internal/app/model_lifecycle.go
@@ -214,6 +214,14 @@ func (m *model) wireTaskLifecycle(hookEngine hook.Handler) {
 	task.SetLifecycleHandler(taskLifecycleFunc{
 		onCreated: func(info task.TaskInfo) {
 			fireHook(hook.TaskCreated, info)
+
+			// The entry is born here rather than off the launching tool's
+			// result, so that it exists before the task can possibly finish:
+			// the manager notifies from inside CreateBashTask / RegisterTask,
+			// while the goroutine that can complete the task is only started
+			// afterwards. Reading it off the tool result instead let a
+			// short-lived task complete an entry that did not exist yet.
+			todo.TrackWorker(trackerSvc, info)
 		},
 		onCompleted: func(info task.TaskInfo) {
 			fireHook(hook.TaskCompleted, info)

--- a/internal/app/model_task_lifecycle_test.go
+++ b/internal/app/model_task_lifecycle_test.go
@@ -8,20 +8,20 @@ import (
 	"github.com/genai-io/san/internal/todo"
 )
 
-// A background task's tracker entry must exist before the task can finish.
+// A background task's tracker item must exist before the task can finish.
 //
-// The entry used to be built from the launching tool's result, which reaches
+// The item used to be built from the launching tool's result, which reaches
 // the UI goroutine well after the task is already running. A task that ended
 // first — a subagent rejected by its provider, a bash command that exits at
-// once — completed an entry that did not exist yet, so the completion was
-// dropped and the entry created afterwards named a task that had already
+// once — completed an item that did not exist yet, so the completion was
+// dropped and the item created afterwards named a task that had already
 // ended. It stayed in_progress for the rest of the session: rendered
 // [stalled] forever, and never letting the tracker panel reset.
 //
-// Registering the task is now what creates the entry, and the manager
+// Registering the task is now what creates the item, and the manager
 // announces that from inside RegisterTask — before the caller has a goroutine
 // that could complete it — so the ordering holds by construction.
-func TestWorkerEntrySurvivesImmediateCompletion(t *testing.T) {
+func TestWorkerItemSurvivesImmediateCompletion(t *testing.T) {
 	todo.Initialize(todo.Options{})
 	t.Cleanup(func() {
 		todo.Default().Reset()
@@ -38,11 +38,11 @@ func TestWorkerEntrySurvivesImmediateCompletion(t *testing.T) {
 	task.Default().RegisterTask(worker)
 	worker.Complete(nil)
 
-	entries := todo.Default().List()
-	if len(entries) != 1 {
-		t.Fatalf("expected 1 tracker entry, got %d", len(entries))
+	items := todo.Default().List()
+	if len(items) != 1 {
+		t.Fatalf("expected 1 tracker item, got %d", len(items))
 	}
-	if entries[0].Status != todo.StatusCompleted {
-		t.Fatalf("status = %q, want %q — the entry was stranded", entries[0].Status, todo.StatusCompleted)
+	if items[0].Status != todo.StatusCompleted {
+		t.Fatalf("status = %q, want %q — the item was stranded", items[0].Status, todo.StatusCompleted)
 	}
 }

--- a/internal/app/model_task_lifecycle_test.go
+++ b/internal/app/model_task_lifecycle_test.go
@@ -1,0 +1,48 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/genai-io/san/internal/task"
+	"github.com/genai-io/san/internal/todo"
+)
+
+// A background task's tracker entry must exist before the task can finish.
+//
+// The entry used to be built from the launching tool's result, which reaches
+// the UI goroutine well after the task is already running. A task that ended
+// first — a subagent rejected by its provider, a bash command that exits at
+// once — completed an entry that did not exist yet, so the completion was
+// dropped and the entry created afterwards named a task that had already
+// ended. It stayed in_progress for the rest of the session: rendered
+// [stalled] forever, and never letting the tracker panel reset.
+//
+// Registering the task is now what creates the entry, and the manager
+// announces that from inside RegisterTask — before the caller has a goroutine
+// that could complete it — so the ordering holds by construction.
+func TestWorkerEntrySurvivesImmediateCompletion(t *testing.T) {
+	todo.Initialize(todo.Options{})
+	t.Cleanup(func() {
+		todo.Default().Reset()
+		task.SetLifecycleHandler(nil)
+	})
+
+	m := &model{services: services{Tracker: todo.Default()}}
+	m.wireTaskLifecycle(nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	worker := task.NewAgentTask("bg-1", "Explore", "Audit deps", ctx, cancel)
+	task.Default().RegisterTask(worker)
+	worker.Complete(nil)
+
+	entries := todo.Default().List()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 tracker entry, got %d", len(entries))
+	}
+	if entries[0].Status != todo.StatusCompleted {
+		t.Fatalf("status = %q, want %q — the entry was stranded", entries[0].Status, todo.StatusCompleted)
+	}
+}

--- a/internal/app/model_tool_effects.go
+++ b/internal/app/model_tool_effects.go
@@ -1,7 +1,9 @@
 // Side effects triggered by tool calls: cwd-changing tools (Bash, worktree),
-// file-touching tools (Write/Edit/Read), agent-launching tools (background
-// task tracking), and large-output persistence (oversized ToolResult.Content
-// gets paged out to a blob and replaced with a preview + reference).
+// file-touching tools (Write/Edit/Read), and large-output persistence
+// (oversized ToolResult.Content gets paged out to a blob and replaced with a
+// preview + reference). Background tasks are not tracked from here — they are
+// tracked from the task manager's lifecycle notifications (wireTaskLifecycle),
+// which fire early enough that a task cannot finish before its entry exists.
 package app
 
 import (
@@ -10,7 +12,6 @@ import (
 
 	"github.com/genai-io/san/internal/app/kit"
 	"github.com/genai-io/san/internal/core"
-	"github.com/genai-io/san/internal/todo"
 	"github.com/genai-io/san/internal/tool"
 )
 
@@ -19,7 +20,6 @@ func (m *model) applyToolSideEffects(toolName string, sideEffect any) {
 	if !ok {
 		return
 	}
-	m.trackAgentLaunch(toolName, resp)
 	switch toolName {
 	case "Bash":
 		if newCwd := kit.MapString(resp, "cwd"); newCwd != "" {
@@ -48,26 +48,6 @@ func (m *model) applyToolSideEffects(toolName string, sideEffect any) {
 			}
 		}
 	}
-}
-
-func (m *model) trackAgentLaunch(toolName string, resp map[string]any) {
-	if !tool.IsAgentToolName(toolName) {
-		return
-	}
-	bg, ok := resp["backgroundTask"].(map[string]any)
-	if !ok {
-		return
-	}
-	launch := todo.BackgroundTaskLaunch{
-		TaskID:      kit.MapString(bg, "taskId"),
-		AgentName:   kit.MapString(bg, "agentName"),
-		AgentType:   kit.MapString(bg, "agentType"),
-		Description: kit.MapString(bg, "description"),
-	}
-	if launch.TaskID == "" {
-		return
-	}
-	todo.TrackWorker(m.services.Tracker, launch)
 }
 
 func (m *model) persistOverflow(result *core.ToolResult) {

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -48,7 +48,7 @@ type resizableOverlay interface {
 	Resize(width, height int)
 }
 
-// pasteHandler is the optional half of overlayPanel for text-entry dialogs.
+// pasteHandler is the optional half of overlayPanel for text-item dialogs.
 // Bracketed paste arrives as tea.PasteMsg, which is not a tea.KeyMsg, so it
 // never reaches HandleKeypress — it needs its own routing (see Update). An
 // overlay that accepts pasted text implements this; one that doesn't has the
@@ -333,12 +333,12 @@ func (m *model) hasRunningBackgroundTask() bool {
 	return m.services.Task.HasRunning()
 }
 
-// executingTrackerTask reports whether the executor behind a tracker entry is
-// running right now. A worker entry names a background task, so todo resolves
+// executingTrackerItem reports whether the executor behind a tracker item is
+// running right now. A worker item names a background task, so todo resolves
 // it against the task manager. A plan item authored by the model has no
 // executor of its own — the main agent loop advances it, so it runs exactly
 // while that loop streams.
-func (m *model) executingTrackerTask(t *todo.Task) bool {
+func (m *model) executingTrackerItem(t *todo.Item) bool {
 	if todo.BackgroundTaskID(t) == "" {
 		return m.conv.Stream.Active
 	}

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -64,7 +64,7 @@ func (m *model) viewString() (string, *tea.Cursor) {
 // isDockedModal reports whether the active overlay docks above the input area
 // — rendered between separators with the task tracker still visible — rather
 // than taking over the full screen like the slash-command pickers do. Only
-// the Question, Approval, and secret-entry modals dock.
+// the Question, Approval, and secret-item modals dock.
 func isDockedModal(ov overlayPanel) bool {
 	switch ov.(type) {
 	case *conv.QuestionPrompt, *input.ApprovalModel, *input.SecretPromptModel:
@@ -262,11 +262,11 @@ func (m *model) renderTrackerList() string {
 		return ""
 	}
 	return conv.RenderTrackerList(conv.TrackerListParams{
-		Tasks:        m.services.Tracker.List(),
+		Items:        m.services.Tracker.List(),
 		StreamActive: m.conv.Stream.Active,
 		Width:        m.env.Width,
 		Blockers:     m.services.Tracker.OpenBlockers,
-		Executing:    m.executingTrackerTask,
+		Executing:    m.executingTrackerItem,
 		Blink:        m.conv.Spinner.Frame(),
 	})
 }
@@ -376,7 +376,7 @@ func buildAgentColors(configs []*subagent.AgentConfig) map[string]string {
 	return colors
 }
 
-func buildTaskOwnerMap(tasks []*todo.Task) map[string]string {
+func buildTaskOwnerMap(tasks []*todo.Item) map[string]string {
 	if len(tasks) == 0 {
 		return nil
 	}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -23,7 +23,7 @@ type Store struct {
 
 	// lastEmittedState caches the projected state most recently written for each
 	// session so Save emits only changed paths. Cold-start after a process
-	// restart pays one full snapshot per session (no entry in the cache means
+	// restart pays one full snapshot per session (no item in the cache means
 	// every non-default field looks "changed" vs the zero state, which is what
 	// we want — the projector still applies last-wins).
 	lastEmittedState map[string]transcript.State
@@ -32,9 +32,9 @@ type Store struct {
 type Snapshot struct {
 	Metadata SessionMetadata
 	Messages []core.Message
-	Tasks    []todo.Task
+	Tasks    []todo.Item
 
-	// OmitMessageWrites skips the per-entry AppendMessage loop in Save. Used
+	// OmitMessageWrites skips the per-item AppendMessage loop in Save. Used
 	// by the main TUI path where the agent's Recorder already persists every
 	// message in causal order via the OnAppend event — running Save's loop on
 	// top would write a second copy under a different ID (the TUI
@@ -153,7 +153,7 @@ func (s *Store) Load(id string) (*Snapshot, error) {
 // Save persists the snapshot via append-only writes:
 //
 //  1. Start (idempotent; no-op if the transcript already exists)
-//  2. AppendMessage per entry (deduped by message ID — cheap re-saves)
+//  2. AppendMessage per item (deduped by message ID — cheap re-saves)
 //  3. PatchState with the full projected state (last-wins on read)
 //
 // No file rewrites; each call writes only the records that didn't already
@@ -214,7 +214,7 @@ func (s *Store) Save(sess *Snapshot) error {
 		Tag:        sess.Metadata.Tag,
 		Mode:       sess.Metadata.Mode,
 		AutoPilot:  sess.Metadata.AutoPilot,
-		Tasks:      transcript.TrackerTaskViewsFromTasks(sess.Tasks),
+		Tasks:      transcript.TrackerItemViewsFromItems(sess.Tasks),
 	}
 	if s.lastEmittedState == nil {
 		s.lastEmittedState = make(map[string]transcript.State)
@@ -355,7 +355,7 @@ func (s *Store) loadSnapshot(ctx context.Context, sessionID string) (*Snapshot, 
 	sess := &Snapshot{
 		Metadata: transcript.MetadataFromTranscript(tx),
 		Messages: messagesFromNodes(tx.Messages),
-		Tasks:    transcript.TrackerTasksFromView(tx.State.Tasks),
+		Tasks:    transcript.TrackerItemsFromView(tx.State.Tasks),
 	}
 
 	if sess.Metadata.Title == "" {

--- a/internal/session/transcript/projector.go
+++ b/internal/session/transcript/projector.go
@@ -151,11 +151,11 @@ func applyStatePatch(state *State, patch *StateRecord) error {
 			}
 			state.AutoPilot = v
 		case PatchPathTasks:
-			var tasks []todo.Task
+			var tasks []todo.Item
 			if err := json.Unmarshal(op.Value, &tasks); err != nil {
 				return fmt.Errorf("patch %s: %w", op.Path, err)
 			}
-			state.Tasks = TrackerTaskViewsFromTasks(tasks)
+			state.Tasks = TrackerItemViewsFromItems(tasks)
 		case PatchPathWorktree:
 			if string(op.Value) == "null" {
 				state.Worktree = nil

--- a/internal/session/transcript/projector_test.go
+++ b/internal/session/transcript/projector_test.go
@@ -83,7 +83,7 @@ func TestProjectAutoPilotRoundTrip(t *testing.T) {
 
 func TestProjectTasksAndWorktreePatches(t *testing.T) {
 	taskTime := time.Date(2026, 4, 6, 14, 10, 0, 0, time.UTC)
-	task := todo.Task{
+	task := todo.Item{
 		ID:              "1",
 		Subject:         "Refactor",
 		Status:          todo.StatusInProgress,
@@ -94,7 +94,7 @@ func TestProjectTasksAndWorktreePatches(t *testing.T) {
 	wt := &WorktreeState{OriginalCwd: "/repo", WorktreePath: "/repo/.wt/1", WorktreeName: "fix-1"}
 	transcript, err := Project([]Record{
 		{SessionID: "tx-1", Time: time.Now(), Type: SessionStarted},
-		{SessionID: "tx-1", Time: time.Now(), Type: SessionStatePatched, State: &StateRecord{Ops: []PatchOp{PatchTasks([]todo.Task{task}), PatchWorktree(wt)}}},
+		{SessionID: "tx-1", Time: time.Now(), Type: SessionStatePatched, State: &StateRecord{Ops: []PatchOp{PatchTasks([]todo.Item{task}), PatchWorktree(wt)}}},
 	})
 	if err != nil {
 		t.Fatalf("Project(): %v", err)

--- a/internal/session/transcript/store.go
+++ b/internal/session/transcript/store.go
@@ -116,7 +116,7 @@ func PatchLastPrompt(prompt string) PatchOp { return mustPatch(PatchPathLastProm
 func PatchTag(tag string) PatchOp           { return mustPatch(PatchPathTag, tag) }
 func PatchMode(mode string) PatchOp         { return mustPatch(PatchPathMode, mode) }
 func PatchAutoPilot(v string) PatchOp       { return mustPatch(PatchPathAutoPilot, v) }
-func PatchTasks(tasks []todo.Task) PatchOp {
+func PatchTasks(tasks []todo.Item) PatchOp {
 	return mustPatch(PatchPathTasks, tasks)
 }
 func PatchWorktree(worktree *WorktreeState) PatchOp { return mustPatch(PatchPathWorktree, worktree) }
@@ -143,7 +143,7 @@ func StateOpsDiff(prev, next State) []PatchOp {
 		ops = append(ops, PatchAutoPilot(next.AutoPilot))
 	}
 	if !tasksEqual(prev.Tasks, next.Tasks) {
-		ops = append(ops, PatchTasks(TrackerTasksFromView(next.Tasks)))
+		ops = append(ops, PatchTasks(TrackerItemsFromView(next.Tasks)))
 	}
 	if !worktreeEqual(prev.Worktree, next.Worktree) {
 		ops = append(ops, PatchWorktree(next.Worktree))
@@ -151,7 +151,7 @@ func StateOpsDiff(prev, next State) []PatchOp {
 	return ops
 }
 
-func tasksEqual(a, b []TrackerTaskView) bool {
+func tasksEqual(a, b []TrackerItemView) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/internal/session/transcript/store_test.go
+++ b/internal/session/transcript/store_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestPatchHelpersEncodeExpectedPayloads(t *testing.T) {
 	taskTime := time.Date(2026, 4, 6, 13, 0, 0, 0, time.UTC)
-	task := todo.Task{
+	task := todo.Item{
 		ID:              "1",
 		Subject:         "Refactor",
 		Status:          todo.StatusInProgress,
@@ -36,8 +36,8 @@ func TestPatchHelpersEncodeExpectedPayloads(t *testing.T) {
 		}
 	}
 
-	taskPatch := PatchTasks([]todo.Task{task})
-	var decodedTasks []todo.Task
+	taskPatch := PatchTasks([]todo.Item{task})
+	var decodedTasks []todo.Item
 	if err := json.Unmarshal(taskPatch.Value, &decodedTasks); err != nil {
 		t.Fatalf("Unmarshal(task patch): %v", err)
 	}

--- a/internal/session/transcript/types.go
+++ b/internal/session/transcript/types.go
@@ -38,11 +38,11 @@ type State struct {
 	// internal/setting dependency; the app marshals/unmarshals it.
 	AutoPilot string
 
-	Tasks    []TrackerTaskView
+	Tasks    []TrackerItemView
 	Worktree *WorktreeState
 }
 
-type TrackerTaskView struct {
+type TrackerItemView struct {
 	ID              string
 	Subject         string
 	Description     string

--- a/internal/session/transcript/types_test.go
+++ b/internal/session/transcript/types_test.go
@@ -29,7 +29,7 @@ func TestTranscriptTypesCarryProjectedState(t *testing.T) {
 		State: State{
 			Title:      "Fix persistence",
 			LastPrompt: "continue",
-			Tasks: []TrackerTaskView{{
+			Tasks: []TrackerItemView{{
 				ID:      "1",
 				Subject: "Refactor store",
 				Status:  "in_progress",
@@ -95,7 +95,7 @@ func TestMetadataAndTaskViewHelpers(t *testing.T) {
 	}
 
 	taskTime := now.Add(2 * time.Minute)
-	tasks := []todo.Task{{
+	tasks := []todo.Item{{
 		ID:              "1",
 		Subject:         "Refactor",
 		Description:     "Move projection helpers",
@@ -108,8 +108,8 @@ func TestMetadataAndTaskViewHelpers(t *testing.T) {
 		UpdatedAt:       taskTime,
 		StatusChangedAt: taskTime,
 	}}
-	views := TrackerTaskViewsFromTasks(tasks)
-	roundTrip := TrackerTasksFromView(views)
+	views := TrackerItemViewsFromItems(tasks)
+	roundTrip := TrackerItemsFromView(views)
 	if !reflect.DeepEqual(roundTrip, tasks) {
 		t.Fatalf("task roundtrip mismatch:\n got: %+v\nwant: %+v", roundTrip, tasks)
 	}

--- a/internal/session/transcript/view.go
+++ b/internal/session/transcript/view.go
@@ -55,41 +55,41 @@ func MetadataFromListItem(item ListItem, cwd string) MetadataView {
 	}
 }
 
-func TrackerTasksFromView(tasks []TrackerTaskView) []todo.Task {
-	out := make([]todo.Task, 0, len(tasks))
-	for _, task := range tasks {
-		out = append(out, todo.Task{
-			ID:              task.ID,
-			Subject:         task.Subject,
-			Description:     task.Description,
-			ActiveForm:      task.ActiveForm,
-			Status:          task.Status,
-			Owner:           task.Owner,
-			Blocks:          append([]string(nil), task.Blocks...),
-			BlockedBy:       append([]string(nil), task.BlockedBy...),
-			CreatedAt:       task.CreatedAt,
-			UpdatedAt:       task.UpdatedAt,
-			StatusChangedAt: task.StatusChangedAt,
+func TrackerItemsFromView(items []TrackerItemView) []todo.Item {
+	out := make([]todo.Item, 0, len(items))
+	for _, item := range items {
+		out = append(out, todo.Item{
+			ID:              item.ID,
+			Subject:         item.Subject,
+			Description:     item.Description,
+			ActiveForm:      item.ActiveForm,
+			Status:          item.Status,
+			Owner:           item.Owner,
+			Blocks:          append([]string(nil), item.Blocks...),
+			BlockedBy:       append([]string(nil), item.BlockedBy...),
+			CreatedAt:       item.CreatedAt,
+			UpdatedAt:       item.UpdatedAt,
+			StatusChangedAt: item.StatusChangedAt,
 		})
 	}
 	return out
 }
 
-func TrackerTaskViewsFromTasks(tasks []todo.Task) []TrackerTaskView {
-	out := make([]TrackerTaskView, 0, len(tasks))
-	for _, task := range tasks {
-		out = append(out, TrackerTaskView{
-			ID:              task.ID,
-			Subject:         task.Subject,
-			Description:     task.Description,
-			ActiveForm:      task.ActiveForm,
-			Status:          task.Status,
-			Owner:           task.Owner,
-			Blocks:          append([]string(nil), task.Blocks...),
-			BlockedBy:       append([]string(nil), task.BlockedBy...),
-			CreatedAt:       task.CreatedAt,
-			UpdatedAt:       task.UpdatedAt,
-			StatusChangedAt: task.StatusChangedAt,
+func TrackerItemViewsFromItems(items []todo.Item) []TrackerItemView {
+	out := make([]TrackerItemView, 0, len(items))
+	for _, item := range items {
+		out = append(out, TrackerItemView{
+			ID:              item.ID,
+			Subject:         item.Subject,
+			Description:     item.Description,
+			ActiveForm:      item.ActiveForm,
+			Status:          item.Status,
+			Owner:           item.Owner,
+			Blocks:          append([]string(nil), item.Blocks...),
+			BlockedBy:       append([]string(nil), item.BlockedBy...),
+			CreatedAt:       item.CreatedAt,
+			UpdatedAt:       item.UpdatedAt,
+			StatusChangedAt: item.StatusChangedAt,
 		})
 	}
 	return out

--- a/internal/task/bash_task.go
+++ b/internal/task/bash_task.go
@@ -3,6 +3,7 @@ package task
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os/exec"
 	"sync"
 	"syscall"
@@ -100,13 +101,25 @@ func (t *BashTask) GetOutput() string {
 	return t.output.String()
 }
 
-// Complete marks the task as completed
+// Complete records the terminal status of a bash task that has exited, the
+// counterpart to AgentTask.Complete and classifying the same three outcomes.
+//
+// A cancelled run reaches cmd.Wait as an ordinary signal death ("signal:
+// killed"), never as context.Canceled, so unlike the agent case the error
+// alone cannot tell a deliberate stop from a genuine failure. The task context
+// draws that line: Stop and Kill cancel it, while the run's own timeout
+// expires it instead — a timeout is a failure, so only cancellation is
+// exempted here. Without this a user-requested TaskStop was recorded as
+// failed, and the main agent could retry work the user had just cancelled,
+// which is the outcome StatusStopped exists to prevent.
 func (t *BashTask) Complete(exitCode int, err error) {
-	status := StatusCompleted
-	errMsg := ""
-	if err != nil {
+	status, errMsg := StatusCompleted, ""
+	switch {
+	case t.ctx != nil && errors.Is(t.ctx.Err(), context.Canceled):
+		status, errMsg = StatusStopped, "stopped before completion"
+	case err != nil:
 		status, errMsg = StatusFailed, err.Error()
-	} else if exitCode != 0 {
+	case exitCode != 0:
 		status = StatusFailed
 	}
 	t.finalize(status, exitCode, errMsg)

--- a/internal/task/bash_task_test.go
+++ b/internal/task/bash_task_test.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"context"
+	"errors"
 	"os/exec"
 	"sync"
 	"testing"
@@ -294,5 +295,46 @@ func TestBashTask_ImplementsBackgroundTask(t *testing.T) {
 	}
 	if bt.GetDescription() != "Interface test" {
 		t.Errorf("GetDescription() = %s, want 'Interface test'", bt.GetDescription())
+	}
+}
+
+// A user-requested stop cancels the task context, and the child dies of the
+// signal that follows — so cmd.Wait reports "signal: killed", not a
+// cancellation. Recording that as failed told the main agent the work had
+// broken rather than been called off, inviting a retry of what the user had
+// just cancelled.
+func TestBashTaskStopIsNotAFailure(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "echo", "test")
+	cmd.Start()
+
+	task := NewBashTask("stop-id", "sleep 100", "Long task", cmd, ctx, cancel)
+
+	cancel()
+	task.Complete(137, errors.New("signal: killed"))
+
+	if info := task.GetStatus(); info.Status != StatusStopped {
+		t.Errorf("expected status '%s', got '%s'", StatusStopped, info.Status)
+	}
+}
+
+// A run that outlives its own timeout also ends with a cancelled context, but
+// it failed on its own terms — nobody called it off, so it stays a failure.
+func TestBashTaskTimeoutRemainsAFailure(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+
+	cmd := exec.Command("echo", "test")
+	cmd.Start()
+
+	task := NewBashTask("timeout-id", "sleep 100", "Long task", cmd, ctx, cancel)
+
+	<-ctx.Done()
+	task.Complete(137, errors.New("signal: killed"))
+
+	if info := task.GetStatus(); info.Status != StatusFailed {
+		t.Errorf("expected status '%s', got '%s'", StatusFailed, info.Status)
 	}
 }

--- a/internal/task/hooks.go
+++ b/internal/task/hooks.go
@@ -24,6 +24,13 @@ func SetLifecycleHandler(h LifecycleHandler) {
 	taskHandler.handler = h
 }
 
+// notifyTaskCreated announces a task the manager has just taken ownership of.
+//
+// Callers must release the manager lock first, as notifyTaskCompleted's callers
+// already do. The handler builds the task's tracker entry, so this reaches the
+// todo store's lock — and that store takes the manager's lock in the other
+// direction when it reconciles orphaned entries against live tasks. Notifying
+// under the manager lock closes that cycle into a deadlock.
 func notifyTaskCreated(info TaskInfo) {
 	taskHandler.mu.RLock()
 	h := taskHandler.handler

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -25,23 +25,23 @@ func NewManager() *Manager {
 
 // CreateBashTask creates and registers a new bash task
 func (m *Manager) CreateBashTask(cmd *exec.Cmd, command, description string, ctx context.Context, cancel context.CancelFunc) *BashTask {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	id := generateID()
 	task := NewBashTask(id, command, description, cmd, ctx, cancel)
 
+	m.mu.Lock()
 	m.tasks[id] = task
-	notifyTaskCreated(task.GetStatus())
+	m.mu.Unlock()
 
+	notifyTaskCreated(task.GetStatus())
 	return task
 }
 
 // RegisterTask registers an existing task (used for agent tasks)
 func (m *Manager) RegisterTask(task BackgroundTask) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.tasks[task.GetID()] = task
+	m.mu.Unlock()
+
 	notifyTaskCreated(task.GetStatus())
 }
 

--- a/internal/todo/background.go
+++ b/internal/todo/background.go
@@ -11,43 +11,47 @@ const (
 	metaStatusDetail = "background_status_detail"
 )
 
-// StatusDetailInterrupted marks a worker entry whose executor died without
-// reporting a terminal status — process exit, crash, or SIGKILL. Set by
-// demoteOrphanedTasks when a persisted store is adopted into a fresh session.
+// An Item is one of two kinds. A plan item is authored by the model and
+// advanced by the main agent loop. A worker item mirrors a background task
+// running in internal/task, joined to it by the metaTaskID metadata key. The
+// helpers below are that join: they read what an item says about its
+// background task, and resolve liveness against the live task manager rather
+// than trusting the item's own recorded status.
+
+// StatusDetailInterrupted marks a worker item whose background task died
+// without reporting a terminal status — process exit, crash, or SIGKILL. Set
+// by demoteOrphanedItems when a persisted store is adopted into a fresh
+// session.
 const StatusDetailInterrupted = "interrupted"
 
-// BackgroundTaskID returns the background task ID backing this entry, or ""
-// when the entry is a plan item authored by the model rather than a worker.
-// Callers resolve liveness by looking the ID up in the live task manager.
-func BackgroundTaskID(t *Task) string {
-	return metadataString(t, metaTaskID)
+// BackgroundTaskID returns the background task ID this item mirrors, or ""
+// when the item is a plan item authored by the model rather than a worker.
+func BackgroundTaskID(item *Item) string {
+	return metadataString(item, metaTaskID)
 }
 
-// BackgroundStatusDetail returns how a worker entry's executor ended —
-// "failed", "killed", "stopped", or StatusDetailInterrupted. Empty for entries
-// that are not backed by a worker, and for workers that ended normally.
-func BackgroundStatusDetail(t *Task) string {
-	return metadataString(t, metaStatusDetail)
+// BackgroundStatusDetail returns how a worker item's background task ended —
+// "failed", "killed", "stopped", or StatusDetailInterrupted. Empty for items
+// that mirror no background task, and for those that ended normally.
+func BackgroundStatusDetail(item *Item) string {
+	return metadataString(item, metaStatusDetail)
 }
 
-// WorkerRunning reports whether the background task backing this entry is
-// executing right now. False for entries that name no worker, and for workers
-// the manager has no record of — a task it never knew or has forgotten cannot
-// be running.
-//
-// This is the read side of the join TrackWorker writes, and lives here so the
-// metadata key and the entry↔executor correspondence stay in one package.
-func WorkerRunning(t *Task) bool {
-	id := BackgroundTaskID(t)
+// WorkerRunning reports whether the background task behind this item is
+// executing right now. False for items that name no background task, and for
+// those the manager has no record of — a task it never knew or has forgotten
+// cannot be running.
+func WorkerRunning(item *Item) bool {
+	id := BackgroundTaskID(item)
 	return id != "" && task.Default().IsRunning(id)
 }
 
-// EndedAbnormally reports whether a worker entry reached its terminal state by
+// EndedAbnormally reports whether a worker item reached its terminal state by
 // any route other than finishing its work. The stored detail is written as
 // string(task.TaskStatus) by CompleteWorker, so it is matched against those
 // constants rather than loose literals.
-func EndedAbnormally(t *Task) bool {
-	switch BackgroundStatusDetail(t) {
+func EndedAbnormally(item *Item) bool {
+	switch BackgroundStatusDetail(item) {
 	case string(task.StatusFailed), string(task.StatusKilled),
 		string(task.StatusStopped), StatusDetailInterrupted:
 		return true
@@ -55,22 +59,22 @@ func EndedAbnormally(t *Task) bool {
 	return false
 }
 
-func metadataString(t *Task, key string) string {
-	if t == nil || t.Metadata == nil {
+func metadataString(item *Item, key string) string {
+	if item == nil || item.Metadata == nil {
 		return ""
 	}
-	value, _ := t.Metadata[key].(string)
+	value, _ := item.Metadata[key].(string)
 	return value
 }
 
-// TrackWorker creates or updates a tracker entry for a running background task.
+// TrackWorker creates or updates a tracker item for a running background task.
 //
 // It takes the same task.TaskInfo that CompleteWorker takes, because the two
 // must be driven by the same source: the task manager's create and complete
 // notifications. Feeding the two halves from different places lets them race,
-// and a completion that arrives before its entry exists is dropped for good —
-// CompleteWorker has nothing to find, and the entry created afterwards names a
-// task that already ended, so it sits in_progress for the rest of the session.
+// and a completion that arrives before its item exists is dropped for good —
+// CompleteWorker has nothing to find, and the item created afterwards names a
+// background task that already ended, so it sits in_progress for the whole session.
 func TrackWorker(svc Service, info task.TaskInfo) {
 	if info.ID == "" {
 		return
@@ -90,22 +94,22 @@ func TrackWorker(svc Service, info task.TaskInfo) {
 		return
 	}
 
-	entry := svc.Create(workerSubject(info), info.Description, "", metadata)
+	item := svc.Create(workerSubject(info), info.Description, "", metadata)
 	opts := []UpdateOption{WithStatus(StatusInProgress)}
 	if info.AgentType != "" {
 		opts = append(opts, WithOwner(info.AgentType))
 	}
-	_ = svc.Update(entry.ID, opts...)
+	_ = svc.Update(item.ID, opts...)
 }
 
-// CompleteWorker marks a tracker entry as completed.
+// CompleteWorker marks a tracker item as completed.
 func CompleteWorker(svc Service, info task.TaskInfo) {
-	entry := svc.FindByMetadata(metaTaskID, info.ID)
-	if entry == nil {
+	item := svc.FindByMetadata(metaTaskID, info.ID)
+	if item == nil {
 		return
 	}
 
-	subject := entry.Subject
+	subject := item.Subject
 	if subject == "" {
 		subject = workerSubject(info)
 	}
@@ -115,7 +119,7 @@ func CompleteWorker(svc Service, info task.TaskInfo) {
 		statusDetail = string(task.StatusCompleted)
 	}
 
-	_ = svc.Update(entry.ID,
+	_ = svc.Update(item.ID,
 		WithSubject(subject),
 		WithDescription(info.Description),
 		WithStatus(StatusCompleted),

--- a/internal/todo/background.go
+++ b/internal/todo/background.go
@@ -63,41 +63,37 @@ func metadataString(t *Task, key string) string {
 	return value
 }
 
-// BackgroundTaskLaunch holds metadata for a newly spawned background task.
-type BackgroundTaskLaunch struct {
-	TaskID      string
-	AgentName   string
-	AgentType   string
-	Description string
-}
-
 // TrackWorker creates or updates a tracker entry for a running background task.
-func TrackWorker(svc Service, launch BackgroundTaskLaunch) {
-	if existing := svc.FindByMetadata(metaTaskID, launch.TaskID); existing != nil {
+//
+// It takes the same task.TaskInfo that CompleteWorker takes, because the two
+// must be driven by the same source: the task manager's create and complete
+// notifications. Feeding the two halves from different places lets them race,
+// and a completion that arrives before its entry exists is dropped for good —
+// CompleteWorker has nothing to find, and the entry created afterwards names a
+// task that already ended, so it sits in_progress for the rest of the session.
+func TrackWorker(svc Service, info task.TaskInfo) {
+	if info.ID == "" {
+		return
+	}
+	metadata := map[string]any{
+		metaTaskID:       info.ID,
+		metaStatusDetail: string(task.StatusRunning),
+	}
+
+	if existing := svc.FindByMetadata(metaTaskID, info.ID); existing != nil {
 		_ = svc.Update(existing.ID,
-			WithSubject(workerSubject(launch)),
-			WithDescription(launch.Description),
+			WithSubject(workerSubject(info)),
+			WithDescription(info.Description),
 			WithStatus(StatusInProgress),
-			WithMetadata(map[string]any{
-				metaTaskID:       launch.TaskID,
-				metaStatusDetail: string(task.StatusRunning),
-			}),
+			WithMetadata(metadata),
 		)
 		return
 	}
 
-	entry := svc.Create(
-		workerSubject(launch),
-		launch.Description,
-		"",
-		map[string]any{
-			metaTaskID:       launch.TaskID,
-			metaStatusDetail: string(task.StatusRunning),
-		},
-	)
+	entry := svc.Create(workerSubject(info), info.Description, "", metadata)
 	opts := []UpdateOption{WithStatus(StatusInProgress)}
-	if launch.AgentType != "" {
-		opts = append(opts, WithOwner(launch.AgentType))
+	if info.AgentType != "" {
+		opts = append(opts, WithOwner(info.AgentType))
 	}
 	_ = svc.Update(entry.ID, opts...)
 }
@@ -111,12 +107,7 @@ func CompleteWorker(svc Service, info task.TaskInfo) {
 
 	subject := entry.Subject
 	if subject == "" {
-		subject = workerSubject(BackgroundTaskLaunch{
-			TaskID:      info.ID,
-			AgentName:   info.AgentName,
-			AgentType:   info.AgentType,
-			Description: info.Description,
-		})
+		subject = workerSubject(info)
 	}
 
 	statusDetail := string(info.Status)
@@ -135,9 +126,9 @@ func CompleteWorker(svc Service, info task.TaskInfo) {
 	)
 }
 
-func workerSubject(launch BackgroundTaskLaunch) string {
-	name := strings.TrimSpace(launch.AgentName)
-	desc := strings.TrimSpace(launch.Description)
+func workerSubject(info task.TaskInfo) string {
+	name := strings.TrimSpace(info.AgentName)
+	desc := strings.TrimSpace(info.Description)
 	switch {
 	case name != "" && desc != "" && !strings.EqualFold(name, desc):
 		return name + ": " + desc
@@ -145,9 +136,13 @@ func workerSubject(launch BackgroundTaskLaunch) string {
 		return desc
 	case name != "":
 		return name
-	case launch.AgentType != "":
-		return launch.AgentType
+	case info.AgentType != "":
+		return info.AgentType
+	// A bash worker names no agent, so its command is the only description of
+	// itself it carries. Better than falling through to the opaque task ID.
+	case info.Command != "":
+		return info.Command
 	default:
-		return launch.TaskID
+		return info.ID
 	}
 }

--- a/internal/todo/background_test.go
+++ b/internal/todo/background_test.go
@@ -19,8 +19,9 @@ func TestTrackWorkerCreatesEntry(t *testing.T) {
 	Initialize(Options{})
 	t.Cleanup(func() { Default().Reset() })
 
-	TrackWorker(Default(), BackgroundTaskLaunch{
-		TaskID:      "bg-1",
+	TrackWorker(Default(), task.TaskInfo{
+		ID:          "bg-1",
+		Type:        task.TaskTypeAgent,
 		AgentName:   "dir-audit",
 		AgentType:   "Explore",
 		Description: "Directory structure audit",
@@ -38,12 +39,46 @@ func TestTrackWorkerCreatesEntry(t *testing.T) {
 	}
 }
 
+// A bash worker names no agent, so the subject falls back through description
+// to the command itself. CompleteWorker already fired for bash tasks before
+// they were tracked at all; now that both halves run, they need a readable row.
+func TestTrackWorkerNamesBashWorker(t *testing.T) {
+	Initialize(Options{})
+	t.Cleanup(func() { Default().Reset() })
+
+	TrackWorker(Default(), task.TaskInfo{
+		ID:      "bg-2",
+		Type:    task.TaskTypeBash,
+		Command: "go test ./...",
+	})
+
+	tasks := Default().List()
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 tracker task, got %d", len(tasks))
+	}
+	if tasks[0].Subject != "go test ./..." {
+		t.Fatalf("subject = %q, want the command", tasks[0].Subject)
+	}
+}
+
+func TestTrackWorkerIgnoresTaskWithoutID(t *testing.T) {
+	Initialize(Options{})
+	t.Cleanup(func() { Default().Reset() })
+
+	TrackWorker(Default(), task.TaskInfo{Description: "no executor behind this"})
+
+	if tasks := Default().List(); len(tasks) != 0 {
+		t.Fatalf("expected no tracker task, got %d", len(tasks))
+	}
+}
+
 func TestCompleteWorkerUpdatesStatus(t *testing.T) {
 	Initialize(Options{})
 	t.Cleanup(func() { Default().Reset() })
 
-	TrackWorker(Default(), BackgroundTaskLaunch{
-		TaskID:      "bg-1",
+	TrackWorker(Default(), task.TaskInfo{
+		ID:          "bg-1",
+		Type:        task.TaskTypeAgent,
 		AgentName:   "dir-audit",
 		AgentType:   "Explore",
 		Description: "Directory audit",
@@ -71,8 +106,9 @@ func TestCompleteWorkerTracksFailure(t *testing.T) {
 	Initialize(Options{})
 	t.Cleanup(func() { Default().Reset() })
 
-	TrackWorker(Default(), BackgroundTaskLaunch{
-		TaskID:      "bg-1",
+	TrackWorker(Default(), task.TaskInfo{
+		ID:          "bg-1",
+		Type:        task.TaskTypeAgent,
 		AgentName:   "fix-auth",
 		AgentType:   "general-purpose",
 		Description: "Fix auth module",

--- a/internal/todo/background_test.go
+++ b/internal/todo/background_test.go
@@ -27,20 +27,20 @@ func TestTrackWorkerCreatesEntry(t *testing.T) {
 		Description: "Directory structure audit",
 	})
 
-	tasks := Default().List()
-	if len(tasks) != 1 {
-		t.Fatalf("expected 1 tracker task, got %d", len(tasks))
+	items := Default().List()
+	if len(items) != 1 {
+		t.Fatalf("expected 1 tracker item, got %d", len(items))
 	}
-	if tasks[0].Status != StatusInProgress {
-		t.Fatalf("status = %q, want %q", tasks[0].Status, StatusInProgress)
+	if items[0].Status != StatusInProgress {
+		t.Fatalf("status = %q, want %q", items[0].Status, StatusInProgress)
 	}
-	if metadataStr(tasks[0].Metadata, metaTaskID) != "bg-1" {
-		t.Fatalf("task ID metadata = %q", metadataStr(tasks[0].Metadata, metaTaskID))
+	if metadataStr(items[0].Metadata, metaTaskID) != "bg-1" {
+		t.Fatalf("item ID metadata = %q", metadataStr(items[0].Metadata, metaTaskID))
 	}
 }
 
 // A bash worker names no agent, so the subject falls back through description
-// to the command itself. CompleteWorker already fired for bash tasks before
+// to the command itself. CompleteWorker already fired for bash items before
 // they were tracked at all; now that both halves run, they need a readable row.
 func TestTrackWorkerNamesBashWorker(t *testing.T) {
 	Initialize(Options{})
@@ -52,12 +52,12 @@ func TestTrackWorkerNamesBashWorker(t *testing.T) {
 		Command: "go test ./...",
 	})
 
-	tasks := Default().List()
-	if len(tasks) != 1 {
-		t.Fatalf("expected 1 tracker task, got %d", len(tasks))
+	items := Default().List()
+	if len(items) != 1 {
+		t.Fatalf("expected 1 tracker item, got %d", len(items))
 	}
-	if tasks[0].Subject != "go test ./..." {
-		t.Fatalf("subject = %q, want the command", tasks[0].Subject)
+	if items[0].Subject != "go test ./..." {
+		t.Fatalf("subject = %q, want the command", items[0].Subject)
 	}
 }
 
@@ -65,10 +65,10 @@ func TestTrackWorkerIgnoresTaskWithoutID(t *testing.T) {
 	Initialize(Options{})
 	t.Cleanup(func() { Default().Reset() })
 
-	TrackWorker(Default(), task.TaskInfo{Description: "no executor behind this"})
+	TrackWorker(Default(), task.TaskInfo{Description: "no worker behind this"})
 
-	if tasks := Default().List(); len(tasks) != 0 {
-		t.Fatalf("expected no tracker task, got %d", len(tasks))
+	if items := Default().List(); len(items) != 0 {
+		t.Fatalf("expected no tracker item, got %d", len(items))
 	}
 }
 
@@ -90,15 +90,15 @@ func TestCompleteWorkerUpdatesStatus(t *testing.T) {
 		Status: task.StatusCompleted,
 	})
 
-	tasks := Default().List()
-	if len(tasks) != 1 {
-		t.Fatalf("expected 1 tracker task, got %d", len(tasks))
+	items := Default().List()
+	if len(items) != 1 {
+		t.Fatalf("expected 1 tracker item, got %d", len(items))
 	}
-	if tasks[0].Status != StatusCompleted {
-		t.Fatalf("status = %q, want %q", tasks[0].Status, StatusCompleted)
+	if items[0].Status != StatusCompleted {
+		t.Fatalf("status = %q, want %q", items[0].Status, StatusCompleted)
 	}
-	if metadataStr(tasks[0].Metadata, metaStatusDetail) != string(task.StatusCompleted) {
-		t.Fatalf("status detail = %q", metadataStr(tasks[0].Metadata, metaStatusDetail))
+	if metadataStr(items[0].Metadata, metaStatusDetail) != string(task.StatusCompleted) {
+		t.Fatalf("status detail = %q", metadataStr(items[0].Metadata, metaStatusDetail))
 	}
 }
 
@@ -121,8 +121,8 @@ func TestCompleteWorkerTracksFailure(t *testing.T) {
 		Error:  "compilation error",
 	})
 
-	tasks := Default().List()
-	if metadataStr(tasks[0].Metadata, metaStatusDetail) != string(task.StatusFailed) {
-		t.Fatalf("status detail = %q, want %q", metadataStr(tasks[0].Metadata, metaStatusDetail), task.StatusFailed)
+	items := Default().List()
+	if metadataStr(items[0].Metadata, metaStatusDetail) != string(task.StatusFailed) {
+		t.Fatalf("status detail = %q, want %q", metadataStr(items[0].Metadata, metaStatusDetail), task.StatusFailed)
 	}
 }

--- a/internal/todo/completion_test.go
+++ b/internal/todo/completion_test.go
@@ -23,8 +23,8 @@ func TestAllMarkedCompleted(t *testing.T) {
 		{"one left in progress", []string{StatusCompleted, StatusInProgress}, false},
 		{"deleted items do not count as open", []string{StatusCompleted, StatusDeleted}, true},
 		// Tombstones only: the map is not empty, so the emptiness check passes
-		// and the loop skips every entry. The view never sees this — List drops
-		// deleted tasks, so it renders nothing either way.
+		// and the loop skips every item. The view never sees this — List drops
+		// deleted items, so it renders nothing either way.
 		{"only tombstones", []string{StatusDeleted}, true},
 	}
 
@@ -32,15 +32,15 @@ func TestAllMarkedCompleted(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			store := NewStore()
 			for _, status := range tc.statuses {
-				entry := store.Create("task", "", "", nil)
+				item := store.Create("item", "", "", nil)
 				var err error
 				if status == StatusDeleted {
-					err = store.Delete(entry.ID)
+					err = store.Delete(item.ID)
 				} else {
-					err = store.Update(entry.ID, WithStatus(status))
+					err = store.Update(item.ID, WithStatus(status))
 				}
 				if err != nil {
-					t.Fatalf("set task %s to %s: %v", entry.ID, status, err)
+					t.Fatalf("set item %s to %s: %v", item.ID, status, err)
 				}
 			}
 			if got := store.AllMarkedCompleted(); got != tc.want {

--- a/internal/todo/orphan_test.go
+++ b/internal/todo/orphan_test.go
@@ -8,10 +8,10 @@ import (
 )
 
 // Adopting a store persisted by a process that is now gone must leave nothing
-// claiming to be in progress: whatever was executing those tasks died with that
+// claiming to be in progress: whatever was executing those items died with that
 // process. Reconciling here rather than at each exit path is what makes the
 // guarantee hold across crashes and SIGKILL, which run no cleanup code at all.
-func TestSetStorageDirDemotesOrphanedTasks(t *testing.T) {
+func TestSetStorageDirDemotesOrphanedItems(t *testing.T) {
 	dir := t.TempDir()
 
 	writer := NewStore()
@@ -34,18 +34,18 @@ func TestSetStorageDirDemotesOrphanedTasks(t *testing.T) {
 
 	gotPlan, ok := reader.Get(plan.ID)
 	if !ok {
-		t.Fatalf("plan task %s missing after adopt", plan.ID)
+		t.Fatalf("plan item %s missing after adopt", plan.ID)
 	}
 	if gotPlan.Status != StatusPending {
-		t.Fatalf("plan task status = %q, want %q", gotPlan.Status, StatusPending)
+		t.Fatalf("plan item status = %q, want %q", gotPlan.Status, StatusPending)
 	}
 
 	gotWorker, ok := reader.Get(worker.ID)
 	if !ok {
-		t.Fatalf("worker task %s missing after adopt", worker.ID)
+		t.Fatalf("worker item %s missing after adopt", worker.ID)
 	}
 	if gotWorker.Status != StatusCompleted {
-		t.Fatalf("worker task status = %q, want %q", gotWorker.Status, StatusCompleted)
+		t.Fatalf("worker item status = %q, want %q", gotWorker.Status, StatusCompleted)
 	}
 	if detail := BackgroundStatusDetail(gotWorker); detail != StatusDetailInterrupted {
 		t.Fatalf("worker status detail = %q, want %q", detail, StatusDetailInterrupted)
@@ -72,8 +72,8 @@ func TestSetStorageDirKeepsRunningWorker(t *testing.T) {
 	if err := writer.SetStorageDir(dir); err != nil {
 		t.Fatalf("SetStorageDir: %v", err)
 	}
-	entry := writer.Create("Audit deps", "", "", map[string]any{metaTaskID: running.ID})
-	if err := writer.Update(entry.ID, WithStatus(StatusInProgress)); err != nil {
+	item := writer.Create("Audit deps", "", "", map[string]any{metaTaskID: running.ID})
+	if err := writer.Update(item.ID, WithStatus(StatusInProgress)); err != nil {
 		t.Fatalf("Update: %v", err)
 	}
 
@@ -82,9 +82,9 @@ func TestSetStorageDirKeepsRunningWorker(t *testing.T) {
 		t.Fatalf("SetStorageDir (adopt): %v", err)
 	}
 
-	got, ok := adopter.Get(entry.ID)
+	got, ok := adopter.Get(item.ID)
 	if !ok {
-		t.Fatalf("entry %s missing after adopt", entry.ID)
+		t.Fatalf("item %s missing after adopt", item.ID)
 	}
 	if got.Status != StatusInProgress {
 		t.Fatalf("running worker demoted: status = %q, want %q", got.Status, StatusInProgress)
@@ -92,7 +92,7 @@ func TestSetStorageDirKeepsRunningWorker(t *testing.T) {
 }
 
 // ReloadFromDisk exists to pick up writes from other processes mid-session, so
-// it must not reconcile: an in_progress task seen there is genuinely running.
+// it must not reconcile: an in_progress item seen there is genuinely running.
 func TestReloadFromDiskPreservesExecutingTasks(t *testing.T) {
 	dir := t.TempDir()
 
@@ -109,9 +109,9 @@ func TestReloadFromDiskPreservesExecutingTasks(t *testing.T) {
 
 	got, ok := store.Get(live.ID)
 	if !ok {
-		t.Fatalf("task %s missing after reload", live.ID)
+		t.Fatalf("item %s missing after reload", live.ID)
 	}
 	if got.Status != StatusInProgress {
-		t.Fatalf("live task demoted by reload: status = %q, want %q", got.Status, StatusInProgress)
+		t.Fatalf("live item demoted by reload: status = %q, want %q", got.Status, StatusInProgress)
 	}
 }

--- a/internal/todo/service.go
+++ b/internal/todo/service.go
@@ -5,11 +5,11 @@ import "sync"
 // Service is the public contract for the tracker module.
 type Service interface {
 	// CRUD
-	Create(subject, description, activeForm string, metadata map[string]any) *Task
-	Get(id string) (*Task, bool)
+	Create(subject, description, activeForm string, metadata map[string]any) *Item
+	Get(id string) (*Item, bool)
 	Update(id string, opts ...UpdateOption) error
 	Delete(id string) error
-	List() []*Task
+	List() []*Item
 
 	// query
 	//
@@ -24,14 +24,14 @@ type Service interface {
 	IsBlocked(id string) bool
 	OpenBlockers(id string) []string
 	AllMarkedCompleted() bool
-	FindByMetadata(key, want string) *Task
+	FindByMetadata(key, want string) *Item
 
 	// persistence
 	SetStorageDir(dir string) error
 	GetStorageDir() string
 	ReloadFromDisk()
-	Export() []Task
-	Import(tasks []Task)
+	Export() []Item
+	Import(items []Item)
 
 	// lifecycle
 	Reset()

--- a/internal/todo/store.go
+++ b/internal/todo/store.go
@@ -11,8 +11,8 @@ import (
 	"time"
 )
 
-// Task represents a tracked task
-type Task struct {
+// Item represents a tracked item
+type Item struct {
 	ID              string         `json:"id"`
 	Subject         string         `json:"subject"`
 	Description     string         `json:"description"`
@@ -27,7 +27,7 @@ type Task struct {
 	StatusChangedAt time.Time      `json:"statusChangedAt"` // when status last changed (for elapsed time display)
 }
 
-// Task status constants
+// Item status constants
 const (
 	StatusPending    = "pending"
 	StatusInProgress = "in_progress"
@@ -35,11 +35,11 @@ const (
 	StatusDeleted    = "deleted"
 )
 
-// Store is a thread-safe task store with optional disk persistence.
-// When a storageDir is set, each task is persisted as {id}.json.
+// Store is a thread-safe item store with optional disk persistence.
+// When a storageDir is set, each item is persisted as {id}.json.
 type Store struct {
 	mu         sync.RWMutex
-	tasks      map[string]*Task
+	items      map[string]*Item
 	nextID     int
 	storageDir string    // empty = in-memory only
 	lastDirMod time.Time // last known dir mtime, for change detection in ReloadFromDisk
@@ -48,12 +48,12 @@ type Store struct {
 // NewStore creates a new in-memory Store
 func NewStore() *Store {
 	return &Store{
-		tasks:  make(map[string]*Task),
+		items:  make(map[string]*Item),
 		nextID: 1,
 	}
 }
 
-// SetStorageDir sets the directory for disk persistence and loads existing tasks.
+// SetStorageDir sets the directory for disk persistence and loads existing items.
 // If dir is empty, the store operates in memory-only mode.
 func (s *Store) SetStorageDir(dir string) error {
 	s.mu.Lock()
@@ -65,7 +65,7 @@ func (s *Store) SetStorageDir(dir string) error {
 	}
 
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return fmt.Errorf("failed to create task storage dir: %w", err)
+		return fmt.Errorf("failed to create item storage dir: %w", err)
 	}
 
 	// Create lock file
@@ -74,61 +74,61 @@ func (s *Store) SetStorageDir(dir string) error {
 		os.WriteFile(lockPath, nil, 0o644)
 	}
 
-	// Load existing tasks from disk, then reconcile: this is the moment a
+	// Load existing items from disk, then reconcile: this is the moment a
 	// fresh process adopts state written by a process that no longer exists.
 	if err := s.loadFromDisk(); err != nil {
 		return err
 	}
-	s.demoteOrphanedTasks()
+	s.demoteOrphanedItems()
 	return nil
 }
 
-// demoteOrphanedTasks demotes tasks recorded as in_progress that no executor is
+// demoteOrphanedItems demotes items recorded as in_progress that no worker is
 // advancing any more. Runs where a store is adopted — SetStorageDir and Import —
 // so records written by a process that has since died stop claiming to be live,
 // however that process ended. Must be called with s.mu held.
 //
 // Adoption also happens mid-session (resuming a session re-points the store), so
 // liveness is asked of the task manager rather than assumed from the call site:
-// a worker still executing keeps its status. Plan items have no executor to ask
+// a worker still executing keeps its status. Plan items have no worker to ask
 // about and fall back to pending, the truthful state of work that was started
 // but never finished.
 //
 // Not called from loadFromDisk — ReloadFromDisk uses that mid-session to pick up
 // cross-process writes, where in_progress is expected and genuine.
-func (s *Store) demoteOrphanedTasks() {
-	for _, entry := range s.tasks {
-		if entry.Status != StatusInProgress || WorkerRunning(entry) {
+func (s *Store) demoteOrphanedItems() {
+	for _, item := range s.items {
+		if item.Status != StatusInProgress || WorkerRunning(item) {
 			continue
 		}
-		if BackgroundTaskID(entry) != "" {
-			entry.Status = StatusCompleted
-			if entry.Metadata == nil {
-				entry.Metadata = map[string]any{}
+		if BackgroundTaskID(item) != "" {
+			item.Status = StatusCompleted
+			if item.Metadata == nil {
+				item.Metadata = map[string]any{}
 			}
-			entry.Metadata[metaStatusDetail] = StatusDetailInterrupted
+			item.Metadata[metaStatusDetail] = StatusDetailInterrupted
 		} else {
-			entry.Status = StatusPending
+			item.Status = StatusPending
 		}
-		entry.StatusChangedAt = time.Now()
-		s.persistTask(entry)
+		item.StatusChangedAt = time.Now()
+		s.persistItem(item)
 	}
 }
 
 // loadFromDisk reads all {id}.json files from storageDir into memory.
 // Must be called with s.mu held.
 func (s *Store) loadFromDisk() error {
-	entries, err := os.ReadDir(s.storageDir)
+	items, err := os.ReadDir(s.storageDir)
 	if err != nil {
 		return err
 	}
 
-	s.tasks = make(map[string]*Task)
+	s.items = make(map[string]*Item)
 	s.nextID = 1
 
-	for _, entry := range entries {
-		name := entry.Name()
-		if entry.IsDir() || filepath.Ext(name) != ".json" {
+	for _, item := range items {
+		name := item.Name()
+		if item.IsDir() || filepath.Ext(name) != ".json" {
 			continue
 		}
 
@@ -137,15 +137,15 @@ func (s *Store) loadFromDisk() error {
 			continue
 		}
 
-		var task Task
-		if err := json.Unmarshal(data, &task); err != nil {
+		var item Item
+		if err := json.Unmarshal(data, &item); err != nil {
 			continue
 		}
 
-		normalizeTaskSlices(&task)
-		s.tasks[task.ID] = &task
+		normalizeItemSlices(&item)
+		s.items[item.ID] = &item
 		var idNum int
-		if _, err := fmt.Sscanf(task.ID, "%d", &idNum); err == nil && idNum >= s.nextID {
+		if _, err := fmt.Sscanf(item.ID, "%d", &idNum); err == nil && idNum >= s.nextID {
 			s.nextID = idNum + 1
 		}
 	}
@@ -153,38 +153,38 @@ func (s *Store) loadFromDisk() error {
 	return nil
 }
 
-// persistTask writes a single task to disk. Must be called with s.mu held.
-func (s *Store) persistTask(task *Task) {
+// persistItem writes a single item to disk. Must be called with s.mu held.
+func (s *Store) persistItem(item *Item) {
 	if s.storageDir == "" {
 		return
 	}
-	data, err := json.MarshalIndent(task, "", "  ")
+	data, err := json.MarshalIndent(item, "", "  ")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "tracker: failed to marshal task %s: %v\n", task.ID, err)
+		fmt.Fprintf(os.Stderr, "tracker: failed to marshal item %s: %v\n", item.ID, err)
 		return
 	}
-	path := filepath.Join(s.storageDir, task.ID+".json")
+	path := filepath.Join(s.storageDir, item.ID+".json")
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		fmt.Fprintf(os.Stderr, "tracker: failed to write task %s: %v\n", task.ID, err)
+		fmt.Fprintf(os.Stderr, "tracker: failed to write item %s: %v\n", item.ID, err)
 		return
 	}
 	if err := os.Rename(tmp, path); err != nil {
 		os.Remove(tmp)
-		fmt.Fprintf(os.Stderr, "tracker: failed to rename task %s: %v\n", task.ID, err)
+		fmt.Fprintf(os.Stderr, "tracker: failed to rename item %s: %v\n", item.ID, err)
 	}
 }
 
-// removeTaskFile deletes a task file from disk. Must be called with s.mu held.
-func (s *Store) removeTaskFile(id string) {
+// removeItemFile deletes an item file from disk. Must be called with s.mu held.
+func (s *Store) removeItemFile(id string) {
 	if s.storageDir == "" {
 		return
 	}
 	_ = os.Remove(filepath.Join(s.storageDir, id+".json"))
 }
 
-// Create adds a new task and returns it
-func (s *Store) Create(subject, description, activeForm string, metadata map[string]any) *Task {
+// Create adds a new item and returns it
+func (s *Store) Create(subject, description, activeForm string, metadata map[string]any) *Item {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -192,7 +192,7 @@ func (s *Store) Create(subject, description, activeForm string, metadata map[str
 	s.nextID++
 
 	now := time.Now()
-	task := &Task{
+	item := &Item{
 		ID:              id,
 		Subject:         subject,
 		Description:     description,
@@ -206,75 +206,75 @@ func (s *Store) Create(subject, description, activeForm string, metadata map[str
 		StatusChangedAt: now,
 	}
 
-	s.tasks[id] = task
-	s.persistTask(task)
-	return task
+	s.items[id] = item
+	s.persistItem(item)
+	return item
 }
 
-// Get retrieves a copy of a task by ID.
-func (s *Store) Get(id string) (*Task, bool) {
+// Get retrieves a copy of an item by ID.
+func (s *Store) Get(id string) (*Item, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	task, ok := s.tasks[id]
-	if !ok || task.Status == StatusDeleted {
+	item, ok := s.items[id]
+	if !ok || item.Status == StatusDeleted {
 		return nil, false
 	}
-	cp := *task
+	cp := *item
 	return &cp, true
 }
 
-// Update modifies an existing task. Returns error if task not found.
+// Update modifies an existing item. Returns error if item not found.
 func (s *Store) Update(id string, opts ...UpdateOption) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	task, ok := s.tasks[id]
+	item, ok := s.items[id]
 	if !ok {
-		return fmt.Errorf("task %s not found", id)
+		return fmt.Errorf("item %s not found", id)
 	}
 
 	for _, opt := range opts {
-		opt(task)
+		opt(item)
 	}
 
-	task.UpdatedAt = time.Now()
-	s.persistTask(task)
+	item.UpdatedAt = time.Now()
+	s.persistItem(item)
 	return nil
 }
 
-// List returns copies of all non-deleted tasks sorted by ID.
-func (s *Store) List() []*Task {
+// List returns copies of all non-deleted items sorted by ID.
+func (s *Store) List() []*Item {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	tasks := make([]*Task, 0, len(s.tasks))
-	for _, task := range s.tasks {
-		if task.Status != StatusDeleted {
-			cp := *task
-			tasks = append(tasks, &cp)
+	items := make([]*Item, 0, len(s.items))
+	for _, item := range s.items {
+		if item.Status != StatusDeleted {
+			cp := *item
+			items = append(items, &cp)
 		}
 	}
 
-	sort.Slice(tasks, func(i, j int) bool {
-		return compareNumericIDs(tasks[i].ID, tasks[j].ID)
+	sort.Slice(items, func(i, j int) bool {
+		return compareNumericIDs(items[i].ID, items[j].ID)
 	})
 
-	return tasks
+	return items
 }
 
-// IsBlocked returns true if the task has any uncompleted blockers
+// IsBlocked returns true if the item has any uncompleted blockers
 func (s *Store) IsBlocked(id string) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	task, ok := s.tasks[id]
-	if !ok || task.Status == StatusDeleted {
+	item, ok := s.items[id]
+	if !ok || item.Status == StatusDeleted {
 		return false
 	}
 
-	for _, blockerID := range task.BlockedBy {
-		blocker, ok := s.tasks[blockerID]
+	for _, blockerID := range item.BlockedBy {
+		blocker, ok := s.items[blockerID]
 		if ok && blocker.Status != StatusCompleted && blocker.Status != StatusDeleted {
 			return true
 		}
@@ -282,19 +282,19 @@ func (s *Store) IsBlocked(id string) bool {
 	return false
 }
 
-// OpenBlockers returns IDs of uncompleted tasks that block the given task
+// OpenBlockers returns IDs of uncompleted items that block the given item
 func (s *Store) OpenBlockers(id string) []string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	task, ok := s.tasks[id]
-	if !ok || task.Status == StatusDeleted {
+	item, ok := s.items[id]
+	if !ok || item.Status == StatusDeleted {
 		return nil
 	}
 
 	var open []string
-	for _, blockerID := range task.BlockedBy {
-		blocker, ok := s.tasks[blockerID]
+	for _, blockerID := range item.BlockedBy {
+		blocker, ok := s.items[blockerID]
 		if ok && blocker.Status != StatusCompleted && blocker.Status != StatusDeleted {
 			open = append(open, blockerID)
 		}
@@ -302,39 +302,39 @@ func (s *Store) OpenBlockers(id string) []string {
 	return open
 }
 
-// Delete marks a task as deleted and removes its file from disk
+// Delete marks an item as deleted and removes its file from disk
 func (s *Store) Delete(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	task, ok := s.tasks[id]
+	item, ok := s.items[id]
 	if !ok {
-		return fmt.Errorf("task %s not found", id)
+		return fmt.Errorf("item %s not found", id)
 	}
 
-	task.Status = StatusDeleted
-	task.UpdatedAt = time.Now()
-	s.removeTaskFile(id)
+	item.Status = StatusDeleted
+	item.UpdatedAt = time.Now()
+	s.removeItemFile(id)
 	return nil
 }
 
-// AllMarkedCompleted reports whether the store has tasks and every one of them
+// AllMarkedCompleted reports whether the store has items and every one of them
 // carries StatusCompleted.
 //
 // The question is what the list records about itself — whether the model closed
 // out every item it wrote down — and Status is the only record of that.
 // Deriving it from executors would answer a different question and answer it
-// wrongly: a task left in_progress with no executor is abandoned work, not
+// wrongly: an item left in_progress with no worker is abandoned work, not
 // finished work, and marking it done would wipe the list at turn end and take
 // the [stalled] row down with it.
 func (s *Store) AllMarkedCompleted() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	if len(s.tasks) == 0 {
+	if len(s.items) == 0 {
 		return false
 	}
-	for _, t := range s.tasks {
+	for _, t := range s.items {
 		if t.Status == StatusDeleted {
 			continue
 		}
@@ -345,55 +345,55 @@ func (s *Store) AllMarkedCompleted() bool {
 	return true
 }
 
-// Reset clears all tasks (for new sessions)
+// Reset clears all items (for new sessions)
 func (s *Store) Reset() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Remove all task files from disk
+	// Remove all item files from disk
 	if s.storageDir != "" {
-		for id := range s.tasks {
+		for id := range s.items {
 			_ = os.Remove(filepath.Join(s.storageDir, id+".json"))
 		}
 	}
 
-	s.tasks = make(map[string]*Task)
+	s.items = make(map[string]*Item)
 	s.nextID = 1
 }
 
-// Export returns a snapshot of all tasks (including deleted) for session persistence
-func (s *Store) Export() []Task {
+// Export returns a snapshot of all items (including deleted) for session persistence
+func (s *Store) Export() []Item {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	tasks := make([]Task, 0, len(s.tasks))
-	for _, t := range s.tasks {
-		tasks = append(tasks, *t)
+	items := make([]Item, 0, len(s.items))
+	for _, t := range s.items {
+		items = append(items, *t)
 	}
-	sort.Slice(tasks, func(i, j int) bool {
-		return compareNumericIDs(tasks[i].ID, tasks[j].ID)
+	sort.Slice(items, func(i, j int) bool {
+		return compareNumericIDs(items[i].ID, items[j].ID)
 	})
-	return tasks
+	return items
 }
 
-// Import restores tasks from a snapshot (used when loading a session)
-func (s *Store) Import(tasks []Task) {
+// Import restores items from a snapshot (used when loading a session)
+func (s *Store) Import(items []Item) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.tasks = make(map[string]*Task, len(tasks))
+	s.items = make(map[string]*Item, len(items))
 	s.nextID = 1
-	for i := range tasks {
-		t := tasks[i]
-		normalizeTaskSlices(&t)
-		s.tasks[t.ID] = &t
+	for i := range items {
+		t := items[i]
+		normalizeItemSlices(&t)
+		s.items[t.ID] = &t
 		var idNum int
 		if _, err := fmt.Sscanf(t.ID, "%d", &idNum); err == nil && idNum >= s.nextID {
 			s.nextID = idNum + 1
 		}
-		s.persistTask(&t)
+		s.persistItem(&t)
 	}
-	s.demoteOrphanedTasks()
+	s.demoteOrphanedItems()
 }
 
 // GetStorageDir returns the current storage directory.
@@ -403,7 +403,7 @@ func (s *Store) GetStorageDir() string {
 	return s.storageDir
 }
 
-// ReloadFromDisk re-reads all task files from the storage directory.
+// ReloadFromDisk re-reads all item files from the storage directory.
 // This picks up changes made by other processes (e.g., background agents).
 // No-op if no storage directory is configured or if directory hasn't been modified.
 func (s *Store) ReloadFromDisk() {
@@ -414,21 +414,21 @@ func (s *Store) ReloadFromDisk() {
 		return
 	}
 
-	// Check if any task file has been modified since last reload.
+	// Check if any item file has been modified since last reload.
 	// We can't rely on directory mtime alone because modifying existing
 	// files in-place doesn't update the directory mtime on macOS/most
 	// filesystems.
-	entries, err := os.ReadDir(s.storageDir)
+	items, err := os.ReadDir(s.storageDir)
 	if err != nil {
 		return
 	}
 
 	changed := false
-	for _, entry := range entries {
-		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+	for _, item := range items {
+		if item.IsDir() || filepath.Ext(item.Name()) != ".json" {
 			continue
 		}
-		info, err := entry.Info()
+		info, err := item.Info()
 		if err != nil {
 			continue
 		}
@@ -446,12 +446,12 @@ func (s *Store) ReloadFromDisk() {
 	_ = s.loadFromDisk()
 }
 
-// UpdateOption is a functional option for updating a task
-type UpdateOption func(*Task)
+// UpdateOption is a functional option for updating an item
+type UpdateOption func(*Item)
 
-// WithStatus sets the task status and records the status change timestamp.
+// WithStatus sets the item status and records the status change timestamp.
 func WithStatus(status string) UpdateOption {
-	return func(t *Task) {
+	return func(t *Item) {
 		if t.Status != status {
 			t.StatusChangedAt = time.Now()
 		}
@@ -459,37 +459,37 @@ func WithStatus(status string) UpdateOption {
 	}
 }
 
-// WithSubject sets the task subject
+// WithSubject sets the item subject
 func WithSubject(subject string) UpdateOption {
-	return func(t *Task) {
+	return func(t *Item) {
 		t.Subject = subject
 	}
 }
 
-// WithDescription sets the task description
+// WithDescription sets the item description
 func WithDescription(description string) UpdateOption {
-	return func(t *Task) {
+	return func(t *Item) {
 		t.Description = description
 	}
 }
 
-// WithActiveForm sets the task activeForm
+// WithActiveForm sets the item activeForm
 func WithActiveForm(activeForm string) UpdateOption {
-	return func(t *Task) {
+	return func(t *Item) {
 		t.ActiveForm = activeForm
 	}
 }
 
-// WithOwner sets the task owner
+// WithOwner sets the item owner
 func WithOwner(owner string) UpdateOption {
-	return func(t *Task) {
+	return func(t *Item) {
 		t.Owner = owner
 	}
 }
 
 // WithMetadata merges metadata (nil values delete keys)
 func WithMetadata(metadata map[string]any) UpdateOption {
-	return func(t *Task) {
+	return func(t *Item) {
 		if t.Metadata == nil {
 			t.Metadata = make(map[string]any)
 		}
@@ -503,22 +503,22 @@ func WithMetadata(metadata map[string]any) UpdateOption {
 	}
 }
 
-// WithAddBlocks adds task IDs that this task blocks
+// WithAddBlocks adds item IDs that this item blocks
 func WithAddBlocks(ids []string) UpdateOption {
-	return func(t *Task) {
+	return func(t *Item) {
 		t.Blocks = appendUnique(t.Blocks, ids)
 	}
 }
 
-// WithAddBlockedBy adds task IDs that block this task
+// WithAddBlockedBy adds item IDs that block this item
 func WithAddBlockedBy(ids []string) UpdateOption {
-	return func(t *Task) {
+	return func(t *Item) {
 		t.BlockedBy = appendUnique(t.BlockedBy, ids)
 	}
 }
 
-// normalizeTaskSlices ensures Blocks and BlockedBy are non-nil slices.
-func normalizeTaskSlices(t *Task) {
+// normalizeItemSlices ensures Blocks and BlockedBy are non-nil slices.
+func normalizeItemSlices(t *Item) {
 	if t.Blocks == nil {
 		t.Blocks = []string{}
 	}
@@ -527,16 +527,16 @@ func normalizeTaskSlices(t *Task) {
 	}
 }
 
-// FindByMetadata returns a copy of the first non-deleted task whose metadata[key] equals want.
+// FindByMetadata returns a copy of the first non-deleted item whose metadata[key] equals want.
 // Returns nil if no match is found.
-func (s *Store) FindByMetadata(key, want string) *Task {
+func (s *Store) FindByMetadata(key, want string) *Item {
 	if want == "" {
 		return nil
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	for _, t := range s.tasks {
+	for _, t := range s.items {
 		if t.Status == StatusDeleted {
 			continue
 		}
@@ -553,7 +553,7 @@ func (s *Store) FindByMetadata(key, want string) *Task {
 	return nil
 }
 
-// compareNumericIDs compares two task IDs numerically (e.g. "2" < "10").
+// compareNumericIDs compares two item IDs numerically (e.g. "2" < "10").
 // Falls back to lexicographic comparison if parsing fails.
 func compareNumericIDs(a, b string) bool {
 	na, errA := strconv.Atoi(a)

--- a/internal/tool/tasktools/trackerlist.go
+++ b/internal/tool/tasktools/trackerlist.go
@@ -65,7 +65,7 @@ func (t *TrackerListTool) Execute(ctx context.Context, params map[string]any, cw
 }
 
 // TaskIcon returns the status icon for a task.
-func TaskIcon(task *todo.Task) string {
+func TaskIcon(task *todo.Item) string {
 	switch task.Status {
 	case todo.StatusCompleted:
 		return "✓"

--- a/tests/integration/session/session_test.go
+++ b/tests/integration/session/session_test.go
@@ -598,7 +598,7 @@ func TestSession_SaveClearedTasks_ClearsOnReload(t *testing.T) {
 	withTasks := &session.Snapshot{
 		Metadata: session.SessionMetadata{ID: "clear-tasks"},
 		Messages: []core.Message{makeUserEntry("m1", "hi")},
-		Tasks: []taskTracker.Task{{
+		Tasks: []taskTracker.Item{{
 			ID: "t1", Subject: "do thing", Status: "in_progress",
 			CreatedAt: time.Now(), UpdatedAt: time.Now(),
 		}},


### PR DESCRIPTION
Closes #344.

The issue expects no behavior change until a third `BackgroundTask` type exists. Tracing it found the opposite: the invariant it names is intact — no path leaves `StatusRunning` without `finalize` — but two live defects sit one layer out, in the join between a task and its tracker item.

## Defect 1 — tracker item stranded `in_progress` forever

The two halves of that join were driven from different places with nothing ordering them:

- **Completion** — worker goroutine → `finalize` → `notifyTaskCompleted` → `CompleteWorker`
- **Creation** — the launching tool's `HookResponse` → agent outbox → UI goroutine → `OnToolResult` → `TrackWorker`

When completion won, `CompleteWorker` found no item and returned silently; `TrackWorker` then created one `in_progress` for a task that had already finished.

Not a tight window: `agent_impl.go` runs every tool call in a batch before emitting any `PostToolEvent`, and a mixed batch is sequential — so `Agent(run_in_background)` alongside `Bash("sleep 30")` gives a deterministic 30s window. Any fast-failing worker hits it without needing a second tool.

The entry then outlives everything: it renders `[stalled]` for the rest of the session, `AllMarkedCompleted()` never returns true so the tracker never resets, and on the next start `demoteOrphanedItems` stamps it `interrupted` — recording a worker that succeeded as aborted.

**Fix.** Both halves now come from the manager's create and complete notifications, which cannot race: the manager announces creation from inside `CreateBashTask` / `RegisterTask`, before the caller has a goroutine that could complete the task. `TrackWorker` takes the same `task.TaskInfo` as `CompleteWorker`, so `BackgroundTaskLaunch` and the app's map-plucking are gone. The `HookResponse` payload stays — it is part of the `PostToolUse` contract.

Removing the tool-name gate also means background **bash** tasks are tracked at all now (they published a launch payload that `IsAgentToolName` dropped, while their completions arrived regardless), and a subagent left running by an interrupted turn gets a row.

**`notifyTaskCreated` now fires outside the manager lock**, as `notifyTaskCompleted` already did. Load-bearing, not tidiness: the handler now reaches the todo store's lock, and `demoteOrphanedItems` takes the manager's lock in the other direction. Notifying under the manager lock would close that cycle into a deadlock.

## Defect 2 — a deliberately stopped bash task recorded as failed

Same class as what #344 names: two types hand-writing one policy and disagreeing. `AgentTask.Complete` maps a cancelled run to `StatusStopped`; `BashTask.Complete` called every non-nil error a failure.

A cancelled bash run reaches `cmd.Wait` as `"signal: killed"`, never `context.Canceled`, so the error alone cannot draw that line. `TaskStop` printed `"Task stopped successfully... Status: failed"`, and the main agent got a failed completion for work the user had just called off — the retry `StatusStopped` exists to prevent. `Complete` now consults the task context: `Stop`/`Kill` cancel it, a timeout expires it, so timeouts stay failures.

## Tests

Both regression tests confirmed failing on `upstream/main` first:

- `TestWorkerItemSurvivesImmediateCompletion` — `expected 1 tracker item, got 0`
- `TestBashTaskStopIsNotAFailure` — `expected status 'stopped', got 'failed'`

Plus `TestBashTaskTimeoutRemainsAFailure` pinning the other side, and coverage for the newly-reachable bash path. `go build`, `go vet`, `go test ./...` and `-race` on the touched packages all pass.

## Not done here

- **The issue's own options 1 and 2** (`terminalState` embed, moving completion into `Manager`). With the join fixed, the remaining duplication is two ~20-line functions over genuinely different state — the call two reviewers already made on #342 — and the third task type still has not arrived.
- **`BashTask.Stop` is not actually graceful**: `cmd.Cancel` is overridden to SIGKILL the group immediately, so the following SIGTERM hits a dead group. Real, but process-signal semantics rather than this invariant, and needs its own Windows verification.
- **`Manager.cleanup` and `Manager.Remove` are dead**, and `BashTask.AppendOutput` has no size cap where `AgentTask`'s caps at 512KB.

## Naming (third commit)

Both defects above are failures of the same join, and the join could not be described clearly because **two different things were both called `Task`**: `todo.Task`, a row recorded in the tracker, and `internal/task`'s `BackgroundTask`, a process or subagent actually running. The sentence these bugs require — "the task finished but the task is still `in_progress`" — was unwriteable.

Each concept also had several names: the row was `Task` in code, "entry" in prose, "plan item" when the model authored it; the executor was `BackgroundTask` as a type, "worker" in API names, "executor" in comments.

The row is now **`Item`** throughout — type, fields, locals, prose. Its two kinds are a *plan item* and a *worker item*, which promotes the existing "plan item" vocabulary from exception to general case. `Item` also carries no sense of *doing*, which is exactly the line being drawn: an item records work, a task performs it.

**`executor` is kept deliberately** rather than folded into "worker". It is the broader term for whatever advances an item — a background task for a worker item, the main agent loop for a plan item — so collapsing it would lose a real distinction.

**Nothing observable is renamed.** Published contracts are untouched: the `TaskCreate` / `TaskGet` / `TaskUpdate` / `TaskList` tool names and their `taskId` parameter, the `background_task_id` metadata key, the transcript's `"tasks"` patch path and `TrackerItemView`'s serialized field names, and the `Tasks` panel header. Translation now happens at those edges instead of inside every package.

Pure mechanical rename: 20 files, no behavior change, full suite green.
