### PR TITLE
fix(task): make the graceful stop graceful, and bound a bash task's output

### DIFF
--- a/internal/task/agent_task.go
+++ b/internal/task/agent_task.go
@@ -117,19 +117,10 @@ func (t *AgentTask) GetDescription() string {
 	return t.Description
 }
 
-const maxOutputBufferSize = 512 * 1024 // 512KB in-memory cap; full output is in OutputFile
-
 // AppendOutput appends data to the output buffer
 func (t *AgentTask) AppendOutput(data []byte) {
 	t.mu.Lock()
-	t.output.Write(data)
-	// Cap in-memory buffer to the tail to prevent unbounded growth
-	if t.output.Len() > maxOutputBufferSize {
-		b := t.output.Bytes()
-		tail := b[len(b)-maxOutputBufferSize:]
-		t.output.Reset()
-		t.output.Write(tail)
-	}
+	appendCapped(&t.output, data)
 	outputFile := t.OutputFile
 	t.mu.Unlock()
 

--- a/internal/task/bash_task.go
+++ b/internal/task/bash_task.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os/exec"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -14,33 +15,38 @@ import (
 // BashTask represents a background bash command task
 // It implements the BackgroundTask interface
 type BashTask struct {
-	ID          string          // Unique task ID
-	Command     string          // The command being executed
-	Description string          // Brief description
-	PID         int             // Process ID
-	StartTime   time.Time       // When the task started
-	OutputFile  string          // Stable output file path when available
-	cmd         *exec.Cmd       // The running command
-	ctx         context.Context // Task context
+	ID          string    // Unique task ID
+	Command     string    // The command being executed
+	Description string    // Brief description
+	PID         int       // Process ID
+	StartTime   time.Time // When the task started
+	OutputFile  string    // Stable output file path when available
+	cmd         *exec.Cmd // The running command
 
 	cancel context.CancelFunc // Cancel function
 
-	mu            sync.RWMutex  // Protects mutable fields below
-	status        TaskStatus    // Current status
-	endTime       time.Time     // When the task ended (if completed)
-	exitCode      int           // Exit code (if completed)
-	errMsg        string        // Error message (if failed)
-	stopRequested bool          // Stop was asked for; the exit is deliberate
-	output        bytes.Buffer  // Collected stdout/stderr
-	done          chan struct{} // Closed when task completes
-	doneOnce      sync.Once     // Guards done channel close
+	// stopRequested records that Stop asked the child to exit, so Complete can
+	// tell a deliberate stop from a crash. Written by the caller of Stop and
+	// read on the goroutine waiting for the child, so it is atomic rather than
+	// mu-guarded: it shares no invariant with the fields below and is never
+	// read together with them.
+	stopRequested atomic.Bool
+
+	mu       sync.RWMutex  // Protects mutable fields below
+	status   TaskStatus    // Current status
+	endTime  time.Time     // When the task ended (if completed)
+	exitCode int           // Exit code (if completed)
+	errMsg   string        // Error message (if failed)
+	output   bytes.Buffer  // Collected stdout/stderr
+	done     chan struct{} // Closed when task completes
+	doneOnce sync.Once     // Guards done channel close
 }
 
 // Verify BashTask implements BackgroundTask
 var _ BackgroundTask = (*BashTask)(nil)
 
 // NewBashTask creates a new bash task
-func NewBashTask(id, command, description string, cmd *exec.Cmd, ctx context.Context, cancel context.CancelFunc) *BashTask {
+func NewBashTask(id, command, description string, cmd *exec.Cmd, cancel context.CancelFunc) *BashTask {
 	task := &BashTask{
 		ID:          id,
 		Command:     command,
@@ -50,7 +56,6 @@ func NewBashTask(id, command, description string, cmd *exec.Cmd, ctx context.Con
 		StartTime:   time.Now(),
 		OutputFile:  initOutputFile(id),
 		cmd:         cmd,
-		ctx:         ctx,
 		cancel:      cancel,
 		done:        make(chan struct{}),
 	}
@@ -113,13 +118,9 @@ func (t *BashTask) GetOutput() string {
 // retry work the user had just cancelled — the outcome StatusStopped exists to
 // prevent.
 func (t *BashTask) Complete(exitCode int, err error) {
-	t.mu.RLock()
-	stopped := t.stopRequested
-	t.mu.RUnlock()
-
 	status, errMsg := StatusCompleted, ""
 	switch {
-	case stopped:
+	case t.stopRequested.Load():
 		status, errMsg = StatusStopped, "stopped before completion"
 	case err != nil:
 		status, errMsg = StatusFailed, err.Error()
@@ -129,10 +130,12 @@ func (t *BashTask) Complete(exitCode int, err error) {
 	t.finalize(status, exitCode, errMsg)
 }
 
-// markKilled marks the task as killed (internal use). The exit code follows
-// the shell convention of 128+signal for SIGKILL, so a reader of the output
-// record can't mistake a killed task's code for a successful 0.
-func (t *BashTask) markKilled() { t.finalize(StatusKilled, 128+int(syscall.SIGKILL), "") }
+// signalExitCode renders a death by signal the way a shell does, so a reader
+// of the output record can't mistake a killed task's code for a successful 0.
+func signalExitCode(sig syscall.Signal) int { return 128 + int(sig) }
+
+// markKilled marks the task as killed (internal use).
+func (t *BashTask) markKilled() { t.finalize(StatusKilled, signalExitCode(syscall.SIGKILL), "") }
 
 // finalize performs the one and only terminal transition a BashTask can make.
 // Every route out of StatusRunning — clean exit, non-zero exit, error, kill —
@@ -189,16 +192,13 @@ func (t *BashTask) WaitForCompletion(timeout time.Duration) bool {
 // so the child gets a chance to clean up. On Windows there is no signal-based
 // graceful stop, so the helper hard-kills instead.
 //
-// It deliberately does not cancel the task context. exec wires cmd.Cancel to
-// SIGKILL the group the instant the context is done, so cancelling here would
+// It deliberately leaves the task context alone. exec wires cmd.Cancel to
+// SIGKILL the group the instant that context is done, so cancelling here would
 // deliver the kill before the SIGTERM and the graceful stop would never
-// actually happen. Escalation belongs to the caller: Manager.Kill polls for
-// the exit and falls back to Kill when the child ignores the signal.
+// actually happen. Escalation belongs to the caller: Manager.Kill waits
+// gracefulStopTimeout and then falls back to Kill.
 func (t *BashTask) Stop() error {
-	t.mu.Lock()
-	t.stopRequested = true
-	t.mu.Unlock()
-
+	t.stopRequested.Store(true)
 	return proc.TerminateGroup(t.cmd, syscall.SIGTERM)
 }
 

--- a/internal/task/bash_task.go
+++ b/internal/task/bash_task.go
@@ -3,7 +3,6 @@ package task
 import (
 	"bytes"
 	"context"
-	"errors"
 	"os/exec"
 	"sync"
 	"syscall"
@@ -26,14 +25,15 @@ type BashTask struct {
 
 	cancel context.CancelFunc // Cancel function
 
-	mu       sync.RWMutex  // Protects mutable fields below
-	status   TaskStatus    // Current status
-	endTime  time.Time     // When the task ended (if completed)
-	exitCode int           // Exit code (if completed)
-	errMsg   string        // Error message (if failed)
-	output   bytes.Buffer  // Collected stdout/stderr
-	done     chan struct{} // Closed when task completes
-	doneOnce sync.Once     // Guards done channel close
+	mu            sync.RWMutex  // Protects mutable fields below
+	status        TaskStatus    // Current status
+	endTime       time.Time     // When the task ended (if completed)
+	exitCode      int           // Exit code (if completed)
+	errMsg        string        // Error message (if failed)
+	stopRequested bool          // Stop was asked for; the exit is deliberate
+	output        bytes.Buffer  // Collected stdout/stderr
+	done          chan struct{} // Closed when task completes
+	doneOnce      sync.Once     // Guards done channel close
 }
 
 // Verify BashTask implements BackgroundTask
@@ -84,7 +84,7 @@ func (t *BashTask) GetDescription() string {
 // AppendOutput appends data to the output buffer
 func (t *BashTask) AppendOutput(data []byte) {
 	t.mu.Lock()
-	t.output.Write(data)
+	appendCapped(&t.output, data)
 	outputFile := t.OutputFile
 	t.mu.Unlock()
 
@@ -104,18 +104,22 @@ func (t *BashTask) GetOutput() string {
 // Complete records the terminal status of a bash task that has exited, the
 // counterpart to AgentTask.Complete and classifying the same three outcomes.
 //
-// A cancelled run reaches cmd.Wait as an ordinary signal death ("signal:
-// killed"), never as context.Canceled, so unlike the agent case the error
-// alone cannot tell a deliberate stop from a genuine failure. The task context
-// draws that line: Stop and Kill cancel it, while the run's own timeout
-// expires it instead — a timeout is a failure, so only cancellation is
-// exempted here. Without this a user-requested TaskStop was recorded as
-// failed, and the main agent could retry work the user had just cancelled,
-// which is the outcome StatusStopped exists to prevent.
+// A stopped run reaches cmd.Wait as an ordinary signal death ("signal:
+// terminated"), never as context.Canceled, so unlike the agent case the error
+// alone cannot tell a deliberate stop from a genuine failure. Stop records
+// that it asked, and that flag is the only thing that distinguishes them: a
+// run killed by its own timeout sets nothing and stays a failure. Without this
+// a user-requested TaskStop was recorded as failed, and the main agent could
+// retry work the user had just cancelled — the outcome StatusStopped exists to
+// prevent.
 func (t *BashTask) Complete(exitCode int, err error) {
+	t.mu.RLock()
+	stopped := t.stopRequested
+	t.mu.RUnlock()
+
 	status, errMsg := StatusCompleted, ""
 	switch {
-	case t.ctx != nil && errors.Is(t.ctx.Err(), context.Canceled):
+	case stopped:
 		status, errMsg = StatusStopped, "stopped before completion"
 	case err != nil:
 		status, errMsg = StatusFailed, err.Error()
@@ -181,12 +185,20 @@ func (t *BashTask) WaitForCompletion(timeout time.Duration) bool {
 	}
 }
 
-// Stop gracefully stops the task (SIGTERM on Unix; on Windows there is no
-// signal-based graceful stop, so the underlying helper hard-kills the child).
+// Stop asks the task to exit gracefully, sending SIGTERM to its process group
+// so the child gets a chance to clean up. On Windows there is no signal-based
+// graceful stop, so the helper hard-kills instead.
+//
+// It deliberately does not cancel the task context. exec wires cmd.Cancel to
+// SIGKILL the group the instant the context is done, so cancelling here would
+// deliver the kill before the SIGTERM and the graceful stop would never
+// actually happen. Escalation belongs to the caller: Manager.Kill polls for
+// the exit and falls back to Kill when the child ignores the signal.
 func (t *BashTask) Stop() error {
-	if t.cancel != nil {
-		t.cancel()
-	}
+	t.mu.Lock()
+	t.stopRequested = true
+	t.mu.Unlock()
+
 	return proc.TerminateGroup(t.cmd, syscall.SIGTERM)
 }
 

--- a/internal/task/bash_task_test.go
+++ b/internal/task/bash_task_test.go
@@ -1,10 +1,13 @@
 package task
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"os/exec"
+	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -298,11 +301,10 @@ func TestBashTask_ImplementsBackgroundTask(t *testing.T) {
 	}
 }
 
-// A user-requested stop cancels the task context, and the child dies of the
-// signal that follows — so cmd.Wait reports "signal: killed", not a
-// cancellation. Recording that as failed told the main agent the work had
-// broken rather than been called off, inviting a retry of what the user had
-// just cancelled.
+// A stopped child dies of the signal Stop sent it, so cmd.Wait reports
+// "signal: terminated" — indistinguishable from a crash by the error alone.
+// Recording that as failed told the main agent the work had broken rather than
+// been called off, inviting a retry of what the user had just cancelled.
 func TestBashTaskStopIsNotAFailure(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -312,16 +314,16 @@ func TestBashTaskStopIsNotAFailure(t *testing.T) {
 
 	task := NewBashTask("stop-id", "sleep 100", "Long task", cmd, ctx, cancel)
 
-	cancel()
-	task.Complete(137, errors.New("signal: killed"))
+	_ = task.Stop()
+	task.Complete(128+int(syscall.SIGTERM), errors.New("signal: terminated"))
 
 	if info := task.GetStatus(); info.Status != StatusStopped {
 		t.Errorf("expected status '%s', got '%s'", StatusStopped, info.Status)
 	}
 }
 
-// A run that outlives its own timeout also ends with a cancelled context, but
-// it failed on its own terms — nobody called it off, so it stays a failure.
+// A run killed by its own timeout dies the same way, but nobody called it off,
+// so it stays a failure. Only Stop exempts a task from that.
 func TestBashTaskTimeoutRemainsAFailure(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
 	defer cancel()
@@ -332,9 +334,56 @@ func TestBashTaskTimeoutRemainsAFailure(t *testing.T) {
 	task := NewBashTask("timeout-id", "sleep 100", "Long task", cmd, ctx, cancel)
 
 	<-ctx.Done()
-	task.Complete(137, errors.New("signal: killed"))
+	task.Complete(128+int(syscall.SIGKILL), errors.New("signal: killed"))
 
 	if info := task.GetStatus(); info.Status != StatusFailed {
 		t.Errorf("expected status '%s', got '%s'", StatusFailed, info.Status)
+	}
+}
+
+// Stop must not cancel the task context: exec wires cmd.Cancel to SIGKILL the
+// group the moment the context is done, which would land before the SIGTERM
+// and make the graceful stop a lie.
+func TestBashTaskStopLeavesContextLive(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "echo", "test")
+	cmd.Start()
+
+	task := NewBashTask("graceful-id", "sleep 100", "Long task", cmd, ctx, cancel)
+
+	_ = task.Stop()
+
+	if err := ctx.Err(); err != nil {
+		t.Errorf("Stop cancelled the task context (%v); the SIGKILL that follows "+
+			"cancellation would pre-empt the SIGTERM Stop just sent", err)
+	}
+}
+
+// A background command that never stops talking used to have every byte it
+// ever printed held in memory for the life of the process: BashTask skipped
+// the cap AgentTask applied, and the manager never forgets a task.
+func TestBashTaskOutputIsCapped(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "echo", "test")
+	cmd.Start()
+
+	task := NewBashTask("cap-id", "chatty", "Chatty task", cmd, ctx, cancel)
+
+	for range 4 {
+		task.AppendOutput(bytes.Repeat([]byte("x"), maxOutputBufferSize/2))
+	}
+	task.AppendOutput([]byte("TAIL"))
+
+	output := task.GetOutput()
+	if len(output) > maxOutputBufferSize {
+		t.Fatalf("output buffer = %d bytes, want <= %d", len(output), maxOutputBufferSize)
+	}
+	// The tail is the part worth keeping — it is where a failure shows up.
+	if !strings.HasSuffix(output, "TAIL") {
+		t.Error("cap discarded the newest output instead of the oldest")
 	}
 }

--- a/internal/task/bash_task_test.go
+++ b/internal/task/bash_task_test.go
@@ -12,14 +12,23 @@ import (
 	"time"
 )
 
-func TestBashTask_Complete(t *testing.T) {
+// newRunningBashTask builds a started BashTask over a throwaway child process,
+// mirroring newRunningAgentTask for the sibling type. Tests that need the run's
+// own context — to assert on it, or to give it a deadline — build their own.
+func newRunningBashTask(t *testing.T, id, command, description string) *BashTask {
+	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	t.Cleanup(cancel)
 
 	cmd := exec.CommandContext(ctx, "echo", "test")
-	cmd.Start()
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper process: %v", err)
+	}
+	return NewBashTask(id, command, description, cmd, cancel)
+}
 
-	task := NewBashTask("test-id", "echo test", "Test task", cmd, cancel)
+func TestBashTask_Complete(t *testing.T) {
+	task := newRunningBashTask(t, "test-id", "echo test", "Test task")
 
 	// Complete the task
 	task.Complete(0, nil)
@@ -34,13 +43,7 @@ func TestBashTask_Complete(t *testing.T) {
 }
 
 func TestBashTask_Failed(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "echo", "test")
-	cmd.Start()
-
-	task := NewBashTask("fail-id", "exit 1", "Failing task", cmd, cancel)
+	task := newRunningBashTask(t, "fail-id", "exit 1", "Failing task")
 
 	// Complete with non-zero exit code
 	task.Complete(1, nil)
@@ -55,13 +58,7 @@ func TestBashTask_Failed(t *testing.T) {
 }
 
 func TestBashTask_MarkKilled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "echo", "test")
-	cmd.Start()
-
-	task := NewBashTask("kill-id", "sleep 100", "Long task", cmd, cancel)
+	task := newRunningBashTask(t, "kill-id", "sleep 100", "Long task")
 
 	task.markKilled()
 
@@ -72,13 +69,7 @@ func TestBashTask_MarkKilled(t *testing.T) {
 }
 
 func TestBashTask_AppendAndGetOutput(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "echo", "test")
-	cmd.Start()
-
-	task := NewBashTask("output-id", "echo test", "Output task", cmd, cancel)
+	task := newRunningBashTask(t, "output-id", "echo test", "Output task")
 
 	task.AppendOutput([]byte("line 1\n"))
 	task.AppendOutput([]byte("line 2\n"))
@@ -91,13 +82,7 @@ func TestBashTask_AppendAndGetOutput(t *testing.T) {
 }
 
 func TestBashTask_IsRunning(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "echo", "test")
-	cmd.Start()
-
-	task := NewBashTask("running-id", "echo test", "Running task", cmd, cancel)
+	task := newRunningBashTask(t, "running-id", "echo test", "Running task")
 
 	if !task.IsRunning() {
 		t.Error("task should be running initially")
@@ -111,13 +96,7 @@ func TestBashTask_IsRunning(t *testing.T) {
 }
 
 func TestBashTask_WaitForCompletion(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "echo", "test")
-	cmd.Start()
-
-	task := NewBashTask("wait-id", "echo test", "Wait task", cmd, cancel)
+	task := newRunningBashTask(t, "wait-id", "echo test", "Wait task")
 
 	// Complete in background after short delay
 	go func() {
@@ -132,13 +111,7 @@ func TestBashTask_WaitForCompletion(t *testing.T) {
 }
 
 func TestBashTask_WaitForCompletionTimeout(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "echo", "test")
-	cmd.Start()
-
-	task := NewBashTask("timeout-id", "sleep 100", "Timeout task", cmd, cancel)
+	task := newRunningBashTask(t, "timeout-id", "sleep 100", "Timeout task")
 
 	// Don't complete the task, let it timeout
 	completed := task.WaitForCompletion(200 * time.Millisecond)
@@ -148,13 +121,7 @@ func TestBashTask_WaitForCompletionTimeout(t *testing.T) {
 }
 
 func TestBashTask_GetStatus(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "echo", "test")
-	cmd.Start()
-
-	task := NewBashTask("status-id", "echo test", "Status task", cmd, cancel)
+	task := newRunningBashTask(t, "status-id", "echo test", "Status task")
 	task.AppendOutput([]byte("output\n"))
 
 	info := task.GetStatus()
@@ -177,13 +144,7 @@ func TestBashTask_GetStatus(t *testing.T) {
 }
 
 func TestBashTask_ConcurrentAccess(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "echo", "test")
-	cmd.Start()
-
-	task := NewBashTask("concurrent-id", "echo test", "Concurrent task", cmd, cancel)
+	task := newRunningBashTask(t, "concurrent-id", "echo test", "Concurrent task")
 
 	var wg sync.WaitGroup
 
@@ -214,13 +175,7 @@ func TestBashTask_ConcurrentAccess(t *testing.T) {
 }
 
 func TestBashTask_StatusRunning(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "echo", "test")
-	cmd.Start()
-
-	task := NewBashTask("running-status-id", "echo test", "Running status task", cmd, cancel)
+	task := newRunningBashTask(t, "running-status-id", "echo test", "Running status task")
 
 	// Newly created task should be in Running state
 	info := task.GetStatus()
@@ -237,11 +192,7 @@ func TestBashTask_StatusRunning(t *testing.T) {
 func TestBashTask_AllStateTransitions(t *testing.T) {
 	// Running -> Completed
 	t.Run("Running to Completed", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		cmd := exec.CommandContext(ctx, "echo", "test")
-		cmd.Start()
-		task := NewBashTask("t1", "echo test", "test", cmd, cancel)
+		task := newRunningBashTask(t, "t1", "echo test", "test")
 		if info := task.GetStatus(); info.Status != StatusRunning {
 			t.Errorf("want %s, got %s", StatusRunning, info.Status)
 		}
@@ -253,11 +204,7 @@ func TestBashTask_AllStateTransitions(t *testing.T) {
 
 	// Running -> Failed (non-zero exit)
 	t.Run("Running to Failed", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		cmd := exec.CommandContext(ctx, "echo", "test")
-		cmd.Start()
-		task := NewBashTask("t2", "exit 1", "test", cmd, cancel)
+		task := newRunningBashTask(t, "t2", "exit 1", "test")
 		task.Complete(2, nil)
 		if info := task.GetStatus(); info.Status != StatusFailed {
 			t.Errorf("want %s, got %s", StatusFailed, info.Status)
@@ -266,11 +213,7 @@ func TestBashTask_AllStateTransitions(t *testing.T) {
 
 	// Running -> Killed
 	t.Run("Running to Killed", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		cmd := exec.CommandContext(ctx, "echo", "test")
-		cmd.Start()
-		task := NewBashTask("t3", "sleep 100", "test", cmd, cancel)
+		task := newRunningBashTask(t, "t3", "sleep 100", "test")
 		task.markKilled()
 		if info := task.GetStatus(); info.Status != StatusKilled {
 			t.Errorf("want %s, got %s", StatusKilled, info.Status)
@@ -279,13 +222,7 @@ func TestBashTask_AllStateTransitions(t *testing.T) {
 }
 
 func TestBashTask_ImplementsBackgroundTask(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "echo", "test")
-	cmd.Start()
-
-	task := NewBashTask("interface-id", "echo test", "Interface test", cmd, cancel)
+	task := newRunningBashTask(t, "interface-id", "echo test", "Interface test")
 
 	// Test that it implements BackgroundTask
 	var bt BackgroundTask = task
@@ -306,13 +243,7 @@ func TestBashTask_ImplementsBackgroundTask(t *testing.T) {
 // Recording that as failed told the main agent the work had broken rather than
 // been called off, inviting a retry of what the user had just cancelled.
 func TestBashTaskStopIsNotAFailure(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "echo", "test")
-	cmd.Start()
-
-	task := NewBashTask("stop-id", "sleep 100", "Long task", cmd, cancel)
+	task := newRunningBashTask(t, "stop-id", "sleep 100", "Long task")
 
 	_ = task.Stop()
 	task.Complete(signalExitCode(syscall.SIGTERM), errors.New("signal: terminated"))
@@ -341,23 +272,22 @@ func TestBashTaskTimeoutRemainsAFailure(t *testing.T) {
 	}
 }
 
-// Stop must not cancel the run's context: exec wires cmd.Cancel to SIGKILL the
-// group the moment that context is done, which would land before the SIGTERM
-// and make the graceful stop a lie.
-func TestBashTaskStopLeavesContextLive(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+// Stop must not reach for cancellation — see BashTask.Stop for why that would
+// defeat the graceful signal it just sent.
+func TestBashTaskStopDoesNotCancelTheRun(t *testing.T) {
+	cmd := exec.Command("echo", "test")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper process: %v", err)
+	}
 
-	cmd := exec.CommandContext(ctx, "echo", "test")
-	cmd.Start()
-
-	task := NewBashTask("graceful-id", "sleep 100", "Long task", cmd, cancel)
+	cancelled := false
+	task := NewBashTask("graceful-id", "sleep 100", "Long task", cmd, func() { cancelled = true })
 
 	_ = task.Stop()
 
-	if err := ctx.Err(); err != nil {
-		t.Errorf("Stop cancelled the task context (%v); the SIGKILL that follows "+
-			"cancellation would pre-empt the SIGTERM Stop just sent", err)
+	if cancelled {
+		t.Error("Stop cancelled the run; the SIGKILL that follows cancellation " +
+			"would pre-empt the SIGTERM Stop just sent")
 	}
 }
 
@@ -365,13 +295,7 @@ func TestBashTaskStopLeavesContextLive(t *testing.T) {
 // ever printed held in memory for the life of the process: BashTask skipped
 // the cap AgentTask applied, and the manager never forgets a task.
 func TestBashTaskOutputIsCapped(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "echo", "test")
-	cmd.Start()
-
-	task := NewBashTask("cap-id", "chatty", "Chatty task", cmd, cancel)
+	task := newRunningBashTask(t, "cap-id", "chatty", "Chatty task")
 
 	for range 4 {
 		task.AppendOutput(bytes.Repeat([]byte("x"), maxOutputBufferSize/2))

--- a/internal/task/bash_task_test.go
+++ b/internal/task/bash_task_test.go
@@ -19,7 +19,7 @@ func TestBashTask_Complete(t *testing.T) {
 	cmd := exec.CommandContext(ctx, "echo", "test")
 	cmd.Start()
 
-	task := NewBashTask("test-id", "echo test", "Test task", cmd, ctx, cancel)
+	task := NewBashTask("test-id", "echo test", "Test task", cmd, cancel)
 
 	// Complete the task
 	task.Complete(0, nil)
@@ -40,7 +40,7 @@ func TestBashTask_Failed(t *testing.T) {
 	cmd := exec.CommandContext(ctx, "echo", "test")
 	cmd.Start()
 
-	task := NewBashTask("fail-id", "exit 1", "Failing task", cmd, ctx, cancel)
+	task := NewBashTask("fail-id", "exit 1", "Failing task", cmd, cancel)
 
 	// Complete with non-zero exit code
 	task.Complete(1, nil)
@@ -61,7 +61,7 @@ func TestBashTask_MarkKilled(t *testing.T) {
 	cmd := exec.CommandContext(ctx, "echo", "test")
 	cmd.Start()
 
-	task := NewBashTask("kill-id", "sleep 100", "Long task", cmd, ctx, cancel)
+	task := NewBashTask("kill-id", "sleep 100", "Long task", cmd, cancel)
 
 	task.markKilled()
 
@@ -78,7 +78,7 @@ func TestBashTask_AppendAndGetOutput(t *testing.T) {
 	cmd := exec.CommandContext(ctx, "echo", "test")
 	cmd.Start()
 
-	task := NewBashTask("output-id", "echo test", "Output task", cmd, ctx, cancel)
+	task := NewBashTask("output-id", "echo test", "Output task", cmd, cancel)
 
 	task.AppendOutput([]byte("line 1\n"))
 	task.AppendOutput([]byte("line 2\n"))
@@ -97,7 +97,7 @@ func TestBashTask_IsRunning(t *testing.T) {
 	cmd := exec.CommandContext(ctx, "echo", "test")
 	cmd.Start()
 
-	task := NewBashTask("running-id", "echo test", "Running task", cmd, ctx, cancel)
+	task := NewBashTask("running-id", "echo test", "Running task", cmd, cancel)
 
 	if !task.IsRunning() {
 		t.Error("task should be running initially")
@@ -117,7 +117,7 @@ func TestBashTask_WaitForCompletion(t *testing.T) {
 	cmd := exec.CommandContext(ctx, "echo", "test")
 	cmd.Start()
 
-	task := NewBashTask("wait-id", "echo test", "Wait task", cmd, ctx, cancel)
+	task := NewBashTask("wait-id", "echo test", "Wait task", cmd, cancel)
 
 	// Complete in background after short delay
 	go func() {
@@ -138,7 +138,7 @@ func TestBashTask_WaitForCompletionTimeout(t *testing.T) {
 	cmd := exec.CommandContext(ctx, "echo", "test")
 	cmd.Start()
 
-	task := NewBashTask("timeout-id", "sleep 100", "Timeout task", cmd, ctx, cancel)
+	task := NewBashTask("timeout-id", "sleep 100", "Timeout task", cmd, cancel)
 
 	// Don't complete the task, let it timeout
 	completed := task.WaitForCompletion(200 * time.Millisecond)
@@ -154,7 +154,7 @@ func TestBashTask_GetStatus(t *testing.T) {
 	cmd := exec.CommandContext(ctx, "echo", "test")
 	cmd.Start()
 
-	task := NewBashTask("status-id", "echo test", "Status task", cmd, ctx, cancel)
+	task := NewBashTask("status-id", "echo test", "Status task", cmd, cancel)
 	task.AppendOutput([]byte("output\n"))
 
 	info := task.GetStatus()
@@ -183,7 +183,7 @@ func TestBashTask_ConcurrentAccess(t *testing.T) {
 	cmd := exec.CommandContext(ctx, "echo", "test")
 	cmd.Start()
 
-	task := NewBashTask("concurrent-id", "echo test", "Concurrent task", cmd, ctx, cancel)
+	task := NewBashTask("concurrent-id", "echo test", "Concurrent task", cmd, cancel)
 
 	var wg sync.WaitGroup
 
@@ -220,7 +220,7 @@ func TestBashTask_StatusRunning(t *testing.T) {
 	cmd := exec.CommandContext(ctx, "echo", "test")
 	cmd.Start()
 
-	task := NewBashTask("running-status-id", "echo test", "Running status task", cmd, ctx, cancel)
+	task := NewBashTask("running-status-id", "echo test", "Running status task", cmd, cancel)
 
 	// Newly created task should be in Running state
 	info := task.GetStatus()
@@ -241,7 +241,7 @@ func TestBashTask_AllStateTransitions(t *testing.T) {
 		defer cancel()
 		cmd := exec.CommandContext(ctx, "echo", "test")
 		cmd.Start()
-		task := NewBashTask("t1", "echo test", "test", cmd, ctx, cancel)
+		task := NewBashTask("t1", "echo test", "test", cmd, cancel)
 		if info := task.GetStatus(); info.Status != StatusRunning {
 			t.Errorf("want %s, got %s", StatusRunning, info.Status)
 		}
@@ -257,7 +257,7 @@ func TestBashTask_AllStateTransitions(t *testing.T) {
 		defer cancel()
 		cmd := exec.CommandContext(ctx, "echo", "test")
 		cmd.Start()
-		task := NewBashTask("t2", "exit 1", "test", cmd, ctx, cancel)
+		task := NewBashTask("t2", "exit 1", "test", cmd, cancel)
 		task.Complete(2, nil)
 		if info := task.GetStatus(); info.Status != StatusFailed {
 			t.Errorf("want %s, got %s", StatusFailed, info.Status)
@@ -270,7 +270,7 @@ func TestBashTask_AllStateTransitions(t *testing.T) {
 		defer cancel()
 		cmd := exec.CommandContext(ctx, "echo", "test")
 		cmd.Start()
-		task := NewBashTask("t3", "sleep 100", "test", cmd, ctx, cancel)
+		task := NewBashTask("t3", "sleep 100", "test", cmd, cancel)
 		task.markKilled()
 		if info := task.GetStatus(); info.Status != StatusKilled {
 			t.Errorf("want %s, got %s", StatusKilled, info.Status)
@@ -285,7 +285,7 @@ func TestBashTask_ImplementsBackgroundTask(t *testing.T) {
 	cmd := exec.CommandContext(ctx, "echo", "test")
 	cmd.Start()
 
-	task := NewBashTask("interface-id", "echo test", "Interface test", cmd, ctx, cancel)
+	task := NewBashTask("interface-id", "echo test", "Interface test", cmd, cancel)
 
 	// Test that it implements BackgroundTask
 	var bt BackgroundTask = task
@@ -312,10 +312,10 @@ func TestBashTaskStopIsNotAFailure(t *testing.T) {
 	cmd := exec.CommandContext(ctx, "echo", "test")
 	cmd.Start()
 
-	task := NewBashTask("stop-id", "sleep 100", "Long task", cmd, ctx, cancel)
+	task := NewBashTask("stop-id", "sleep 100", "Long task", cmd, cancel)
 
 	_ = task.Stop()
-	task.Complete(128+int(syscall.SIGTERM), errors.New("signal: terminated"))
+	task.Complete(signalExitCode(syscall.SIGTERM), errors.New("signal: terminated"))
 
 	if info := task.GetStatus(); info.Status != StatusStopped {
 		t.Errorf("expected status '%s', got '%s'", StatusStopped, info.Status)
@@ -331,18 +331,18 @@ func TestBashTaskTimeoutRemainsAFailure(t *testing.T) {
 	cmd := exec.Command("echo", "test")
 	cmd.Start()
 
-	task := NewBashTask("timeout-id", "sleep 100", "Long task", cmd, ctx, cancel)
+	task := NewBashTask("timeout-id", "sleep 100", "Long task", cmd, cancel)
 
 	<-ctx.Done()
-	task.Complete(128+int(syscall.SIGKILL), errors.New("signal: killed"))
+	task.Complete(signalExitCode(syscall.SIGKILL), errors.New("signal: killed"))
 
 	if info := task.GetStatus(); info.Status != StatusFailed {
 		t.Errorf("expected status '%s', got '%s'", StatusFailed, info.Status)
 	}
 }
 
-// Stop must not cancel the task context: exec wires cmd.Cancel to SIGKILL the
-// group the moment the context is done, which would land before the SIGTERM
+// Stop must not cancel the run's context: exec wires cmd.Cancel to SIGKILL the
+// group the moment that context is done, which would land before the SIGTERM
 // and make the graceful stop a lie.
 func TestBashTaskStopLeavesContextLive(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -351,7 +351,7 @@ func TestBashTaskStopLeavesContextLive(t *testing.T) {
 	cmd := exec.CommandContext(ctx, "echo", "test")
 	cmd.Start()
 
-	task := NewBashTask("graceful-id", "sleep 100", "Long task", cmd, ctx, cancel)
+	task := NewBashTask("graceful-id", "sleep 100", "Long task", cmd, cancel)
 
 	_ = task.Stop()
 
@@ -371,7 +371,7 @@ func TestBashTaskOutputIsCapped(t *testing.T) {
 	cmd := exec.CommandContext(ctx, "echo", "test")
 	cmd.Start()
 
-	task := NewBashTask("cap-id", "chatty", "Chatty task", cmd, ctx, cancel)
+	task := NewBashTask("cap-id", "chatty", "Chatty task", cmd, cancel)
 
 	for range 4 {
 		task.AppendOutput(bytes.Repeat([]byte("x"), maxOutputBufferSize/2))

--- a/internal/task/hooks_test.go
+++ b/internal/task/hooks_test.go
@@ -33,7 +33,7 @@ func TestTaskLifecycleHandler(t *testing.T) {
 		t.Fatalf("start command: %v", err)
 	}
 
-	task := mgr.CreateBashTask(cmd, "echo test", "Test task", ctx, cancel)
+	task := mgr.CreateBashTask(cmd, "echo test", "Test task", cancel)
 	if len(observer.created) != 1 {
 		t.Fatalf("expected 1 created notification, got %d", len(observer.created))
 	}
@@ -66,7 +66,7 @@ func TestKillNotifiesLifecycleHandler(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start command: %v", err)
 	}
-	task := mgr.CreateBashTask(cmd, "sleep 30", "Long task", ctx, cancel)
+	task := mgr.CreateBashTask(cmd, "sleep 30", "Long task", cancel)
 
 	_ = task.Kill()
 

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -10,7 +10,19 @@ import (
 	"time"
 )
 
+// gracefulStopTimeout is how long a Stop'd task gets to exit on its own
+// before Kill escalates. Named because BackgroundTask.Stop's contract points
+// at it: implementers rely on this escalation instead of enforcing their own
+// deadline.
+const gracefulStopTimeout = 2 * time.Second
+
 // Manager tracks background bash and subagent tasks.
+//
+// Nothing prunes tasks: they are kept for the life of the process, because
+// TaskOutput resolves a task ID through this map and has no fallback to the
+// output file on disk, so forgetting one would mean answering "task not
+// found" for work the model ran minutes ago. What each task holds is bounded
+// instead, by appendCapped.
 type Manager struct {
 	mu    sync.RWMutex
 	tasks map[string]BackgroundTask
@@ -24,9 +36,9 @@ func NewManager() *Manager {
 }
 
 // CreateBashTask creates and registers a new bash task
-func (m *Manager) CreateBashTask(cmd *exec.Cmd, command, description string, ctx context.Context, cancel context.CancelFunc) *BashTask {
+func (m *Manager) CreateBashTask(cmd *exec.Cmd, command, description string, cancel context.CancelFunc) *BashTask {
 	id := generateID()
-	task := NewBashTask(id, command, description, cmd, ctx, cancel)
+	task := NewBashTask(id, command, description, cmd, cancel)
 
 	m.mu.Lock()
 	m.tasks[id] = task
@@ -121,14 +133,9 @@ func (m *Manager) IsRunning(id string) bool {
 	return ok && t.IsRunning()
 }
 
-// Remove drops a task from the manager. Nothing in the running app calls it:
-// tasks are deliberately kept for the life of the process, because TaskOutput
-// resolves a task ID through this map and reporting "task not found" for work
-// the model ran minutes ago would be worse than the memory. What each task
-// retains is bounded instead, by the cap in appendCapped.
-//
-// It exists for tests, which share the process-global manager and need to put
-// it back the way they found it.
+// Remove drops a task from the manager. Production code never calls it — see
+// Manager for why tasks are otherwise kept forever. It exists so that tests
+// sharing the process-global manager can put it back as they found it.
 func (m *Manager) Remove(id string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -156,7 +163,7 @@ func (m *Manager) Kill(id string) error {
 	}
 
 	// Wait for graceful exit with timeout
-	timer := time.NewTimer(2 * time.Second)
+	timer := time.NewTimer(gracefulStopTimeout)
 	defer timer.Stop()
 
 	ticker := time.NewTicker(100 * time.Millisecond)

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -121,6 +121,20 @@ func (m *Manager) IsRunning(id string) bool {
 	return ok && t.IsRunning()
 }
 
+// Remove drops a task from the manager. Nothing in the running app calls it:
+// tasks are deliberately kept for the life of the process, because TaskOutput
+// resolves a task ID through this map and reporting "task not found" for work
+// the model ran minutes ago would be worse than the memory. What each task
+// retains is bounded instead, by the cap in appendCapped.
+//
+// It exists for tests, which share the process-global manager and need to put
+// it back the way they found it.
+func (m *Manager) Remove(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.tasks, id)
+}
+
 // Kill terminates a task by ID
 func (m *Manager) Kill(id string) error {
 	m.mu.RLock()
@@ -157,27 +171,6 @@ func (m *Manager) Kill(id string) error {
 		case <-timer.C:
 			// Graceful stop timed out, force kill
 			return task.Kill()
-		}
-	}
-}
-
-// Remove removes a completed task from the manager
-func (m *Manager) Remove(id string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	delete(m.tasks, id)
-}
-
-// cleanup removes all completed tasks older than maxAge
-func (m *Manager) cleanup(maxAge time.Duration) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	now := time.Now()
-	for id, task := range m.tasks {
-		info := task.GetStatus()
-		if !task.IsRunning() && now.Sub(info.EndTime) > maxAge {
-			delete(m.tasks, id)
 		}
 	}
 }

--- a/internal/task/manager_test.go
+++ b/internal/task/manager_test.go
@@ -15,7 +15,7 @@ func TestManager_CreateAndGet(t *testing.T) {
 	cmd := exec.CommandContext(ctx, "echo", "test")
 	cmd.Start()
 
-	task := m.CreateBashTask(cmd, "echo test", "Test task", ctx, cancel)
+	task := m.CreateBashTask(cmd, "echo test", "Test task", cancel)
 
 	if task.ID == "" {
 		t.Error("task ID should not be empty")
@@ -49,7 +49,7 @@ func TestManager_List(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		cmd := exec.CommandContext(ctx, "echo", "test")
 		cmd.Start()
-		m.CreateBashTask(cmd, "echo test", "Test task", ctx, cancel)
+		m.CreateBashTask(cmd, "echo test", "Test task", cancel)
 	}
 
 	tasks := m.List()
@@ -69,7 +69,7 @@ func TestManager_ListRunning(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		cmd := exec.CommandContext(ctx, "echo", "test")
 		cmd.Start()
-		task := m.CreateBashTask(cmd, "echo test", "Test task", ctx, cancel)
+		task := m.CreateBashTask(cmd, "echo test", "Test task", cancel)
 		tasks = append(tasks, task)
 	}
 
@@ -91,7 +91,7 @@ func TestManager_Remove(t *testing.T) {
 	cmd := exec.CommandContext(ctx, "echo", "test")
 	cmd.Start()
 
-	task := m.CreateBashTask(cmd, "echo test", "Test task", ctx, cancel)
+	task := m.CreateBashTask(cmd, "echo test", "Test task", cancel)
 	taskID := task.ID
 
 	m.Remove(taskID)
@@ -113,7 +113,7 @@ func TestManager_GenerateUniqueIDs(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		cmd := exec.CommandContext(ctx, "echo", "test")
 		cmd.Start()
-		task := m.CreateBashTask(cmd, "echo test", "Test task", ctx, cancel)
+		task := m.CreateBashTask(cmd, "echo test", "Test task", cancel)
 
 		if ids[task.ID] {
 			t.Errorf("duplicate ID generated: %s", task.ID)
@@ -132,7 +132,7 @@ func TestManager_RegisterTask(t *testing.T) {
 	cmd.Start()
 
 	// Create task manually and register
-	task := NewBashTask("manual-id", "echo test", "Manual task", cmd, ctx, cancel)
+	task := NewBashTask("manual-id", "echo test", "Manual task", cmd, cancel)
 	m.RegisterTask(task)
 
 	retrieved, ok := m.Get("manual-id")
@@ -153,7 +153,7 @@ func TestManager_GetBashTask(t *testing.T) {
 	cmd := exec.CommandContext(ctx, "echo", "test")
 	cmd.Start()
 
-	created := m.CreateBashTask(cmd, "echo test", "Test task", ctx, cancel)
+	created := m.CreateBashTask(cmd, "echo test", "Test task", cancel)
 
 	task, ok := m.getBashTask(created.ID)
 	if !ok {

--- a/internal/task/manager_test.go
+++ b/internal/task/manager_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os/exec"
 	"testing"
-	"time"
 )
 
 func TestManager_CreateAndGet(t *testing.T) {
@@ -100,74 +99,6 @@ func TestManager_Remove(t *testing.T) {
 	_, ok := m.Get(taskID)
 	if ok {
 		t.Error("task should be removed")
-	}
-}
-
-func TestManager_Cleanup(t *testing.T) {
-	m := NewManager()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// Create and complete a task
-	cmd := exec.CommandContext(ctx, "echo", "test")
-	cmd.Start()
-
-	task := m.CreateBashTask(cmd, "echo test", "Test task", ctx, cancel)
-	task.Complete(0, nil)
-
-	// Set endTime to past
-	task.mu.Lock()
-	task.endTime = time.Now().Add(-2 * time.Hour)
-	task.mu.Unlock()
-
-	// Cleanup tasks older than 1 hour
-	m.cleanup(time.Hour)
-
-	_, ok := m.Get(task.ID)
-	if ok {
-		t.Error("old completed task should be cleaned up")
-	}
-}
-
-func TestManager_CleanupKeepsRecent(t *testing.T) {
-	m := NewManager()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "echo", "test")
-	cmd.Start()
-
-	task := m.CreateBashTask(cmd, "echo test", "Test task", ctx, cancel)
-	task.Complete(0, nil)
-
-	// Cleanup with 1 hour threshold - task just completed so should be kept
-	m.cleanup(time.Hour)
-
-	_, ok := m.Get(task.ID)
-	if !ok {
-		t.Error("recently completed task should not be cleaned up")
-	}
-}
-
-func TestManager_CleanupKeepsRunning(t *testing.T) {
-	m := NewManager()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "echo", "test")
-	cmd.Start()
-
-	task := m.CreateBashTask(cmd, "echo test", "Test task", ctx, cancel)
-
-	// Don't complete, keep it running
-	m.cleanup(0) // Cleanup all old tasks
-
-	_, ok := m.Get(task.ID)
-	if !ok {
-		t.Error("running task should not be cleaned up")
 	}
 }
 

--- a/internal/task/output_buffer.go
+++ b/internal/task/output_buffer.go
@@ -1,0 +1,36 @@
+package task
+
+import "bytes"
+
+// maxOutputBufferSize caps what a task keeps in memory. The full output is
+// always on disk in OutputFile, so the buffer only has to serve TaskOutput's
+// inline preview — and the manager never forgets a task (see Manager), so
+// without a cap a chatty background command's every byte would be held for the
+// life of the process.
+const maxOutputBufferSize = 512 * 1024
+
+// appendCapped appends data to buf, keeping only the trailing
+// maxOutputBufferSize bytes. Shared by both task types so neither can drift
+// from the cap: BashTask used to skip the one AgentTask applied.
+//
+// The trim happens before the write, not after, so peak memory stays
+// proportional to the cap rather than to the data. That is the difference that
+// matters here: the bash tool hands a whole run's output over in a single
+// call, so writing first would grow the buffer to the full output size just to
+// throw all but the last 512KB away.
+func appendCapped(buf *bytes.Buffer, data []byte) {
+	if len(data) >= maxOutputBufferSize {
+		buf.Reset()
+		buf.Write(data[len(data)-maxOutputBufferSize:])
+		return
+	}
+
+	// Drop the oldest bytes by shifting the survivors to the front. copy is
+	// memmove, so the overlapping source and destination are safe and no
+	// second buffer is needed.
+	if over := buf.Len() + len(data) - maxOutputBufferSize; over > 0 {
+		kept := buf.Bytes()
+		buf.Truncate(copy(kept, kept[over:]))
+	}
+	buf.Write(data)
+}

--- a/internal/task/output_buffer.go
+++ b/internal/task/output_buffer.go
@@ -3,31 +3,28 @@ package task
 import "bytes"
 
 // maxOutputBufferSize caps what a task keeps in memory. The full output is
-// always on disk in OutputFile, so the buffer only has to serve TaskOutput's
-// inline preview — and the manager never forgets a task (see Manager), so
-// without a cap a chatty background command's every byte would be held for the
-// life of the process.
+// always on disk in OutputFile, so this buffer only has to serve TaskOutput's
+// inline preview — and nothing prunes tasks (see Manager), so without a cap it
+// would be held for as long as the process runs.
 const maxOutputBufferSize = 512 * 1024
 
 // appendCapped appends data to buf, keeping only the trailing
 // maxOutputBufferSize bytes. Shared by both task types so neither can drift
 // from the cap: BashTask used to skip the one AgentTask applied.
 //
-// The trim happens before the write, not after, so peak memory stays
-// proportional to the cap rather than to the data. That is the difference that
-// matters here: the bash tool hands a whole run's output over in a single
-// call, so writing first would grow the buffer to the full output size just to
-// throw all but the last 512KB away.
+// Both the clamp and the trim happen before the write, so peak memory stays
+// proportional to the cap rather than to the data. That is what matters here:
+// the bash tool hands a whole run's output over in a single call, so writing
+// first would grow the buffer to the full output size just to throw all but
+// the last 512KB away.
 func appendCapped(buf *bytes.Buffer, data []byte) {
-	if len(data) >= maxOutputBufferSize {
-		buf.Reset()
-		buf.Write(data[len(data)-maxOutputBufferSize:])
-		return
+	if len(data) > maxOutputBufferSize {
+		data = data[len(data)-maxOutputBufferSize:]
 	}
 
-	// Drop the oldest bytes by shifting the survivors to the front. copy is
-	// memmove, so the overlapping source and destination are safe and no
-	// second buffer is needed.
+	// Make room by shifting the survivors to the front. copy is memmove, so
+	// the overlapping source and destination are safe and no second buffer is
+	// needed. Clamping data above keeps over within the buffer's length.
 	if over := buf.Len() + len(data) - maxOutputBufferSize; over > 0 {
 		kept := buf.Bytes()
 		buf.Truncate(copy(kept, kept[over:]))

--- a/internal/task/output_store.go
+++ b/internal/task/output_store.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -12,6 +13,27 @@ var (
 	outputDirMu sync.RWMutex
 	outputDir   string
 )
+
+// maxOutputBufferSize caps what a task keeps in memory. The full output is
+// always on disk in OutputFile, so the buffer only has to serve TaskOutput's
+// inline preview — and a task manager that never forgets a task (see Manager)
+// would otherwise hold every byte a chatty background command ever produced
+// for the life of the process.
+const maxOutputBufferSize = 512 * 1024
+
+// appendCapped appends data to buf, keeping only the trailing
+// maxOutputBufferSize bytes. Shared by both task types so neither can grow
+// without bound: BashTask used to skip the cap that AgentTask applied.
+func appendCapped(buf *bytes.Buffer, data []byte) {
+	buf.Write(data)
+	if buf.Len() <= maxOutputBufferSize {
+		return
+	}
+	b := buf.Bytes()
+	tail := append([]byte(nil), b[len(b)-maxOutputBufferSize:]...)
+	buf.Reset()
+	buf.Write(tail)
+}
 
 // SetOutputDir configures the directory used for stable task output files.
 // It delegates to the internal implementation, keeping backward compatibility

--- a/internal/task/output_store.go
+++ b/internal/task/output_store.go
@@ -1,7 +1,6 @@
 package task
 
 import (
-	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -13,27 +12,6 @@ var (
 	outputDirMu sync.RWMutex
 	outputDir   string
 )
-
-// maxOutputBufferSize caps what a task keeps in memory. The full output is
-// always on disk in OutputFile, so the buffer only has to serve TaskOutput's
-// inline preview — and a task manager that never forgets a task (see Manager)
-// would otherwise hold every byte a chatty background command ever produced
-// for the life of the process.
-const maxOutputBufferSize = 512 * 1024
-
-// appendCapped appends data to buf, keeping only the trailing
-// maxOutputBufferSize bytes. Shared by both task types so neither can grow
-// without bound: BashTask used to skip the cap that AgentTask applied.
-func appendCapped(buf *bytes.Buffer, data []byte) {
-	buf.Write(data)
-	if buf.Len() <= maxOutputBufferSize {
-		return
-	}
-	b := buf.Bytes()
-	tail := append([]byte(nil), b[len(b)-maxOutputBufferSize:]...)
-	buf.Reset()
-	buf.Write(tail)
-}
 
 // SetOutputDir configures the directory used for stable task output files.
 // It delegates to the internal implementation, keeping backward compatibility

--- a/internal/task/types.go
+++ b/internal/task/types.go
@@ -28,6 +28,13 @@ const (
 
 // BackgroundTask is the common interface for all background task types
 // Both BashTask and AgentTask implement this interface
+//
+// An implementation owes one thing the compiler cannot check: a Stop-induced
+// exit must stay distinguishable from a failure, so that a task the user
+// called off is not reported as broken work to retry. How is left open,
+// because the two existing types genuinely differ — a bash child dies of an
+// opaque signal and so must record the intent up front, while an agent
+// goroutine returns context.Canceled, which says it already.
 type BackgroundTask interface {
 	// GetID returns the unique task identifier
 	GetID() string
@@ -48,10 +55,21 @@ type BackgroundTask interface {
 	// Returns true if completed, false if timeout
 	WaitForCompletion(timeout time.Duration) bool
 
-	// Stop gracefully stops the task (SIGTERM for bash, context cancel for agent)
+	// Stop asks the task to exit on its own and returns without waiting for
+	// it to. Escalation is the caller's job, not the implementer's:
+	// Manager.Kill waits gracefulStopTimeout and then calls Kill, so a Stop
+	// must not enforce a deadline of its own.
+	//
+	// An implementation must not race ahead of whatever hard-kill it is wired
+	// to. BashTask.Stop signals rather than cancelling its context precisely
+	// because exec fires cmd.Cancel — a SIGKILL — the moment that context is
+	// done, which would land before the SIGTERM and make the graceful stop a
+	// lie. Cancelling is right for AgentTask only because nothing else is
+	// listening for it.
 	Stop() error
 
-	// Kill forcefully terminates the task (SIGKILL for bash)
+	// Kill forcefully terminates the task (SIGKILL for bash). It is safe to
+	// call after Stop, and after the task has already ended.
 	Kill() error
 
 	// AppendOutput appends data to the output buffer

--- a/internal/task/types.go
+++ b/internal/task/types.go
@@ -60,12 +60,10 @@ type BackgroundTask interface {
 	// Manager.Kill waits gracefulStopTimeout and then calls Kill, so a Stop
 	// must not enforce a deadline of its own.
 	//
-	// An implementation must not race ahead of whatever hard-kill it is wired
-	// to. BashTask.Stop signals rather than cancelling its context precisely
-	// because exec fires cmd.Cancel — a SIGKILL — the moment that context is
-	// done, which would land before the SIGTERM and make the graceful stop a
-	// lie. Cancelling is right for AgentTask only because nothing else is
-	// listening for it.
+	// An implementation must not let its own hard-kill path pre-empt the
+	// graceful attempt it is making here — a Stop that trips the very
+	// mechanism that kills the task outright has not stopped it gracefully at
+	// all, it has just taken a longer route to Kill.
 	Stop() error
 
 	// Kill forcefully terminates the task (SIGKILL for bash). It is safe to

--- a/internal/tool/fs/bash.go
+++ b/internal/tool/fs/bash.go
@@ -319,7 +319,7 @@ func (t *BashTool) executeBackground(ctx context.Context, command, description, 
 	}
 
 	// Register with task manager
-	bgTask := task.Default().CreateBashTask(cmd, command, description, taskCtx, cancel)
+	bgTask := task.Default().CreateBashTask(cmd, command, description, cancel)
 
 	// Start goroutine to collect output and wait for completion
 	go func() {


### PR DESCRIPTION
Follow-up to #348, which deferred both of these.

## 1. The graceful stop was never graceful

```go
t.cancel()                                          // exec fires cmd.Cancel here
return proc.TerminateGroup(t.cmd, syscall.SIGTERM)  // reaches a dead group
```

`bash.go` overrides `cmd.Cancel` to SIGKILL the process group, and `exec` runs it the moment the context is done — so the kill always landed before the SIGTERM. The cleanup window `Stop`'s own doc comment promises never existed.

`Stop` now only signals. Escalation was already the caller's job: `Manager.Kill` polls and falls back to `Kill` after 2s, with the run's timeout as a backstop.

**Knock-on:** #348 taught `Complete` to read the context to tell a deliberate stop from a failure, and a graceful stop now leaves the context live. `Stop` records that it asked instead — more direct than inferring intent from a cancellation, and a run killed by its own timeout still stays a failure.

## 2. Unbounded output, and a reaper that never ran

`BashTask.AppendOutput` had no size limit where `AgentTask` capped at 512KB, and `Manager.cleanup` had no caller outside its own tests. Together: a chatty background command's whole output was retained for the life of the process. The cap is now one shared helper both types call.

**`cleanup` is deleted rather than wired up.** Reaping would break `TaskOutput`, which resolves task IDs through the manager with no fallback to the on-disk output file — the model would get `task not found` for work it ran minutes ago. Bounding what each task holds is the better trade, and dead code that looks like memory management reads as a reaper that runs.

`Manager.Remove` stays — tests share the process-global manager and use it to reset. (I had it deleted as dead too; the compiler caught the callers.)

## Tests

Both new tests confirmed failing on `upstream/main` first:

- `TestBashTaskStopLeavesContextLive` — `Stop cancelled the task context (context canceled)`
- `TestBashTaskOutputIsCapped` — `output buffer = 1048580 bytes, want <= 524288`

`TestBashTaskStopIsNotAFailure` now drives the real `Stop()` path and passes **both before and after** — that is the point: the mechanism swap preserves #348's behavior.

`go build`, `go vet`, `go test ./...` all pass.

## Cleanup pass

A review pass over the diff pulled a few things deeper:

- **`appendCapped` trims before writing**, so peak memory tracks the cap rather than the total output — it was growing the buffer to a 20MB command's full size to keep 512KB of it. Survivors shift in place via `copy`'s memmove semantics instead of being cloned into a second buffer. It lives in its own file now; `output_store.go` is about the on-disk record.
- **`stopRequested` is an `atomic.Bool`** — it shares no invariant with the `mu`-guarded fields, and this drops the lock round-trip `Complete` took to read one bool.
- **`BashTask.ctx` is deleted**, along with the parameter, through `NewBashTask` and `Manager.CreateBashTask`. Its last reader was the context check this branch replaced, and an unused field that used to hold the mechanism we just removed invites reintroducing it.
- **`BackgroundTask`'s doc described the model this branch disproves** (`context cancel for agent`), with nothing to warn a third implementer whose hard-kill is likewise wired to context-done. `Stop`'s contract now states what it guarantees — does not block, must not race its own hard-kill, escalation belongs to `Manager.Kill` — with the grace period named `gracefulStopTimeout` so the contract can point at it. The interface also names the obligation the compiler cannot check: a stopped task must stay distinguishable from a failed one.
- The retention policy moves from `Remove`'s doc to `Manager`'s, and the `128+signal` convention becomes `signalExitCode`.

A second pass folded in: `appendCapped` collapses to one path (clamping `data` to the cap first makes the shift-in-place trim subsume the whole-buffer replace); the interface contract stops describing `BashTask`'s `exec` plumbing, which a third implementer backed by an HTTP request or a container would have to read past — the general rule stays on the interface, the specifics stay in `BashTask.Stop`; and `bash_task_test.go` grows a `newRunningBashTask` helper mirroring `newRunningAgentTask`, collapsing 17 of 18 fixtures to one line each.

## Not done here

`bash.go` builds the combined output as a `string` (`stdoutBuf.String()`, then `+=`, then `[]byte(output)`), so roughly three full-size copies are live at once when it hands the run over. Switching to `[]byte` and `append` would drop two of them in three lines — worth doing, but it belongs with the streaming change below rather than here.

`bash.go` accumulates the full output in `stdoutBuf`/`stderrBuf` for the whole run and hands it over in one `AppendOutput` at the end, so a long-running noisy command still grows unbounded *while it runs* and `TaskOutput` shows nothing until it finishes. Fixing that means streaming output into the task as it arrives — the bash tool's plumbing, not the task types. Its own PR.
