### PR TITLE
fix(core): report the model's own output at every turn exit

### DIFF
--- a/internal/core/agent_content_test.go
+++ b/internal/core/agent_content_test.go
@@ -1,0 +1,164 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// The turn loop reports Content from a single tracked value rather than from
+// each return site. These tests pin the two exits that used to supply it by
+// hand and got it wrong: the step cap substituted a status string, and every
+// cancellation path substituted "". Both discarded work the model had already
+// done and the caller had already paid for.
+
+// noopTool lets a scripted response carry a tool call, which is what keeps the
+// turn loop iterating instead of ending on the first step.
+type noopTool struct{}
+
+func (noopTool) Name() string        { return "noop" }
+func (noopTool) Description() string { return "does nothing" }
+func (noopTool) Schema() ToolSchema  { return ToolSchema{Name: "noop"} }
+func (noopTool) Execute(context.Context, map[string]any) (string, error) {
+	return "done", nil
+}
+
+// talkingLLM answers every inference with text plus a tool call, so the turn
+// never reaches end_turn on its own and the loop exits through a guard.
+type talkingLLM struct {
+	text string
+	// quietAfterFirst silences every step past the first, producing a turn that
+	// ends on a tool-only step carrying no assistant text.
+	quietAfterFirst bool
+	calls           int
+	onInfer         func(call int)
+}
+
+func (t *talkingLLM) InputLimit() int { return 0 }
+
+func (t *talkingLLM) Infer(_ context.Context, _ InferRequest) (<-chan Chunk, error) {
+	t.calls++
+	if t.onInfer != nil {
+		t.onInfer(t.calls)
+	}
+	text := t.text
+	if t.quietAfterFirst && t.calls > 1 {
+		text = ""
+	}
+	ch := make(chan Chunk, 1)
+	go func() {
+		defer close(ch)
+		ch <- Chunk{Done: true, Response: &InferResponse{
+			Content:    text,
+			StopReason: StopToolUse,
+			ToolCalls:  []ToolCall{{ID: "call-1", Name: "noop", Input: "{}"}},
+		}}
+	}()
+	return ch, nil
+}
+
+// newContentAgent mirrors newRetryAgent in retry_test.go: build, seed a user
+// message, and drain the outbox, which emit() blocks on once the buffer fills.
+func newContentAgent(llm LLM, maxSteps int) *agent {
+	ag := NewAgent(Config{
+		ID:       "test",
+		LLM:      llm,
+		System:   NewSystem(),
+		Tools:    NewTools(noopTool{}),
+		MaxSteps: maxSteps,
+	}).(*agent)
+	ag.append(Message{Role: RoleUser, Content: "go"})
+	go func() {
+		for range ag.Outbox() {
+		}
+	}()
+	return ag
+}
+
+func TestThinkActReportsModelOutputWhenStepCapHits(t *testing.T) {
+	llm := &talkingLLM{text: "partial analysis of the repo"}
+	ag := newContentAgent(llm, 2)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	result, err := ag.ThinkAct(ctx)
+	if err != nil {
+		t.Fatalf("ThinkAct returned error: %v", err)
+	}
+	if result.StopReason != StopMaxSteps {
+		t.Fatalf("StopReason = %q, want %q", result.StopReason, StopMaxSteps)
+	}
+	// The cap is already reported through StopReason; Content must not be
+	// overwritten with a status string, or a subagent that hits its cap hands
+	// its parent that string in place of the work.
+	if result.Content != llm.text {
+		t.Errorf("Content = %q, want the model's last output %q", result.Content, llm.text)
+	}
+	if result.Steps != 2 {
+		t.Errorf("Steps = %d, want 2", result.Steps)
+	}
+}
+
+func TestThinkActPreservesPartialOutputOnCancel(t *testing.T) {
+	// Bounded as well as cancellable: talkingLLM always answers with a tool
+	// call, so if the cancel hook below ever stopped firing the loop would spin
+	// until go test's global timeout instead of failing here.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	llm := &talkingLLM{text: "found the bug in fs_store"}
+	// Cancel on the second inference, so step one has fully completed and its
+	// assistant message is already appended. Cancelling during the first
+	// inference would be a different case: no assistant message exists yet, and
+	// an empty Content is then the honest answer rather than a lost one.
+	llm.onInfer = func(call int) {
+		if call == 2 {
+			cancel()
+		}
+	}
+
+	ag := newContentAgent(llm, 0)
+
+	result, err := ag.ThinkAct(ctx)
+	if err == nil {
+		t.Fatal("ThinkAct returned nil error on a cancelled turn")
+	}
+	if result == nil {
+		t.Fatal("ThinkAct returned nil Result on cancel; observers need the turn boundary")
+	}
+	if result.StopReason != StopCancelled {
+		t.Fatalf("StopReason = %q, want %q", result.StopReason, StopCancelled)
+	}
+	// subagent.buildCancelledAgentResult documents that a cancelled run's
+	// partial content travels back with the error, and RunBackground gates that
+	// on Content != "". An empty string here makes that feature dead code.
+	if result.Content != llm.text {
+		t.Errorf("Content = %q, want the partial output %q", result.Content, llm.text)
+	}
+}
+
+// TestThinkActReportsEmptyContentWhenTurnEndsOnToolOnlyStep pins the deliberate
+// half of the tracking rule. lastContent follows the newest assistant message
+// unconditionally, so a turn whose last step is pure tool calls reports "" —
+// it does not fall back to narration from an earlier step. That fallback would
+// present stale text as this turn's outcome, so the emptiness is the intended
+// answer rather than a gap to close.
+func TestThinkActReportsEmptyContentWhenTurnEndsOnToolOnlyStep(t *testing.T) {
+	llm := &talkingLLM{text: "starting the sweep", quietAfterFirst: true}
+	ag := newContentAgent(llm, 2)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	result, err := ag.ThinkAct(ctx)
+	if err != nil {
+		t.Fatalf("ThinkAct returned error: %v", err)
+	}
+	if result.StopReason != StopMaxSteps {
+		t.Fatalf("StopReason = %q, want %q", result.StopReason, StopMaxSteps)
+	}
+	if result.Content != "" {
+		t.Errorf("Content = %q, want \"\" — the last step carried no assistant text", result.Content)
+	}
+}

--- a/internal/core/agent_impl.go
+++ b/internal/core/agent_impl.go
@@ -314,23 +314,29 @@ func (a *agent) ThinkAct(ctx context.Context) (*Result, error) {
 	var steps, toolUses, tokensIn, tokensOut int
 	var maxOutputRecoveryCount int
 	var turnRetries int
+	// lastContent tracks the newest assistant text this turn, so every exit —
+	// including cancel and the step cap — reports what the model actually said
+	// rather than an empty string or a status placeholder.
+	var lastContent string
 
-	makeResult := func(content string, stop StopReason, detail string) *Result {
+	makeResult := func(stop StopReason) *Result {
 		return &Result{
-			Content: content, Messages: a.snapshot(),
+			Content: lastContent, Messages: a.snapshot(),
 			Steps: steps, ToolUses: toolUses, InputTokens: tokensIn, OutputTokens: tokensOut,
-			StopReason: stop, StopDetail: detail,
+			StopReason: stop,
 		}
 	}
 
 	for {
 		if ctx.Err() != nil {
-			return makeResult("", StopCancelled, ""), ctx.Err()
+			return makeResult(StopCancelled), ctx.Err()
 		}
 
-		// Max steps guard
+		// Max steps guard. The cap itself is reported through StopReason —
+		// interpretStopReason turns it into "reached maximum steps (N)" — so
+		// Content stays the model's own last output rather than a status string.
 		if a.maxSteps > 0 && steps >= a.maxSteps {
-			return makeResult("max steps reached", StopMaxSteps, ""), nil
+			return makeResult(StopMaxSteps), nil
 		}
 
 		// Between steps: drain any new inbox messages (non-blocking)
@@ -365,7 +371,7 @@ func (a *agent) ThinkAct(ctx context.Context) (*Result, error) {
 			// turn boundary with StopCancelled. The error is still
 			// propagated so Run's loop can branch on it.
 			if errors.Is(err, context.Canceled) {
-				return makeResult("", StopCancelled, ""), err
+				return makeResult(StopCancelled), err
 			}
 			// Transient stream failure (network blip, 5xx/529 overload,
 			// 429, idle stall, truncation): discard the partial assistant
@@ -377,7 +383,7 @@ func (a *agent) ThinkAct(ctx context.Context) (*Result, error) {
 					turnRetries++
 					a.emit(ctx, StreamResetEvent(a.id))
 					if werr := BackoffSleep(ctx, turnRetries, re.RetryAfter()); werr != nil {
-						return makeResult("", StopCancelled, ""), werr
+						return makeResult(StopCancelled), werr
 					}
 					continue
 				}
@@ -406,6 +412,9 @@ func (a *agent) ThinkAct(ctx context.Context) (*Result, error) {
 			Reasoning:         resp.Reasoning,
 			ToolCalls:         resp.ToolCalls,
 		})
+		// Unconditional: a tool-only step carries no text, and reporting that
+		// honestly beats resurrecting an earlier step's narration as the outcome.
+		lastContent = resp.Content
 
 		// Max tokens recovery — output truncated, ask LLM to continue
 		if resp.StopReason == StopMaxTokens && len(resp.ToolCalls) == 0 {
@@ -414,7 +423,7 @@ func (a *agent) ThinkAct(ctx context.Context) (*Result, error) {
 				maxRecovery = 3
 			}
 			if maxOutputRecoveryCount >= maxRecovery {
-				return makeResult(resp.Content, StopMaxOutputRecoveryExhausted, ""), nil
+				return makeResult(StopMaxOutputRecoveryExhausted), nil
 			}
 			maxOutputRecoveryCount++
 			a.append(Message{Role: RoleUser, Content: TruncatedResumePrompt})
@@ -423,7 +432,7 @@ func (a *agent) ThinkAct(ctx context.Context) (*Result, error) {
 
 		// No tool calls → end turn
 		if len(resp.ToolCalls) == 0 {
-			return makeResult(resp.Content, StopEndTurn, ""), nil
+			return makeResult(StopEndTurn), nil
 		}
 
 		// Execute tool calls


### PR DESCRIPTION
`ThinkAct` built `Result.Content` from a per-return-site argument while `Steps` and the token counts came from closure capture; four of the six exits supplied it wrong, discarding the model's real output.

- A subagent hitting its step cap returned the literal `"max steps reached"` to its parent in place of the work. The cap already travels via `StopReason` (`interpretStopReason` renders it as `reached maximum steps (N)`), so the placeholder only displaced output.
- `buildCancelledAgentResult` documents that a cancelled run's partial content returns with the error, but `RunBackground` gates that on `Content != ""` — which no cancellation path could satisfy, leaving the feature dead since it was written.

The fix tracks the newest assistant text in a turn-scoped variable and drops the `content` parameter, so a return site can no longer supply it at all. The two already-correct exits are unchanged.

Content is tracked rather than derived from `Result.Messages`: `applyCompaction` replaces the whole chain with a single user-role summary and can fire mid-turn, and the chain also spans turns, so a backward scan for the last assistant message would return the wrong text or none.

Follow-up in #352: `ThinkAct` still has two `return nil, err` exits that return no `Result` at all.