### PR TITLE
fix(core): return a Result when a turn dies on inference failure

### DIFF
--- a/internal/core/agent_content_test.go
+++ b/internal/core/agent_content_test.go
@@ -130,7 +130,7 @@ func TestThinkActPreservesPartialOutputOnCancel(t *testing.T) {
 	if result.StopReason != StopCancelled {
 		t.Fatalf("StopReason = %q, want %q", result.StopReason, StopCancelled)
 	}
-	// subagent.buildCancelledAgentResult documents that a cancelled run's
+	// subagent.buildUnfinishedAgentResult documents that a cancelled run's
 	// partial content travels back with the error, and RunBackground gates that
 	// on Content != "". An empty string here makes that feature dead code.
 	if result.Content != llm.text {

--- a/internal/core/agent_impl.go
+++ b/internal/core/agent_impl.go
@@ -144,7 +144,10 @@ func (a *agent) Run(ctx context.Context) error {
 				break
 			}
 
-			if result != nil {
+			// A failed turn (StopError) is an agent stop, not a turn boundary:
+			// emitting TurnEvent would fire OnTurnEnd on top of OnAgentStop.
+			// Cancellation still emits (OnTurnEnd guards StopCancelled).
+			if result != nil && result.StopReason != StopError {
 				glog.QueueLog("agent.Run: ThinkAct done, emitting TurnEvent")
 				a.emit(ctx, TurnEvent(a.id, *result))
 			}

--- a/internal/core/agent_impl.go
+++ b/internal/core/agent_impl.go
@@ -310,6 +310,12 @@ func (a *agent) ingest(ctx context.Context, msg Message) bool {
 
 // ThinkAct runs one full inference-action cycle until end_turn.
 // Returns the result directly — the caller decides whether to emit TurnEvent.
+//
+// A Result accompanies every outcome, including the errors: a turn that ends
+// on cancellation or an inference failure still carries the messages, steps
+// and token usage it accumulated, which is what lets the caller persist the
+// run. The sole exception is a deliberate shutdown (errStopped), where no turn
+// outcome exists to report.
 func (a *agent) ThinkAct(ctx context.Context) (*Result, error) {
 	var steps, toolUses, tokensIn, tokensOut int
 	var maxOutputRecoveryCount int
@@ -339,7 +345,10 @@ func (a *agent) ThinkAct(ctx context.Context) (*Result, error) {
 			return makeResult(StopMaxSteps), nil
 		}
 
-		// Between steps: drain any new inbox messages (non-blocking)
+		// Between steps: drain any new inbox messages (non-blocking).
+		// errStopped is drainInbox's only error, and it means a deliberate
+		// shutdown (closed inbox or SigStop) rather than a failed turn — the
+		// one exit with no outcome to report, hence no Result.
 		if steps > 0 {
 			if _, err := a.drainInbox(ctx); err != nil {
 				return nil, err
@@ -388,7 +397,13 @@ func (a *agent) ThinkAct(ctx context.Context) (*Result, error) {
 					continue
 				}
 			}
-			return nil, err
+			// Retry budget exhausted, or the failure was not retryable. Report
+			// the turn rather than dropping it: the steps already taken are
+			// billed, and a caller with no Result cannot persist what the run
+			// produced — a subagent loses its entire transcript that way.
+			failed := makeResult(StopError)
+			failed.StopDetail = err.Error()
+			return failed, err
 		}
 		turnRetries = 0 // reset budget once a step completes
 

--- a/internal/core/llm.go
+++ b/internal/core/llm.go
@@ -17,6 +17,11 @@ const (
 	StopCancelled                  StopReason = "cancelled"
 	StopHook                       StopReason = "stop_hook"
 	StopMaxOutputRecoveryExhausted StopReason = "max_output_recovery_exhausted"
+	// StopError marks a turn that died on an inference failure — the retry
+	// budget ran out, or the error was not retryable. The turn still produced
+	// messages and token usage, so it reports an outcome like any other stop
+	// reason rather than vanishing. StopDetail carries the underlying error.
+	StopError StopReason = "error"
 )
 
 // InferRequest is sent to the LLM for inference.

--- a/internal/core/retry_test.go
+++ b/internal/core/retry_test.go
@@ -175,3 +175,34 @@ func TestStreamInferIdleTimeoutRetries(t *testing.T) {
 		t.Fatalf("Infer calls = %d, want 2 (idle-timeout retry)", llm.calls)
 	}
 }
+
+// TestThinkActReturnsResultWhenRetriesAreExhausted pins the Result contract on
+// the failure path. A turn that dies on a provider outage has still appended
+// messages and burned tokens, and the caller persists a run from its Result —
+// so returning only an error silently discards the work. subagent's
+// finalizeResult is the concrete casualty: no Result means the transcript is
+// never written to disk.
+func TestThinkActReturnsResultWhenRetriesAreExhausted(t *testing.T) {
+	llm := &scriptedLLM{failErr: errStreamStalled, failures: 99}
+	a := newRetryAgent(t, llm, 2, 0)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := a.ThinkAct(ctx)
+	if err == nil {
+		t.Fatal("ThinkAct should surface the error after exhausting retries")
+	}
+	if result == nil {
+		t.Fatal("ThinkAct returned nil Result on a failed turn; the caller cannot persist the run")
+	}
+	if result.StopReason != StopError {
+		t.Errorf("StopReason = %q, want %q", result.StopReason, StopError)
+	}
+	if result.StopDetail == "" {
+		t.Error("StopDetail is empty; it should carry the underlying failure")
+	}
+	if len(result.Messages) == 0 {
+		t.Error("Messages is empty; the conversation is what the caller persists")
+	}
+}

--- a/internal/subagent/executor.go
+++ b/internal/subagent/executor.go
@@ -140,9 +140,8 @@ func (e *Executor) Run(ctx context.Context, req tool.AgentExecRequest) (*AgentRe
 		result, err = e.executePreparedRun(ctx, run)
 	}
 	if err != nil {
-		cancelled := e.buildCancelledAgentResult(run, result)
-		if cancelled != nil {
-			return cancelled, err
+		if unfinished := e.buildUnfinishedAgentResult(run, result); unfinished != nil {
+			return unfinished, err
 		}
 		e.fireSubagentStop(run.req, run.hookID, "", "")
 		return nil, fmt.Errorf("LLM completion failed: %w", err)
@@ -435,7 +434,9 @@ func interpretStopReason(result *core.Result, maxSteps int) (success bool, errMs
 		errMsg = fmt.Sprintf("reached maximum steps (%d)", maxSteps)
 	case core.StopMaxOutputRecoveryExhausted:
 		errMsg = "output was repeatedly truncated and recovery was exhausted"
-	case core.StopHook:
+	case core.StopCancelled:
+		errMsg = "agent cancelled"
+	case core.StopHook, core.StopError:
 		errMsg = result.StopDetail
 	}
 	return success, errMsg

--- a/internal/subagent/executor_run.go
+++ b/internal/subagent/executor_run.go
@@ -178,14 +178,21 @@ func (e *Executor) buildAgentResult(run *preparedRun, result *core.Result) *Agen
 	return e.finalizeResult(run, result, success, errMsg)
 }
 
-// buildCancelledAgentResult preserves a cancelled run's partial work: the
-// conversation is persisted, the stop hook fires, and the partial content
-// travels back to the caller alongside the error.
-func (e *Executor) buildCancelledAgentResult(run *preparedRun, result *core.Result) *AgentResult {
-	if result == nil || result.StopReason != core.StopCancelled {
+// buildUnfinishedAgentResult preserves the partial work of a run that ended
+// without completing: the conversation is persisted, the stop hook fires, and
+// the partial content travels back to the caller alongside the error. Covers
+// both ways a turn can end early — the user cancelled it, or inference failed
+// past the retry budget — since either way the steps already taken are worth
+// keeping. A nil Result means there is nothing to preserve.
+func (e *Executor) buildUnfinishedAgentResult(run *preparedRun, result *core.Result) *AgentResult {
+	if result == nil {
 		return nil
 	}
-	return e.finalizeResult(run, result, false, "agent cancelled")
+	if result.StopReason != core.StopCancelled && result.StopReason != core.StopError {
+		return nil
+	}
+	_, errMsg := interpretStopReason(result, run.cfg.maxSteps)
+	return e.finalizeResult(run, result, false, errMsg)
 }
 
 // finalizeResult persists the session, fires the stop hook, and projects the

--- a/internal/subagent/executor_test.go
+++ b/internal/subagent/executor_test.go
@@ -210,7 +210,7 @@ func TestShouldRetryWithParentModelOnlyForMissingDifferentModel(t *testing.T) {
 	}
 }
 
-func TestBuildCancelledAgentResultUsesPreparedRunMetadata(t *testing.T) {
+func TestBuildUnfinishedAgentResultUsesPreparedRunMetadata(t *testing.T) {
 	executor := &Executor{}
 	run := &preparedRun{
 		req: tool.AgentExecRequest{Agent: "general-purpose"},
@@ -222,7 +222,7 @@ func TestBuildCancelledAgentResultUsesPreparedRunMetadata(t *testing.T) {
 		activity:  []string{"Read(main.go)"},
 	}
 
-	result := executor.buildCancelledAgentResult(run, &core.Result{
+	result := executor.buildUnfinishedAgentResult(run, &core.Result{
 		Content:    "partial",
 		Messages:   []core.Message{{Role: core.RoleAssistant, Content: "partial"}},
 		Steps:      2,
@@ -591,3 +591,58 @@ func (s *stubSystem) Drop(_, _ string)                      {}
 func (s *stubSystem) Refresh(_, _ string)                   {}
 func (s *stubSystem) Sections() []core.Section              { return nil }
 func (s *stubSystem) SetObserver(_ func(core.SystemChange)) {}
+
+// TestBuildUnfinishedAgentResultPreservesFailedRun covers the other way a run
+// ends early. A cancelled run was already preserved; a run that died on an
+// inference failure was not, because ThinkAct returned no Result at all — so
+// Run fell through to the bare-error path and persistSubagentSession never
+// ran, losing the transcript of everything the agent had done.
+func TestBuildUnfinishedAgentResultPreservesFailedRun(t *testing.T) {
+	executor := &Executor{}
+	run := &preparedRun{
+		req:       tool.AgentExecRequest{Agent: "general-purpose"},
+		cfg:       &runConfig{displayName: "Scout", modelID: "test-model"},
+		startedAt: time.Now().Add(-time.Second),
+	}
+
+	result := executor.buildUnfinishedAgentResult(run, &core.Result{
+		Content:    "partial",
+		Messages:   []core.Message{{Role: core.RoleAssistant, Content: "partial"}},
+		Steps:      8,
+		StopReason: core.StopError,
+		StopDetail: "provider unavailable",
+	})
+	if result == nil {
+		t.Fatal("a failed run must still be preserved, or its transcript is never persisted")
+	}
+	if result.Success {
+		t.Error("Success = true, want false")
+	}
+	if result.Error != "provider unavailable" {
+		t.Errorf("Error = %q, want the underlying failure", result.Error)
+	}
+	if result.Content != "partial" {
+		t.Errorf("Content = %q, want the partial output", result.Content)
+	}
+	if result.StepCount != 8 {
+		t.Errorf("StepCount = %d, want 8", result.StepCount)
+	}
+}
+
+// A normally-completed run is not "unfinished" — it goes through
+// buildAgentResult instead, so this guard must keep rejecting it.
+func TestBuildUnfinishedAgentResultRejectsCompletedRun(t *testing.T) {
+	executor := &Executor{}
+	run := &preparedRun{
+		req:       tool.AgentExecRequest{Agent: "general-purpose"},
+		cfg:       &runConfig{displayName: "Scout", modelID: "test-model"},
+		startedAt: time.Now(),
+	}
+
+	if got := executor.buildUnfinishedAgentResult(run, &core.Result{StopReason: core.StopEndTurn}); got != nil {
+		t.Fatalf("completed run treated as unfinished: %#v", got)
+	}
+	if got := executor.buildUnfinishedAgentResult(run, nil); got != nil {
+		t.Fatalf("nil Result treated as unfinished: %#v", got)
+	}
+}


### PR DESCRIPTION
On a non-retryable inference error or an exhausted retry budget, `ThinkAct` returned `nil, err`.

For a **subagent** this drops the whole transcript: `executor_run.go` reads the Result directly, so with `result == nil` it never reaches `persistSubagentSession`, and a subagent has no other persistence path. The **main agent is unaffected** — its messages stream into the committed conversation independently of the Result.

## Fix
Return a Result carrying a new `StopError` stop reason so `buildUnfinishedAgentResult` persists the partial run; the underlying error still propagates.

## Caveat for review (not yet applied)
Returning non-nil on error also makes the main-agent `Run` loop emit `TurnEvent` on the failure path, firing `OnTurnEnd` (idle hooks, tracker reset, queue drain) on top of `OnAgentStop`. The emit should be gated to skip `StopError` — `if result != nil && result.StopReason != StopError`. Cancellation must still emit. I have not landed this yet.

Tests cover the subagent persist path and the widened `buildUnfinishedAgentResult` guard.