### PR TITLE
refactor: write files atomically through one helper

### DIFF
--- a/docs/reference/package-map.md
+++ b/docs/reference/package-map.md
@@ -79,6 +79,7 @@ Configuration and supporting capabilities:
 | `internal/markdown` | `infrastructure` | Markdown frontmatter parsing. |
 | `internal/proc` | `infrastructure` | Cross-platform process-group / signal helpers (Unix/Windows variants). |
 | `internal/confdir` | `infrastructure` | Shared `.san` configuration directory naming helper. |
+| `internal/atomicfile` | `infrastructure` | Temp-file-then-rename file replacement, so a reader never sees a half-written file. |
 
 ## Ownership Rule
 

--- a/internal/app/kit/history/history.go
+++ b/internal/app/kit/history/history.go
@@ -2,11 +2,11 @@ package history
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/genai-io/san/internal/atomicfile"
 	"github.com/genai-io/san/internal/confdir"
 )
 
@@ -59,25 +59,11 @@ func Load(cwd string) []string {
 }
 
 func Save(cwd string, history []string) {
-	path := historyFilePath(cwd)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return
-	}
-	// Write to temp file + rename for atomic replacement (prevents data loss on crash)
-	tmp := path + ".tmp"
-	f, err := os.Create(tmp)
-	if err != nil {
-		return
-	}
-	w := bufio.NewWriter(f)
+	var b strings.Builder
 	for _, entry := range truncate(history) {
-		_, _ = fmt.Fprintln(w, escapeEntry(entry))
+		b.WriteString(escapeEntry(entry))
+		b.WriteByte('\n')
 	}
-	if err := w.Flush(); err != nil {
-		f.Close()
-		os.Remove(tmp)
-		return
-	}
-	f.Close()
-	_ = os.Rename(tmp, path)
+	// Best-effort: losing shell history is not worth surfacing to the user.
+	_ = atomicfile.Write(historyFilePath(cwd), []byte(b.String()), 0o644)
 }

--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -1,0 +1,69 @@
+// Package atomicfile replaces a file's contents in one observable step.
+//
+// The content is written to a temporary file in the destination directory and
+// renamed over the target, so a concurrent reader sees either the old contents
+// or the new ones — never a half-written file — and a failed write leaves the
+// previous version intact.
+//
+// The temporary name is unique per call. A fixed "<path>.tmp" would have two
+// concurrent writers of the same path share one scratch file and interleave
+// their bytes into it, which is exactly the corruption the rename is meant to
+// prevent.
+package atomicfile
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// DirPerm is the mode used for directories created on the way to the target.
+const DirPerm os.FileMode = 0o755
+
+// Write replaces the file at path with data, creating parent directories as
+// needed. The temporary file is removed on every failure path, so a failed
+// write leaves nothing behind.
+func Write(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, DirPerm); err != nil {
+		return fmt.Errorf("create dir for %s: %w", path, err)
+	}
+
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp for %s: %w", path, err)
+	}
+	// Armed until the rename succeeds, so every failure below — including a
+	// panic — leaves nothing behind. Both calls are no-ops once they have run.
+	tmpName := tmp.Name()
+	defer func() {
+		tmp.Close()
+		os.Remove(tmpName)
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", path, err)
+	}
+	// CreateTemp always makes the file 0600; widen or narrow it to the caller's
+	// mode before it becomes visible under the target name.
+	if err := os.Chmod(tmpName, perm); err != nil {
+		return fmt.Errorf("chmod %s: %w", path, err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename %s: %w", path, err)
+	}
+	return nil
+}
+
+// WriteJSON marshals v as indented JSON and writes it through Write.
+func WriteJSON(path string, v any, perm os.FileMode) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", path, err)
+	}
+	return Write(path, data, perm)
+}

--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -18,15 +18,15 @@ import (
 	"path/filepath"
 )
 
-// DirPerm is the mode used for directories created on the way to the target.
-const DirPerm os.FileMode = 0o755
+// dirPerm is the mode used for directories created on the way to the target.
+const dirPerm os.FileMode = 0o755
 
 // Write replaces the file at path with data, creating parent directories as
 // needed. The temporary file is removed on every failure path, so a failed
 // write leaves nothing behind.
 func Write(path string, data []byte, perm os.FileMode) error {
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, DirPerm); err != nil {
+	if err := os.MkdirAll(dir, dirPerm); err != nil {
 		return fmt.Errorf("create dir for %s: %w", path, err)
 	}
 

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -1,0 +1,128 @@
+package atomicfile
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestWriteCreatesParentDirs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "a", "b", "c.json")
+	if err := Write(path, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("contents = %q, want %q", got, "hello")
+	}
+}
+
+// CreateTemp always makes 0600, so the caller's mode has to be applied before
+// the file becomes visible under the target name — secrets stay 0600, shared
+// config becomes 0644.
+func TestWriteAppliesRequestedPerm(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix file modes")
+	}
+	dir := t.TempDir()
+	for _, perm := range []os.FileMode{0o600, 0o644} {
+		path := filepath.Join(dir, perm.String()+".json")
+		if err := Write(path, []byte("{}"), perm); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("Stat: %v", err)
+		}
+		if info.Mode().Perm() != perm {
+			t.Errorf("mode = %v, want %v", info.Mode().Perm(), perm)
+		}
+	}
+}
+
+// A failed write must leave no scratch file behind — the secrets store used to
+// leak one containing API keys when the rename failed.
+func TestWriteLeavesNoTempOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	// Renaming onto a path whose parent is a directory entry that already
+	// exists as a non-empty directory fails on every platform.
+	target := filepath.Join(dir, "occupied")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "child"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := Write(target, []byte("data"), 0o644); err == nil {
+		t.Fatal("Write onto a non-empty directory should fail")
+	}
+	assertNoTempLeft(t, dir)
+}
+
+// Two writers racing on the same path must not share one scratch file. With a
+// fixed "<path>.tmp" they interleave into it; unique names keep each write's
+// bytes to itself, so the winner's content is intact rather than a blend.
+func TestConcurrentWritesLeaveIntactContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "contended.json")
+	a := strings.Repeat("a", 4096)
+	b := strings.Repeat("b", 4096)
+
+	var wg sync.WaitGroup
+	for _, payload := range []string{a, b} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 50 {
+				if err := Write(path, []byte(payload), 0o644); err != nil {
+					t.Errorf("Write: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != a && string(got) != b {
+		t.Errorf("contents are a blend of both writers (len=%d), want exactly one payload", len(got))
+	}
+	assertNoTempLeft(t, dir)
+}
+
+func TestWriteJSONRoundTrips(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "v.json")
+	if err := WriteJSON(path, map[string]string{"k": "v"}, 0o644); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if want := "{\n  \"k\": \"v\"\n}"; string(got) != want {
+		t.Errorf("contents = %q, want indented %q", got, want)
+	}
+}
+
+func assertNoTempLeft(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("temp file left behind: %s", e.Name())
+		}
+	}
+}

--- a/internal/cron/store.go
+++ b/internal/cron/store.go
@@ -7,13 +7,13 @@ import (
 	"fmt"
 	"hash/fnv"
 	"os"
-	"path/filepath"
 	"sort"
 	"sync"
 	"time"
 
 	"go.uber.org/zap"
 
+	"github.com/genai-io/san/internal/atomicfile"
 	"github.com/genai-io/san/internal/log"
 )
 
@@ -469,23 +469,8 @@ func (s *Scheduler) saveDurableLocked() {
 	}
 	durable = append(durable, s.foreignDurableLocked(durable)...)
 
-	data, err := json.MarshalIndent(durable, "", "  ")
-	if err != nil {
-		log.Logger().Error("cron: failed to marshal durable jobs", zap.Error(err))
-		return
-	}
-	if err := os.MkdirAll(filepath.Dir(s.storagePath), 0o755); err != nil {
-		log.Logger().Error("cron: failed to create storage directory", zap.Error(err))
-		return
-	}
-	tmp := s.storagePath + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		log.Logger().Error("cron: failed to write durable jobs", zap.Error(err))
-		return
-	}
-	if err := os.Rename(tmp, s.storagePath); err != nil {
-		os.Remove(tmp)
-		log.Logger().Error("cron: failed to rename durable jobs file", zap.Error(err))
+	if err := atomicfile.WriteJSON(s.storagePath, durable, 0o644); err != nil {
+		log.Logger().Error("cron: persist durable jobs", zap.Error(err))
 	}
 }
 

--- a/internal/llm/store.go
+++ b/internal/llm/store.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/genai-io/san/internal/atomicfile"
 	"github.com/genai-io/san/internal/confdir"
 )
 
@@ -141,19 +142,7 @@ func (s *Store) ensureMapsInitialized() {
 
 // save writes the store data to disk
 func (s *Store) save() error {
-	data, err := json.MarshalIndent(s.data, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal provider store: %w", err)
-	}
-	tmp := s.path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return fmt.Errorf("write provider store %s: %w", s.path, err)
-	}
-	if err := os.Rename(tmp, s.path); err != nil {
-		os.Remove(tmp)
-		return fmt.Errorf("rename provider store %s: %w", s.path, err)
-	}
-	return nil
+	return atomicfile.WriteJSON(s.path, s.data, 0o644)
 }
 
 // Connect saves a connection for a provider

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/genai-io/san/internal/atomicfile"
 	"github.com/genai-io/san/internal/confdir"
 )
 
@@ -122,17 +123,7 @@ func (l *ConfigLoader) SaveServer(name string, config ServerConfig, scope Scope)
 	mcpConfig.MCPServers[name] = configToSave
 
 	// Write back
-	data, err := json.MarshalIndent(mcpConfig, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	tmp := filePath + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return err
-	}
-	if err := os.Rename(tmp, filePath); err != nil {
-		os.Remove(tmp)
+	if err := atomicfile.WriteJSON(filePath, mcpConfig, 0o644); err != nil {
 		return err
 	}
 	fireConfigChanged(scopeConfigSource(scope), filePath)
@@ -160,17 +151,7 @@ func (l *ConfigLoader) RemoveServer(name string, scope Scope) error {
 	delete(mcpConfig.MCPServers, name)
 
 	// Write back
-	data, err = json.MarshalIndent(mcpConfig, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	tmp := filePath + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return err
-	}
-	if err := os.Rename(tmp, filePath); err != nil {
-		os.Remove(tmp)
+	if err := atomicfile.WriteJSON(filePath, mcpConfig, 0o644); err != nil {
 		return err
 	}
 	fireConfigChanged(scopeConfigSource(scope), filePath)
@@ -203,16 +184,7 @@ func (l *ConfigLoader) removeServerFromFile(filePath, name string) {
 
 	delete(mcpConfig.MCPServers, name)
 
-	data, err = json.MarshalIndent(mcpConfig, "", "  ")
-	if err != nil {
-		return
-	}
-	tmp := filePath + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return
-	}
-	if err := os.Rename(tmp, filePath); err != nil {
-		os.Remove(tmp)
+	if err := atomicfile.WriteJSON(filePath, mcpConfig, 0o644); err != nil {
 		return
 	}
 	fireConfigChanged(configSourceFromFilePath(filePath), filePath)

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/genai-io/san/internal/atomicfile"
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/log"
 	"go.uber.org/zap"
@@ -564,15 +565,5 @@ func (r *Registry) saveState() {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return
 	}
-	data, err := json.MarshalIndent(state, "", "  ")
-	if err != nil {
-		return
-	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		os.Remove(tmp)
-	}
+	_ = atomicfile.WriteJSON(path, state, 0o644)
 }

--- a/internal/plugin/installer.go
+++ b/internal/plugin/installer.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/genai-io/san/internal/atomicfile"
 	"github.com/genai-io/san/internal/confdir"
 )
 
@@ -446,19 +447,7 @@ func (i *Installer) addToInstalledV2(scope Scope, pluginKey string, info PluginI
 	}
 	v2.Plugins[pluginKey] = existing
 
-	data, err := json.MarshalIndent(v2, "", "  ")
-	if err != nil {
-		return err
-	}
-	tmp := installedFile + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return err
-	}
-	if err := os.Rename(tmp, installedFile); err != nil {
-		os.Remove(tmp)
-		return err
-	}
-	return nil
+	return atomicfile.WriteJSON(installedFile, v2, 0o644)
 }
 
 // loadInstalledPluginsV2 loads the installed plugins in v2 format.
@@ -525,19 +514,7 @@ func (i *Installer) removeFromInstalled(scope Scope, source string) error {
 		return os.Remove(installedFile)
 	}
 
-	data, err := json.MarshalIndent(v2, "", "  ")
-	if err != nil {
-		return err
-	}
-	tmp := installedFile + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return err
-	}
-	if err := os.Rename(tmp, installedFile); err != nil {
-		os.Remove(tmp)
-		return err
-	}
-	return nil
+	return atomicfile.WriteJSON(installedFile, v2, 0o644)
 }
 
 // copyDir copies a directory recursively.
@@ -659,18 +636,5 @@ func (i *Installer) AddMarketplace(source MarketplaceSource) error {
 		return err
 	}
 
-	data, err := json.MarshalIndent(km, "", "  ")
-	if err != nil {
-		return err
-	}
-	// Use atomic tmp+rename to prevent corruption on crash
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return err
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		os.Remove(tmp)
-		return err
-	}
-	return nil
+	return atomicfile.WriteJSON(path, km, 0o644)
 }

--- a/internal/plugin/marketplace.go
+++ b/internal/plugin/marketplace.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/genai-io/san/internal/atomicfile"
 	"github.com/genai-io/san/internal/confdir"
 )
 
@@ -123,20 +124,7 @@ func (m *MarketplaceManager) Save() error {
 	}
 
 	path := filepath.Join(m.configDir, "known_marketplaces.json")
-	data, err := json.MarshalIndent(m.marketplaces, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return err
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		os.Remove(tmp)
-		return err
-	}
-	return nil
+	return atomicfile.WriteJSON(path, m.marketplaces, 0o644)
 }
 
 // Get returns a marketplace by ID.

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/genai-io/san/internal/atomicfile"
 	"github.com/genai-io/san/internal/confdir"
 )
 
@@ -281,16 +282,7 @@ func (r *Registry) saveEnabledState(name string, enabled bool, scope Scope) erro
 	settings["enabledPlugins"] = enabledPlugins
 
 	// Write back
-	data, err := json.MarshalIndent(settings, "", "  ")
-	if err != nil {
-		return err
-	}
-	tmp := settingsPath + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return err
-	}
-	if err := os.Rename(tmp, settingsPath); err != nil {
-		os.Remove(tmp)
+	if err := atomicfile.WriteJSON(settingsPath, settings, 0o644); err != nil {
 		return err
 	}
 	fireConfigChanged(scopeConfigSource(scope), settingsPath)

--- a/internal/secret/store.go
+++ b/internal/secret/store.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/genai-io/san/internal/atomicfile"
 	"github.com/genai-io/san/internal/confdir"
 )
 
@@ -59,15 +60,8 @@ func (s *Store) load() error {
 }
 
 func (s *Store) save() error {
-	raw, err := json.MarshalIndent(s.data, "", "  ")
-	if err != nil {
-		return err
-	}
-	tmp := s.path + ".tmp"
-	if err := os.WriteFile(tmp, raw, 0o600); err != nil {
-		return err
-	}
-	return os.Rename(tmp, s.path)
+	// 0600: this file holds API keys and tokens.
+	return atomicfile.WriteJSON(s.path, s.data, 0o600)
 }
 
 func (s *Store) Set(key, value string) error {

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/genai-io/san/internal/atomicfile"
 	"github.com/genai-io/san/internal/confdir"
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/session/transcript"
@@ -292,16 +293,7 @@ func (s *Store) PersistToolResult(sessionID, toolCallID, content string) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("failed to create tool result dir: %w", err)
 	}
-	filePath := filepath.Join(dir, safeName)
-	tmp := filePath + ".tmp"
-	if err := os.WriteFile(tmp, []byte(content), 0o644); err != nil {
-		return fmt.Errorf("failed to write tool result: %w", err)
-	}
-	if err := os.Rename(tmp, filePath); err != nil {
-		os.Remove(tmp)
-		return fmt.Errorf("failed to finalize tool result: %w", err)
-	}
-	return nil
+	return atomicfile.Write(filepath.Join(dir, safeName), []byte(content), 0o644)
 }
 
 func (s *Store) SaveSubagentConversation(parentSessionID, title, modelID, cwd string, messages []core.Message) (string, string, error) {

--- a/internal/session/transcript/fs_store.go
+++ b/internal/session/transcript/fs_store.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/genai-io/san/internal/atomicfile"
 	"github.com/genai-io/san/internal/log"
 	"go.uber.org/zap"
 )
@@ -885,14 +886,8 @@ func (s *FileStore) saveIndexLocked(index *fileIndex) error {
 	if err != nil {
 		return fmt.Errorf("marshal transcript index: %w", err)
 	}
-	idxPath := s.indexPath()
-	tmp := idxPath + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+	if err := atomicfile.Write(s.indexPath(), data, 0o644); err != nil {
 		return fmt.Errorf("write transcript index: %w", err)
-	}
-	if err := os.Rename(tmp, idxPath); err != nil {
-		os.Remove(tmp)
-		return fmt.Errorf("finalize transcript index: %w", err)
 	}
 	s.cachedIndex = index
 	s.indexDirty = false

--- a/internal/setting/loader.go
+++ b/internal/setting/loader.go
@@ -12,6 +12,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/genai-io/san/internal/atomicfile"
 	"github.com/genai-io/san/internal/confdir"
 	"github.com/genai-io/san/internal/log"
 )
@@ -197,28 +198,7 @@ func (l *Loader) saveToFile(path string, settings *Data) error {
 			toSave = mergeSettings(existing, settings)
 		}
 	}
-	return writeJSONAtomic(path, toSave)
-}
-
-// writeJSONAtomic marshals v as indented JSON and writes it to path via a
-// temp file + rename so a kill mid-write cannot truncate the target.
-func writeJSONAtomic(path string, v any) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
-	data, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return err
-	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return err
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		os.Remove(tmp)
-		return err
-	}
-	return nil
+	return atomicfile.WriteJSON(path, toSave, 0o644)
 }
 
 var (
@@ -307,7 +287,7 @@ func updateSettingsFile(userLevel bool, mutate func(*Data)) error {
 		_ = json.Unmarshal(data, existing)
 	}
 	mutate(existing)
-	if err := writeJSONAtomic(path, existing); err != nil {
+	if err := atomicfile.WriteJSON(path, existing, 0o644); err != nil {
 		return err
 	}
 
@@ -359,7 +339,7 @@ func ExportAutoPilot(name string, cfg AutoPilotSettings) (string, error) {
 		return "", err
 	}
 	path := filepath.Join(dir, base+".json")
-	if err := writeJSONAtomic(path, cfg); err != nil {
+	if err := atomicfile.WriteJSON(path, cfg, 0o644); err != nil {
 		return "", err
 	}
 	return path, nil
@@ -567,7 +547,7 @@ func SavePersonaAt(cwd, name string, userLevel bool) error {
 	}
 	existing.Persona = name
 
-	if err := writeJSONAtomic(path, existing); err != nil {
+	if err := atomicfile.WriteJSON(path, existing, 0o644); err != nil {
 		return err
 	}
 

--- a/internal/skill/registry.go
+++ b/internal/skill/registry.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/genai-io/san/internal/atomicfile"
 	"github.com/genai-io/san/internal/confdir"
 )
 
@@ -119,20 +120,7 @@ func (s *Store) save() error {
 		Skills: s.states,
 	}
 
-	data, err := json.MarshalIndent(storeData, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	tmp := s.path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return err
-	}
-	if err := os.Rename(tmp, s.path); err != nil {
-		os.Remove(tmp)
-		return err
-	}
-	return nil
+	return atomicfile.WriteJSON(s.path, storeData, 0o644)
 }
 
 // GetState returns the persisted state for a skill.

--- a/internal/subagent/store.go
+++ b/internal/subagent/store.go
@@ -2,12 +2,12 @@ package subagent
 
 import (
 	"encoding/json"
-	"fmt"
 	"maps"
 	"os"
 	"path/filepath"
 	"sync"
 
+	"github.com/genai-io/san/internal/atomicfile"
 	"github.com/genai-io/san/internal/confdir"
 )
 
@@ -71,25 +71,7 @@ func (s *AgentStore) load() {
 // persistDisabled writes the disabled agent list to disk. Lock-free — operates
 // only on the provided snapshot.
 func persistDisabled(path string, disabled []string) error {
-	data, err := json.MarshalIndent(AgentStoreData{Disabled: disabled}, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal agent store: %w", err)
-	}
-
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return fmt.Errorf("create agent store directory %s: %w", dir, err)
-	}
-
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return fmt.Errorf("write agent store %s: %w", path, err)
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		os.Remove(tmp)
-		return fmt.Errorf("rename agent store %s: %w", path, err)
-	}
-	return nil
+	return atomicfile.WriteJSON(path, AgentStoreData{Disabled: disabled}, 0o644)
 }
 
 // IsDisabled returns whether an agent is disabled

--- a/internal/todo/store.go
+++ b/internal/todo/store.go
@@ -9,6 +9,11 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/genai-io/san/internal/atomicfile"
+	"github.com/genai-io/san/internal/log"
 )
 
 // Item represents a tracked item
@@ -158,20 +163,12 @@ func (s *Store) persistItem(item *Item) {
 	if s.storageDir == "" {
 		return
 	}
-	data, err := json.MarshalIndent(item, "", "  ")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "tracker: failed to marshal item %s: %v\n", item.ID, err)
-		return
-	}
 	path := filepath.Join(s.storageDir, item.ID+".json")
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		fmt.Fprintf(os.Stderr, "tracker: failed to write item %s: %v\n", item.ID, err)
-		return
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		os.Remove(tmp)
-		fmt.Fprintf(os.Stderr, "tracker: failed to rename item %s: %v\n", item.ID, err)
+	// Report through the logger, not os.Stderr: bubbletea owns the terminal
+	// while this runs, and a stray write corrupts the rendered frame.
+	if err := atomicfile.WriteJSON(path, item, 0o644); err != nil {
+		log.Logger().Error("tracker: persist item",
+			zap.String("item", item.ID), zap.Error(err))
 	}
 }
 


### PR DESCRIPTION
Replaces 19 hand-rolled temp-file+rename sites with one `internal/atomicfile` helper (`Write` / `WriteJSON`). Each site shed ~12 lines of identical boilerplate, and the fixed `<path>.tmp` becomes `os.CreateTemp`, removing the shared-scratch-file interleave when two writers hit one path.

## Two minor correctness improvements it folds in
- `secret/store.go` was the only site that did not remove its temp on rename failure. Minor — the temp is `0600` (same as the target) and holds secrets already in `secrets.json`, and a same-dir rename effectively never fails on Unix. Litter cleanup, not a security fix.
- `todo/store.go` wrote persist errors to `os.Stderr`, which corrupts the bubbletea frame. Real but low-frequency (only on a disk/marshal error). Now routed through the logger.

The consolidation itself is the main value. Tests cover the helper (perms, no-temp-on-failure, concurrent writers).

Note: `DirPerm` should be unexported (used only inside the package) — will fix.