### PR TITLE
fix(setting): stop the permission check racing the mode switch

### DIFF
--- a/internal/app/env.go
+++ b/internal/app/env.go
@@ -171,11 +171,7 @@ func (m *env) OperationModeName() string {
 }
 
 func (m *env) ResetSessionPermissions() {
-	m.SessionPermissions.AllowAllEdits = false
-	m.SessionPermissions.AllowAllWrites = false
-	m.SessionPermissions.AllowAllBash = false
-	m.SessionPermissions.AllowAllSkills = false
-	m.SessionPermissions.Mode = setting.ModeNormal
+	m.SessionPermissions.ResetPosture()
 }
 
 // applyEditPosture grants the accept-edits posture — edits/writes auto-approved,
@@ -183,9 +179,7 @@ func (m *env) ResetSessionPermissions() {
 // routes non-edit prompts to the review agent). ApplyModePermissions owns
 // SessionPermissions.Mode; this only layers on the extra allowances.
 func (m *env) applyEditPosture(cwd string) {
-	m.SessionPermissions.AllowAllEdits = true
-	m.SessionPermissions.AllowAllWrites = true
-	m.SessionPermissions.AddWorkingDirectory(cwd)
+	m.SessionPermissions.GrantEditPosture(cwd)
 }
 
 func (m *env) DetectThinkingKeywords(input string) {
@@ -219,7 +213,7 @@ func (m *env) ApplyModePermissions(cwd string) {
 	// SessionPermissions.Mode always mirrors OperationMode; the switch below only
 	// layers on the extra allowances for the edit modes. Bypass needs no extra
 	// allowances — mirroring the mode is enough.
-	m.SessionPermissions.Mode = m.OperationMode
+	m.SessionPermissions.SetMode(m.OperationMode)
 
 	switch m.OperationMode {
 	case setting.ModeAutoAccept, setting.ModeAutoPilot:

--- a/internal/setting/permission.go
+++ b/internal/setting/permission.go
@@ -45,6 +45,13 @@ func decide(b perm.Decision, reason string) PermissionDecision {
 // HasPermissionToUseTool is the central permission gate that determines
 // whether a tool invocation should be allowed, denied, or prompted.
 func (s *Data) HasPermissionToUseTool(toolName string, args map[string]any, session *SessionPermissions) PermissionDecision {
+	// One coherent view for the whole decision. The agent goroutine runs this
+	// while the UI goroutine may be rewriting the posture (mode cycling), and
+	// the steps below read the mode, the allowances and the working
+	// directories separately — reading them live would let a single decision
+	// straddle two postures.
+	session = session.Snapshot()
+
 	rule := BuildRule(toolName, args)
 
 	// ── Step 1: Deny rules ──

--- a/internal/setting/session_permissions_race_test.go
+++ b/internal/setting/session_permissions_race_test.go
@@ -1,0 +1,78 @@
+package setting
+
+import (
+	"sync"
+	"testing"
+)
+
+// SessionPermissions is shared by two goroutines: the UI one rewrites the
+// posture when the user cycles the operation mode (Shift+Tab), and the agent
+// one reads it on every tool call. Before the mutex and Snapshot, the writes
+// in env.ApplyModePermissions raced the reads in HasPermissionToUseTool — the
+// race detector flagged both the WorkingDirectories append and the Mode write.
+// Run with -race; without the fix this test reports DATA RACE.
+func TestSessionPermissionsSurviveConcurrentPostureChange(t *testing.T) {
+	data := &Data{}
+	perms := NewSessionPermissions()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// UI goroutine: cycle Normal → AutoAccept repeatedly.
+	go func() {
+		defer wg.Done()
+		for range 2000 {
+			perms.ResetPosture()
+			perms.SetMode(ModeAutoAccept)
+			perms.GrantEditPosture("/repo")
+		}
+	}()
+
+	// Agent goroutine: one permission check per tool call.
+	go func() {
+		defer wg.Done()
+		for range 2000 {
+			data.HasPermissionToUseTool("Edit", map[string]any{"file_path": "/repo/a.go"}, perms)
+		}
+	}()
+
+	wg.Wait()
+}
+
+// A decision must not straddle a posture change: Snapshot is taken once, so
+// every step of the evaluation sees the same mode and allowances.
+func TestSnapshotDetachesFromLaterMutation(t *testing.T) {
+	perms := NewSessionPermissions()
+	perms.SetMode(ModeAutoAccept)
+	perms.GrantEditPosture("/repo")
+	perms.AllowPattern("Bash(ls)")
+
+	snap := perms.Snapshot()
+
+	perms.ResetPosture()
+	perms.AddWorkingDirectory("/elsewhere")
+	perms.AllowPattern("Bash(rm)")
+
+	if snap.Mode != ModeAutoAccept {
+		t.Errorf("Mode = %q, want the mode at snapshot time %q", snap.Mode, ModeAutoAccept)
+	}
+	if !snap.AllowAllEdits {
+		t.Error("AllowAllEdits = false, want the posture at snapshot time")
+	}
+	if len(snap.WorkingDirectories) != 1 || snap.WorkingDirectories[0] != "/repo" {
+		t.Errorf("WorkingDirectories = %v, want only /repo", snap.WorkingDirectories)
+	}
+	if snap.AllowedPatterns["Bash(rm)"] {
+		t.Error("snapshot picked up a pattern granted after it was taken")
+	}
+	if !snap.AllowedPatterns["Bash(ls)"] {
+		t.Error("snapshot lost a pattern granted before it was taken")
+	}
+}
+
+func TestSnapshotOfNilSessionIsNil(t *testing.T) {
+	var perms *SessionPermissions
+	if perms.Snapshot() != nil {
+		t.Error("Snapshot of a nil session should stay nil; callers pass an optional session")
+	}
+}

--- a/internal/setting/settings.go
+++ b/internal/setting/settings.go
@@ -16,7 +16,9 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
+	"sync"
 
 	"github.com/genai-io/san/internal/confdir"
 )
@@ -399,7 +401,15 @@ type HookCmd struct {
 }
 
 // SessionPermissions tracks runtime permission state for the current session.
+//
+// It is shared across goroutines: the UI goroutine rewrites the posture when
+// the user cycles the operation mode, while the agent goroutine reads it on
+// every tool call. Mutations go through the methods below, which hold mu;
+// readers take a Snapshot rather than reading fields directly, so one decision
+// never straddles a posture change.
 type SessionPermissions struct {
+	mu sync.RWMutex
+
 	Mode            OperationMode // Active permission mode (Normal, BypassPermissions, DontAsk, etc.)
 	AllowAllEdits   bool
 	AllowAllWrites  bool
@@ -427,7 +437,68 @@ func NewSessionPermissions() *SessionPermissions {
 	}
 }
 
+// Snapshot returns a detached copy safe to read without holding the lock.
+// A permission decision reads the mode, the blanket allowances, the granted
+// patterns and the working directories in sequence; taking them from one
+// snapshot keeps the decision coherent even if the user cycles the operation
+// mode mid-turn. Returns nil for a nil receiver, since callers pass an
+// optional session through.
+func (sp *SessionPermissions) Snapshot() *SessionPermissions {
+	if sp == nil {
+		return nil
+	}
+	sp.mu.RLock()
+	defer sp.mu.RUnlock()
+	// Field-by-field rather than *sp: the copy gets its own zero mutex, and a
+	// snapshot is read-only anyway.
+	return &SessionPermissions{
+		Mode:               sp.Mode,
+		AllowAllEdits:      sp.AllowAllEdits,
+		AllowAllWrites:     sp.AllowAllWrites,
+		AllowAllBash:       sp.AllowAllBash,
+		AllowAllSkills:     sp.AllowAllSkills,
+		AllowAllTasks:      sp.AllowAllTasks,
+		AllowedTools:       maps.Clone(sp.AllowedTools),
+		AllowedPatterns:    maps.Clone(sp.AllowedPatterns),
+		Denials:            sp.Denials,
+		WorkingDirectories: slices.Clone(sp.WorkingDirectories),
+		ShouldAvoidPrompts: sp.ShouldAvoidPrompts,
+	}
+}
+
+// ResetPosture clears the blanket allowances and returns to Normal mode. One
+// critical section, so a reader never observes a half-cleared posture.
+func (sp *SessionPermissions) ResetPosture() {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.AllowAllEdits = false
+	sp.AllowAllWrites = false
+	sp.AllowAllBash = false
+	sp.AllowAllSkills = false
+	sp.Mode = ModeNormal
+}
+
+// SetMode points the session at an operation mode without touching the
+// allowances layered on top of it.
+func (sp *SessionPermissions) SetMode(mode OperationMode) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.Mode = mode
+}
+
+// GrantEditPosture auto-approves edits and writes and trusts cwd, as one
+// atomic change — the accept-edits and auto-pilot posture.
+func (sp *SessionPermissions) GrantEditPosture(cwd string) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.AllowAllEdits = true
+	sp.AllowAllWrites = true
+	sp.addWorkingDirectoryLocked(cwd)
+}
+
 func (sp *SessionPermissions) AllowTool(toolName string) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
 	if sp.AllowedTools == nil {
 		sp.AllowedTools = make(map[string]bool)
 	}
@@ -435,6 +506,8 @@ func (sp *SessionPermissions) AllowTool(toolName string) {
 }
 
 func (sp *SessionPermissions) AllowPattern(pattern string) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
 	if sp.AllowedPatterns == nil {
 		sp.AllowedPatterns = make(map[string]bool)
 	}
@@ -462,6 +535,15 @@ func (sp *SessionPermissions) IsToolAllowed(toolName string) bool {
 
 // AddWorkingDirectory adds a directory to the allowed working directories list.
 func (sp *SessionPermissions) AddWorkingDirectory(dir string) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.addWorkingDirectoryLocked(dir)
+}
+
+// addWorkingDirectoryLocked is the body of AddWorkingDirectory for callers
+// that already hold mu (GrantEditPosture, which grants the directory and the
+// edit allowances together).
+func (sp *SessionPermissions) addWorkingDirectoryLocked(dir string) {
 	// Avoid duplicates
 	for _, d := range sp.WorkingDirectories {
 		if d == dir {


### PR DESCRIPTION
The permission check runs on the agent goroutine (`HasPermissionToUseTool(..., m.env.SessionPermissions)`) and reads `Mode`, `AllowedPatterns`, `WorkingDirectories` as bare fields, while `ApplyModePermissions` writes those same fields (including a `WorkingDirectories` slice append) on the UI goroutine. The object is genuinely shared with no synchronization.

## Honest reachability
The Shift+Tab path is **not** the trigger: `cycleOperationMode` only runs when `!m.conv.Stream.Active`, so during a live turn (when the agent reads permissions) Shift+Tab is inert. The real exposure is narrower — `Session.Stop()` is async, and `/resume` and autopilot Save-and-Start both call `ApplyModePermissions` without waiting for the agent goroutine to unwind, so a UI write can overlap a not-yet-stopped permission check. Narrow, but a real cross-goroutine race the detector flags.

## Fix
Guard `SessionPermissions` with a mutex; readers take a `Snapshot()`. Defensive hardening of genuinely-shared state.

Tests drive both goroutines concurrently (DATA RACE without the fix) and pin snapshot isolation.