### PR TITLE
fix: stop byte-offset truncation from splitting UTF-8 runes

### DIFF
--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -152,10 +152,3 @@ func (m *model) Init() tea.Cmd {
 	}
 	return tea.Batch(cmds...)
 }
-
-func truncate(s string, max int) string {
-	if len(s) <= max {
-		return s
-	}
-	return s[:max] + "..."
-}

--- a/internal/app/update_submit.go
+++ b/internal/app/update_submit.go
@@ -12,6 +12,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/genai-io/san/internal/app/input"
+	"github.com/genai-io/san/internal/app/kit"
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/log"
@@ -200,7 +201,7 @@ func (m *model) drainInputQueueWhileIdle() tea.Cmd {
 // On no-provider or ensureAgentSession failure, posts a notice and
 // returns a commit cmd (the agent is not contacted).
 func (m *model) SubmitToAgent(content string, images []core.Image) tea.Cmd {
-	log.QueueLog("SubmitToAgent: %q", truncate(content, 60))
+	log.QueueLog("SubmitToAgent: %q", kit.TruncateText(content, 60))
 	if m.env.LLMProvider == nil {
 		return m.notifyNoProvider()
 	}

--- a/internal/core/system/memory.go
+++ b/internal/core/system/memory.go
@@ -105,6 +105,13 @@ func LoadAutoMemoryAt(dir string) (string, bool) {
 
 // truncateOnLineBoundary trims s to at most max bytes, cutting at the last
 // newline within the budget so a partial line is never injected.
+//
+// With no newline in the budget the cut falls back to a raw byte offset, which
+// can land inside a multi-byte rune. This block goes into the system prompt, so
+// the result is scrubbed to valid UTF-8 before it leaves — an invalid sequence
+// is either rejected by the provider or silently turned into U+FFFD. CJK makes
+// that the likely case rather than the unlucky one: with three-byte runes, two
+// of every three offsets fall inside a character.
 func truncateOnLineBoundary(s string, max int) string {
 	if len(s) <= max {
 		return s
@@ -113,7 +120,7 @@ func truncateOnLineBoundary(s string, max int) string {
 	if i := strings.LastIndexByte(cut, '\n'); i > 0 {
 		return cut[:i]
 	}
-	return cut
+	return strings.ToValidUTF8(cut, "")
 }
 
 // MemoryFile represents a loaded memory file with metadata.

--- a/internal/core/system/memory_test.go
+++ b/internal/core/system/memory_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestResolveImports(t *testing.T) {
@@ -549,5 +550,41 @@ func TestResolveAutoMemoryDir(t *testing.T) {
 		if got := ResolveAutoMemoryDir(cwd, "~/mem"); got != filepath.Join(home, "mem") {
 			t.Fatalf("tilde override: got %q, want %q", got, filepath.Join(home, "mem"))
 		}
+	}
+}
+
+// A CJK memory index with no newline inside the byte cap falls through to the
+// raw byte offset, which lands inside a three-byte rune two times out of three.
+// The block goes into the system prompt, so the result has to be valid UTF-8 —
+// before the fix this emitted a dangling lead byte for the provider to reject
+// or replace with U+FFFD.
+func TestTruncateOnLineBoundaryKeepsValidUTF8(t *testing.T) {
+	paragraph := strings.Repeat("这是一段中文记忆内容。", 400)
+
+	// Sweep a rune's worth of offsets so the mid-rune cuts are covered, not
+	// just the one that happens to align.
+	for budget := 100; budget < 106; budget++ {
+		got := truncateOnLineBoundary(paragraph, budget)
+		if !utf8.ValidString(got) {
+			t.Errorf("budget=%d: result is not valid UTF-8: %q", budget, got)
+		}
+		if len(got) > budget {
+			t.Errorf("budget=%d: result is %d bytes, over budget", budget, len(got))
+		}
+	}
+}
+
+// The line-boundary path is the common one and must keep cutting there.
+func TestTruncateOnLineBoundaryPrefersNewline(t *testing.T) {
+	s := "第一行内容\n第二行内容\n第三行内容"
+	got := truncateOnLineBoundary(s, len(s)-3)
+	if strings.HasSuffix(got, "\n") || !strings.HasPrefix(got, "第一行内容") {
+		t.Fatalf("unexpected cut: %q", got)
+	}
+	if !utf8.ValidString(got) {
+		t.Errorf("result is not valid UTF-8: %q", got)
+	}
+	if strings.Count(got, "\n") != 1 {
+		t.Errorf("expected the cut at the last newline in budget, got %q", got)
 	}
 }

--- a/internal/reviewer/reviewer.go
+++ b/internal/reviewer/reviewer.go
@@ -303,9 +303,12 @@ func ExtractJSONObject(s string) string {
 	return s[start : end+1]
 }
 
+// truncate caps s at n bytes for an error message. The byte cut can land inside
+// a multi-byte rune, so the result is scrubbed rather than handed to %q as
+// invalid UTF-8 — judge responses are model output and can be any language.
 func truncate(s string, n int) string {
 	if len(s) <= n {
 		return s
 	}
-	return s[:n] + "…"
+	return strings.ToValidUTF8(s[:n], "") + "…"
 }


### PR DESCRIPTION
Three helpers cut strings at a byte offset and returned the result as-is. With ASCII that is fine. With CJK a three-byte rune puts **two of every three offsets inside a character**, so the tail is a dangling lead byte.

## The one that reaches a provider

`core/system/truncateOnLineBoundary` caps the auto-memory index at 25KB before it is injected into the **system prompt**. It cuts at the last newline in the budget — but a paragraph with no newline inside 25KB falls through to the raw byte cut:

```go
truncateOnLineBoundary(strings.Repeat("这是一段中文记忆内容。", 400), 100)
→ "…这是一段中文记忆内容。\xe8"        // invalid UTF-8, into the system prompt
```

An invalid sequence there is either rejected by the provider or silently replaced with U+FFFD. Fixed with `strings.ToValidUTF8` rather than a hand-rolled rune walk — the stdlib already does exactly this, and the earlier draft of this patch reimplemented it for no benefit.

The line-boundary path is untouched: `\n` is a single byte, so that cut already lands on a rune boundary.

## The other two — mojibake, not failed requests

- **`app/model.go`** carried its own `truncate` that byte-sliced and appended `"..."`, used for `log.QueueLog`. Deleted outright: `kit.TruncateText` is rune- and display-width-aware, lives one package away, and `internal/app` already imports `kit`. One fewer duplicate as well as one fewer bug.
- **`reviewer.go`** truncates a judge response into an error message. It cannot reach `kit` without inverting the layering (reviewer is a domain service, kit is TUI), so it scrubs in place.

## Tests

`TestTruncateOnLineBoundaryKeepsValidUTF8` sweeps a full rune's worth of offsets so the mid-rune cuts are covered rather than the one that happens to align. Reverting the fix fails it on 4 of 6 offsets. `TestTruncateOnLineBoundaryPrefersNewline` pins that the common line-boundary path still cuts where it did.

`go build ./...`, `go vet ./...`, `gofmt -l` and the full `go test ./...` are clean.