### PR TITLE
refactor(todo): give the two status axes distinct types

### DIFF
--- a/internal/app/conv/tracker_view.go
+++ b/internal/app/conv/tracker_view.go
@@ -142,7 +142,7 @@ func renderItem(t *todo.Item, phase itemPhase, width, idWidth int, blockers func
 	switch phase {
 	case itemAborted:
 		abortedStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Error)
-		detail := mutedStyle.Render("[" + todo.BackgroundStatusDetail(t) + "]")
+		detail := mutedStyle.Render("[" + string(todo.BackgroundStatusDetail(t)) + "]")
 		return renderItemLine(indent, abortedStyle.Render("!"), idTag, subject, detail)
 
 	case itemFinished:

--- a/internal/app/conv/tracker_view_test.go
+++ b/internal/app/conv/tracker_view_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/genai-io/san/internal/task"
 	"github.com/genai-io/san/internal/todo"
 )
 
@@ -202,16 +203,19 @@ func TestRenderTrackerListWindowsOnNewestTasks(t *testing.T) {
 }
 
 func TestPhaseOf(t *testing.T) {
-	worker := func(statusDetail string) map[string]any {
+	// Mirrors setBackgroundStatusDetail: the detail is a task.TaskStatus that
+	// has to land in the map as a plain string, since it is read back with a
+	// .(string) assertion.
+	worker := func(statusDetail task.TaskStatus) map[string]any {
 		return map[string]any{
 			"background_task_id":       "bg-1",
-			"background_status_detail": statusDetail,
+			"background_status_detail": string(statusDetail),
 		}
 	}
 
 	cases := []struct {
 		name      string
-		status    string
+		status    todo.Status
 		metadata  map[string]any
 		executing bool
 		want      itemPhase

--- a/internal/session/transcript/view.go
+++ b/internal/session/transcript/view.go
@@ -59,11 +59,13 @@ func TrackerItemsFromView(items []TrackerItemView) []todo.Item {
 	out := make([]todo.Item, 0, len(items))
 	for _, item := range items {
 		out = append(out, todo.Item{
-			ID:              item.ID,
-			Subject:         item.Subject,
-			Description:     item.Description,
-			ActiveForm:      item.ActiveForm,
-			Status:          item.Status,
+			ID:          item.ID,
+			Subject:     item.Subject,
+			Description: item.Description,
+			ActiveForm:  item.ActiveForm,
+			// The view type carries the persisted wire string; the domain type
+			// is where it becomes a checked lifecycle value.
+			Status:          todo.Status(item.Status),
 			Owner:           item.Owner,
 			Blocks:          append([]string(nil), item.Blocks...),
 			BlockedBy:       append([]string(nil), item.BlockedBy...),
@@ -83,7 +85,7 @@ func TrackerItemViewsFromItems(items []todo.Item) []TrackerItemView {
 			Subject:         item.Subject,
 			Description:     item.Description,
 			ActiveForm:      item.ActiveForm,
-			Status:          item.Status,
+			Status:          string(item.Status),
 			Owner:           item.Owner,
 			Blocks:          append([]string(nil), item.Blocks...),
 			BlockedBy:       append([]string(nil), item.BlockedBy...),

--- a/internal/todo/background.go
+++ b/internal/todo/background.go
@@ -22,7 +22,12 @@ const (
 // without reporting a terminal status — process exit, crash, or SIGKILL. Set
 // by demoteOrphanedItems when a persisted store is adopted into a fresh
 // session.
-const StatusDetailInterrupted = "interrupted"
+//
+// It is a task.TaskStatus rather than a todo.Status: this axis records how the
+// background task ended, not where the item sits in its own lifecycle. The
+// value extends task's vocabulary with the one outcome only the tracker can
+// observe — a task that stopped reporting rather than reporting a stop.
+const StatusDetailInterrupted task.TaskStatus = "interrupted"
 
 // BackgroundTaskID returns the background task ID this item mirrors, or ""
 // when the item is a plan item authored by the model rather than a worker.
@@ -31,10 +36,11 @@ func BackgroundTaskID(item *Item) string {
 }
 
 // BackgroundStatusDetail returns how a worker item's background task ended —
-// "failed", "killed", "stopped", or StatusDetailInterrupted. Empty for items
-// that mirror no background task, and for those that ended normally.
-func BackgroundStatusDetail(item *Item) string {
-	return metadataString(item, metaStatusDetail)
+// task.StatusFailed, StatusKilled, StatusStopped, or StatusDetailInterrupted.
+// Empty for items that mirror no background task, and for those that ended
+// normally.
+func BackgroundStatusDetail(item *Item) task.TaskStatus {
+	return task.TaskStatus(metadataString(item, metaStatusDetail))
 }
 
 // WorkerRunning reports whether the background task behind this item is
@@ -47,16 +53,29 @@ func WorkerRunning(item *Item) bool {
 }
 
 // EndedAbnormally reports whether a worker item reached its terminal state by
-// any route other than finishing its work. The stored detail is written as
-// string(task.TaskStatus) by CompleteWorker, so it is matched against those
-// constants rather than loose literals.
+// any route other than finishing its work.
 func EndedAbnormally(item *Item) bool {
 	switch BackgroundStatusDetail(item) {
-	case string(task.StatusFailed), string(task.StatusKilled),
-		string(task.StatusStopped), StatusDetailInterrupted:
+	case task.StatusFailed, task.StatusKilled, task.StatusStopped, StatusDetailInterrupted:
 		return true
 	}
 	return false
+}
+
+// setBackgroundStatusDetail records how a worker item's background task ended.
+//
+// Metadata is map[string]any and is read back with a .(string) assertion, so
+// the value has to be stored as a plain string — putting a task.TaskStatus in
+// the slot reads back as "" with no error anywhere. Routing every write through
+// here keeps that conversion off the call sites.
+func setBackgroundStatusDetail(item *Item, detail task.TaskStatus) {
+	if item == nil {
+		return
+	}
+	if item.Metadata == nil {
+		item.Metadata = map[string]any{}
+	}
+	item.Metadata[metaStatusDetail] = string(detail)
 }
 
 func metadataString(item *Item, key string) string {
@@ -114,9 +133,9 @@ func CompleteWorker(svc Service, info task.TaskInfo) {
 		subject = workerSubject(info)
 	}
 
-	statusDetail := string(info.Status)
+	statusDetail := info.Status
 	if statusDetail == "" {
-		statusDetail = string(task.StatusCompleted)
+		statusDetail = task.StatusCompleted
 	}
 
 	_ = svc.Update(item.ID,
@@ -125,7 +144,7 @@ func CompleteWorker(svc Service, info task.TaskInfo) {
 		WithStatus(StatusCompleted),
 		WithMetadata(map[string]any{
 			metaTaskID:       info.ID,
-			metaStatusDetail: statusDetail,
+			metaStatusDetail: string(statusDetail),
 		}),
 	)
 }

--- a/internal/todo/background_test.go
+++ b/internal/todo/background_test.go
@@ -126,3 +126,37 @@ func TestCompleteWorkerTracksFailure(t *testing.T) {
 		t.Fatalf("status detail = %q, want %q", metadataStr(items[0].Metadata, metaStatusDetail), task.StatusFailed)
 	}
 }
+
+// The detail axis is stored in map[string]any and read back with a .(string)
+// assertion, so a task.TaskStatus has to be converted on the way in. Storing
+// the typed value directly reads back as "" with no error anywhere — which is
+// how demoteOrphanedItems briefly lost its "interrupted" marker.
+func TestBackgroundStatusDetailRoundTripsThroughMetadata(t *testing.T) {
+	for _, detail := range []task.TaskStatus{
+		task.StatusFailed, task.StatusKilled, task.StatusStopped, StatusDetailInterrupted,
+	} {
+		item := &Item{ID: "1", Metadata: map[string]any{metaTaskID: "bg-1"}}
+		setBackgroundStatusDetail(item, detail)
+
+		if got := BackgroundStatusDetail(item); got != detail {
+			t.Errorf("detail = %q, want %q", got, detail)
+		}
+		if !EndedAbnormally(item) {
+			t.Errorf("%q should count as an abnormal end", detail)
+		}
+	}
+}
+
+// A task that finished normally is not an abnormal end, and neither is a plan
+// item that never had a worker.
+func TestEndedAbnormallyIgnoresNormalCompletionAndPlanItems(t *testing.T) {
+	done := &Item{ID: "1", Metadata: map[string]any{metaTaskID: "bg-1"}}
+	setBackgroundStatusDetail(done, task.StatusCompleted)
+	if EndedAbnormally(done) {
+		t.Error("a completed task should not count as an abnormal end")
+	}
+
+	if EndedAbnormally(&Item{ID: "2"}) {
+		t.Error("a plan item has no worker and cannot have ended abnormally")
+	}
+}

--- a/internal/todo/completion_test.go
+++ b/internal/todo/completion_test.go
@@ -10,22 +10,22 @@ import "testing"
 func TestAllMarkedCompleted(t *testing.T) {
 	cases := []struct {
 		name     string
-		statuses []string
+		statuses []Status
 		want     bool
 	}{
 		{"empty store", nil, false},
-		{"all completed", []string{StatusCompleted, StatusCompleted}, true},
-		{"one still pending", []string{StatusCompleted, StatusPending}, false},
+		{"all completed", []Status{StatusCompleted, StatusCompleted}, true},
+		{"one still pending", []Status{StatusCompleted, StatusPending}, false},
 		// The case the tracker used to get wrong elsewhere: an item the model
 		// marked in progress and never closed. No executor is advancing it, but
 		// it is abandoned work rather than finished work, so the list is not
 		// complete and the list stays up showing it as [stalled].
-		{"one left in progress", []string{StatusCompleted, StatusInProgress}, false},
-		{"deleted items do not count as open", []string{StatusCompleted, StatusDeleted}, true},
+		{"one left in progress", []Status{StatusCompleted, StatusInProgress}, false},
+		{"deleted items do not count as open", []Status{StatusCompleted, StatusDeleted}, true},
 		// Tombstones only: the map is not empty, so the emptiness check passes
 		// and the loop skips every item. The view never sees this — List drops
 		// deleted items, so it renders nothing either way.
-		{"only tombstones", []string{StatusDeleted}, true},
+		{"only tombstones", []Status{StatusDeleted}, true},
 	}
 
 	for _, tc := range cases {

--- a/internal/todo/store.go
+++ b/internal/todo/store.go
@@ -17,7 +17,7 @@ type Item struct {
 	Subject         string         `json:"subject"`
 	Description     string         `json:"description"`
 	ActiveForm      string         `json:"activeForm,omitempty"`
-	Status          string         `json:"status"`
+	Status          Status         `json:"status"`
 	Owner           string         `json:"owner,omitempty"`
 	Metadata        map[string]any `json:"metadata,omitempty"`
 	Blocks          []string       `json:"blocks"`
@@ -27,13 +27,32 @@ type Item struct {
 	StatusChangedAt time.Time      `json:"statusChangedAt"` // when status last changed (for elapsed time display)
 }
 
+// Status is where a tracker item sits in its own lifecycle. It is a distinct
+// axis from a background task's terminal state (task.TaskStatus, stored on a
+// worker item under metaStatusDetail) — the two vocabularies overlap on
+// "completed" but answer different questions, and naming them both
+// StatusCompleted in one scope is exactly why this needs a type.
+type Status string
+
 // Item status constants
 const (
-	StatusPending    = "pending"
-	StatusInProgress = "in_progress"
-	StatusCompleted  = "completed"
-	StatusDeleted    = "deleted"
+	StatusPending    Status = "pending"
+	StatusInProgress Status = "in_progress"
+	StatusCompleted  Status = "completed"
+	StatusDeleted    Status = "deleted"
 )
+
+// ParseStatus converts an external status string — tool input, a persisted
+// record — into a Status, reporting whether it named one. It is the single
+// place the valid set is enumerated, so a new status cannot be accepted in one
+// caller and rejected in another.
+func ParseStatus(s string) (Status, bool) {
+	switch Status(s) {
+	case StatusPending, StatusInProgress, StatusCompleted, StatusDeleted:
+		return Status(s), true
+	}
+	return "", false
+}
 
 // Store is a thread-safe item store with optional disk persistence.
 // When a storageDir is set, each item is persisted as {id}.json.
@@ -103,10 +122,7 @@ func (s *Store) demoteOrphanedItems() {
 		}
 		if BackgroundTaskID(item) != "" {
 			item.Status = StatusCompleted
-			if item.Metadata == nil {
-				item.Metadata = map[string]any{}
-			}
-			item.Metadata[metaStatusDetail] = StatusDetailInterrupted
+			setBackgroundStatusDetail(item, StatusDetailInterrupted)
 		} else {
 			item.Status = StatusPending
 		}
@@ -450,7 +466,7 @@ func (s *Store) ReloadFromDisk() {
 type UpdateOption func(*Item)
 
 // WithStatus sets the item status and records the status change timestamp.
-func WithStatus(status string) UpdateOption {
+func WithStatus(status Status) UpdateOption {
 	return func(t *Item) {
 		if t.Status != status {
 			t.StatusChangedAt = time.Now()

--- a/internal/tool/tasktools/tracker_tools_test.go
+++ b/internal/tool/tasktools/tracker_tools_test.go
@@ -51,7 +51,7 @@ func TestTrackerUpdateTool_ParsesJSONBlockedByAndPersistsFields(t *testing.T) {
 
 	result := (&TrackerUpdateTool{}).Execute(context.Background(), map[string]any{
 		"taskId":       task.ID,
-		"status":       todo.StatusInProgress,
+		"status":       string(todo.StatusInProgress),
 		"owner":        "Plan",
 		"description":  "write more tests",
 		"addBlockedBy": `["` + blocker.ID + `"]`,
@@ -60,7 +60,7 @@ func TestTrackerUpdateTool_ParsesJSONBlockedByAndPersistsFields(t *testing.T) {
 	if !result.Success {
 		t.Fatalf("expected success, got error: %s", result.Error)
 	}
-	if result.Metadata.Subtitle != "#"+task.ID+" "+todo.StatusInProgress {
+	if result.Metadata.Subtitle != "#"+task.ID+" "+string(todo.StatusInProgress) {
 		t.Fatalf("unexpected subtitle %q", result.Metadata.Subtitle)
 	}
 

--- a/internal/tool/tasktools/trackerupdate.go
+++ b/internal/tool/tasktools/trackerupdate.go
@@ -24,7 +24,7 @@ func (t *TrackerUpdateTool) Execute(ctx context.Context, params map[string]any, 
 	}
 
 	// Handle deletion separately
-	if status := tool.GetString(params, "status"); status == todo.StatusDeleted {
+	if status := tool.GetString(params, "status"); status == string(todo.StatusDeleted) {
 		if err := todo.Default().Delete(taskID); err != nil {
 			return toolresult.NewErrorResult(t.Name(), err.Error())
 		}
@@ -54,7 +54,7 @@ func (t *TrackerUpdateTool) Execute(ctx context.Context, params map[string]any, 
 
 	subtitle := fmt.Sprintf("#%s", taskID)
 	if statusChange != "" {
-		subtitle += " " + statusChange
+		subtitle += " " + string(statusChange)
 	}
 
 	return toolresult.ToolResult{
@@ -69,18 +69,18 @@ func (t *TrackerUpdateTool) Execute(ctx context.Context, params map[string]any, 
 }
 
 // buildUpdateOptions extracts update options from params, returns options, status change, and error
-func buildUpdateOptions(params map[string]any) ([]todo.UpdateOption, string, error) {
+func buildUpdateOptions(params map[string]any) ([]todo.UpdateOption, todo.Status, error) {
 	var opts []todo.UpdateOption
-	var statusChange string
+	var statusChange todo.Status
 
-	if status := tool.GetString(params, "status"); status != "" {
-		switch status {
-		case todo.StatusPending, todo.StatusInProgress, todo.StatusCompleted:
-			opts = append(opts, todo.WithStatus(status))
-			statusChange = status
-		default:
-			return nil, "", fmt.Errorf("invalid status: %s (must be pending, in_progress, completed, or deleted)", status)
+	if raw := tool.GetString(params, "status"); raw != "" {
+		// Deletion is not an update — Execute routes it before reaching here.
+		status, ok := todo.ParseStatus(raw)
+		if !ok || status == todo.StatusDeleted {
+			return nil, "", fmt.Errorf("invalid status: %s (must be pending, in_progress, completed, or deleted)", raw)
 		}
+		opts = append(opts, todo.WithStatus(status))
+		statusChange = status
 	}
 
 	if subject := tool.GetString(params, "subject"); subject != "" {


### PR DESCRIPTION
A tracker item carries **two independent statuses**, and both were bare strings with colliding constant names.

| Axis | Where | Vocabulary |
|---|---|---|
| `Item.Status` | the item's own lifecycle | `pending`, `in_progress`, `completed`, `deleted` |
| `metaStatusDetail` | how the worker's background task ended | `task.TaskStatus`: `running`, `completed`, `failed`, `killed`, `stopped` |

Different questions, different vocabularies, one overlapping literal — and `CompleteWorker` uses both within eight lines:

```go
statusDetail = string(task.StatusCompleted)   // the task's outcome
...
WithStatus(StatusCompleted)                   // the item's lifecycle
```

That works only because both spell `"completed"`.

## What the missing type cost

`todo`'s constants were untyped, so an untyped constant converts to whichever side it meets. This compiled, and was **silently always false** — `task` has no `pending`:

```go
info.Status == StatusPending      // task.TaskStatus vs untyped "pending"
```

Three consecutive fixes have landed in this area (#342, #346, #348), and #215 renamed around the tangle without typing it. After this change the same line is a compile error:

```
invalid operation: info.Status == StatusPending (mismatched types task.TaskStatus and Status)
```

## What the type flushed out

Adding it turned two latent hazards into build failures:

- **`ParseStatus`** is now the single enumeration of the valid set. `tracker_update` was duplicating it in a switch that listed three of the four statuses.
- **Metadata is `map[string]any`, read back with a `.(string)` assertion**, so a typed value stored there reads back as `""` with no error anywhere. This actually broke `"interrupted"` partway through the change and `orphan_test.go` caught it. Writes now go through `setBackgroundStatusDetail`, which owns the conversion; `TestBackgroundStatusDetailRoundTripsThroughMetadata` pins the property.

## Boundaries

`transcript.TrackerItemView` keeps its plain `string` field — it is a wire contract — and the conversion is explicit at that boundary in both directions. Tool params keep arriving as JSON strings and are parsed, not cast.

**JSON output is unchanged**: a named string type marshals identically, so persisted tracker items round-trip as before.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l`, full `go test ./...` and `go test -race` over `todo`, `app`, `tool` and `session` are clean.