### PR TITLE
fix(llm): stop a provider switch from crashing the TUI on cost accounting

### DIFF
--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -193,7 +193,7 @@ func TestRenderModeStatusShowsTokenUsageWithModel(t *testing.T) {
 		ModelName:        "claude-sonnet-4-6",
 		InputTokens:      142000,
 		InputLimit:       200000,
-		ConversationCost: llm.Money{Amount: 0.04, Currency: llm.CurrencyUSD},
+		ConversationCost: llm.NewCostTotal(llm.Money{Amount: 0.04, Currency: llm.CurrencyUSD}),
 		ShowContextBar:   true,
 		Width:            120,
 	})

--- a/internal/app/conv/status_bar.go
+++ b/internal/app/conv/status_bar.go
@@ -222,7 +222,7 @@ type OperationModeParams struct {
 	InputLimit        int
 	ModelName         string
 	StatusMessage     string
-	ConversationCost  llm.Money
+	ConversationCost  llm.CostTotal
 	Compressions      int  // session compact count, drives the "compacted ×N" badge
 	ShowContextBar    bool // render the visual [██████░░░░] 71% bar (opt-in)
 	Width             int
@@ -303,7 +303,7 @@ func renderStatusCluster(p OperationModeParams) string {
 		segments = append(segments, statusSegment{text: badge, priority: 5})
 	}
 	if !p.ConversationCost.IsZero() {
-		segments = append(segments, statusSegment{text: muted.Render(kit.FormatMoney(p.ConversationCost)), priority: 6})
+		segments = append(segments, statusSegment{text: muted.Render(kit.FormatCostTotal(p.ConversationCost)), priority: 6})
 	}
 
 	survivors := fitStatusSegments(segments, p.Width, lipgloss.Width(sep))

--- a/internal/app/env.go
+++ b/internal/app/env.go
@@ -36,7 +36,7 @@ type env struct {
 	// ConversationCost is the session-cumulative spend shown in the status
 	// bar. It survives ResetContextDisplay (per-compaction) so compaction
 	// doesn't erase prior spend; only ResetTokens (/clear, /new) zeroes it.
-	ConversationCost llm.Money
+	ConversationCost llm.CostTotal
 	ThinkingEffort   string
 	// Compressions counts auto + manual compacts this session. Survives
 	// ResetContextDisplay (called per-compact); zeroed only by ResetTokens
@@ -277,6 +277,6 @@ func (m *env) ResetContextDisplay() {
 // ConversationCost and the compaction counter.
 func (m *env) ResetTokens() {
 	m.ResetContextDisplay()
-	m.ConversationCost = llm.Money{}
+	m.ConversationCost = llm.CostTotal{}
 	m.Compressions = 0
 }

--- a/internal/app/env_test.go
+++ b/internal/app/env_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/genai-io/san/internal/llm"
@@ -51,11 +52,11 @@ func TestResetContextDisplay_PreservesCompressions(t *testing.T) {
 // cost must survive it, otherwise a long session's displayed spend resets to
 // zero each time the context is compacted.
 func TestResetContextDisplay_PreservesConversationCost(t *testing.T) {
-	cost := llm.Money{Amount: 1.25, Currency: llm.CurrencyUSD}
+	cost := llm.NewCostTotal(llm.Money{Amount: 1.25, Currency: llm.CurrencyUSD})
 	e := &env{InputTokens: 100, OutputTokens: 50, ConversationCost: cost}
 	e.ResetContextDisplay()
-	if e.ConversationCost != cost {
-		t.Errorf("ConversationCost = %v, want %v (must survive ResetContextDisplay)", e.ConversationCost, cost)
+	if !slices.Equal(e.ConversationCost.Amounts(), cost.Amounts()) {
+		t.Errorf("ConversationCost = %v, want %v (must survive ResetContextDisplay)", e.ConversationCost.Amounts(), cost.Amounts())
 	}
 }
 
@@ -71,7 +72,7 @@ func TestResetTokens_ZeroesCompressions(t *testing.T) {
 }
 
 func TestResetTokens_ZeroesConversationCost(t *testing.T) {
-	e := &env{ConversationCost: llm.Money{Amount: 2.50, Currency: llm.CurrencyUSD}}
+	e := &env{ConversationCost: llm.NewCostTotal(llm.Money{Amount: 2.50, Currency: llm.CurrencyUSD})}
 	e.ResetTokens()
 	if !e.ConversationCost.IsZero() {
 		t.Errorf("ConversationCost = %v, want zero after ResetTokens", e.ConversationCost)

--- a/internal/app/kit/cost.go
+++ b/internal/app/kit/cost.go
@@ -2,6 +2,7 @@ package kit
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/genai-io/san/internal/llm"
 )
@@ -31,4 +32,19 @@ func formatCurrencyAmount(symbol string, amount float64) string {
 	default:
 		return fmt.Sprintf("%s%.3f", symbol, amount)
 	}
+}
+
+// FormatCostTotal renders a session total that may span currencies. Providers
+// do not agree on one and there is no rate to convert with, so each currency is
+// shown on its own rather than folded into a single misleading figure.
+func FormatCostTotal(total llm.CostTotal) string {
+	amounts := total.Amounts()
+	if len(amounts) == 0 {
+		return "0"
+	}
+	parts := make([]string, 0, len(amounts))
+	for _, m := range amounts {
+		parts = append(parts, FormatMoney(m))
+	}
+	return strings.Join(parts, " + ")
 }

--- a/internal/llm/money.go
+++ b/internal/llm/money.go
@@ -1,6 +1,9 @@
 package llm
 
-import "fmt"
+import (
+	"slices"
+	"strings"
+)
 
 type Currency string
 
@@ -9,6 +12,8 @@ const (
 	CurrencyUSD Currency = "USD"
 )
 
+// Money is one amount in one currency — what a single provider charges for a
+// single call. Amounts are not summed across currencies; see CostTotal.
 type Money struct {
 	Amount   float64
 	Currency Currency
@@ -18,18 +23,49 @@ func (m Money) IsZero() bool {
 	return m.Amount == 0 || m.Currency == ""
 }
 
-func (m Money) Add(other Money) Money {
+// CostTotal accumulates spend that may span currencies. A session can switch
+// providers, and providers do not agree on one: MiniMax prices in CNY while
+// DeepSeek, MiMo and Ollama price in USD. There is no exchange rate here, so
+// adding across them would invent a number — each currency is kept on its own
+// and rendered side by side.
+//
+// The zero value is an empty total. Add returns a new CostTotal rather than
+// mutating, so the value can be copied freely; env is passed around by value.
+type CostTotal struct {
+	// entries holds at most one Money per currency, sorted by currency code so
+	// the status bar renders them in a stable order rather than reshuffling as
+	// the map iteration order changes.
+	entries []Money
+}
+
+// NewCostTotal starts a total from a single amount.
+func NewCostTotal(m Money) CostTotal {
+	return CostTotal{}.Add(m)
+}
+
+// Add folds m into the total, keeping it on its own currency's running sum.
+func (c CostTotal) Add(m Money) CostTotal {
 	if m.IsZero() {
-		return other
+		return c
 	}
-	if other.IsZero() {
-		return m
+	entries := slices.Clone(c.entries)
+	if i := slices.IndexFunc(entries, func(e Money) bool { return e.Currency == m.Currency }); i >= 0 {
+		entries[i].Amount += m.Amount
+		return CostTotal{entries: entries}
 	}
-	if m.Currency != other.Currency {
-		panic(fmt.Sprintf("cannot add %s to %s", m.Currency, other.Currency))
-	}
-	return Money{
-		Amount:   m.Amount + other.Amount,
-		Currency: m.Currency,
-	}
+	entries = append(entries, m)
+	slices.SortFunc(entries, func(a, b Money) int {
+		return strings.Compare(string(a.Currency), string(b.Currency))
+	})
+	return CostTotal{entries: entries}
+}
+
+// IsZero reports whether nothing has been spent.
+func (c CostTotal) IsZero() bool {
+	return len(c.entries) == 0
+}
+
+// Amounts returns the per-currency totals, ordered by currency code.
+func (c CostTotal) Amounts() []Money {
+	return slices.Clone(c.entries)
 }

--- a/internal/llm/money_test.go
+++ b/internal/llm/money_test.go
@@ -1,0 +1,72 @@
+package llm
+
+import (
+	"slices"
+	"testing"
+)
+
+// A session can switch providers, and ConversationCost survives the switch —
+// only /clear and /new reset it. MiniMax prices in CNY while DeepSeek, MiMo and
+// Ollama price in USD, so the accumulator has to hold both. Summing them would
+// invent a number; the previous Money.Add panicked instead, taking the TUI with
+// it since nothing recovers on that path.
+func TestCostTotalKeepsCurrenciesApart(t *testing.T) {
+	total := NewCostTotal(Money{Amount: 1.20, Currency: CurrencyCNY}) // MiniMax
+	total = total.Add(Money{Amount: 0.30, Currency: CurrencyUSD})     // switch to DeepSeek
+	total = total.Add(Money{Amount: 0.80, Currency: CurrencyCNY})     // and back
+
+	want := []Money{
+		{Amount: 2.00, Currency: CurrencyCNY},
+		{Amount: 0.30, Currency: CurrencyUSD},
+	}
+	got := total.Amounts()
+	if len(got) != len(want) {
+		t.Fatalf("Amounts() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i].Currency != want[i].Currency || !almostEqual(got[i].Amount, want[i].Amount) {
+			t.Errorf("Amounts()[%d] = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+// Ordering is by currency code so the status bar does not reshuffle between
+// renders as amounts arrive in different orders.
+func TestCostTotalOrderIsStableRegardlessOfArrival(t *testing.T) {
+	usdFirst := NewCostTotal(Money{Amount: 1, Currency: CurrencyUSD}).
+		Add(Money{Amount: 1, Currency: CurrencyCNY})
+	cnyFirst := NewCostTotal(Money{Amount: 1, Currency: CurrencyCNY}).
+		Add(Money{Amount: 1, Currency: CurrencyUSD})
+
+	if !slices.Equal(usdFirst.Amounts(), cnyFirst.Amounts()) {
+		t.Errorf("order depends on arrival: %v vs %v", usdFirst.Amounts(), cnyFirst.Amounts())
+	}
+}
+
+// Add returns a new value; a copy taken earlier must not move.
+func TestCostTotalAddDoesNotMutateTheReceiver(t *testing.T) {
+	base := NewCostTotal(Money{Amount: 1, Currency: CurrencyUSD})
+	_ = base.Add(Money{Amount: 5, Currency: CurrencyUSD})
+
+	if got := base.Amounts(); len(got) != 1 || !almostEqual(got[0].Amount, 1) {
+		t.Errorf("receiver changed: %v", got)
+	}
+}
+
+func TestCostTotalZeroValueAndZeroAmounts(t *testing.T) {
+	var total CostTotal
+	if !total.IsZero() {
+		t.Error("the zero value should report IsZero")
+	}
+	// A provider with no registered pricing returns Money{}; it must not create
+	// an empty-currency entry.
+	if total = total.Add(Money{}); !total.IsZero() {
+		t.Errorf("a zero Money should not register: %v", total.Amounts())
+	}
+}
+
+func almostEqual(a, b float64) bool {
+	const eps = 1e-9
+	d := a - b
+	return d < eps && d > -eps
+}


### PR DESCRIPTION
`Money.Add` panicked on mismatched currencies. That is reachable: MiniMax prices in CNY, DeepSeek/MiMo/Ollama in USD, and `ConversationCost` survives a provider switch (only `/clear` and `/new` reset it). So MiniMax → DeepSeek mid-session accumulates USD onto a CNY total → panic, on the UI goroutine, unrecovered → the TUI crashes. Directly reachable for this repo’s own audience.

Fix: `CostTotal` accumulates one running sum per currency (you cannot sum CNY+USD without a rate), rendered side by side (`¥1.200 + $0.300`). `Money` keeps its single-amount meaning and loses `Add`. Right-sized, not over-engineered.

Tests: MiniMax → DeepSeek → back keeps the currencies apart; stable order; Add does not mutate; zero-Money is a no-op.