### PR TITLE
fix(skill): guard the package-level registry against concurrent reinit

### DIFF
--- a/internal/skill/registry_race_test.go
+++ b/internal/skill/registry_race_test.go
@@ -1,0 +1,37 @@
+package skill
+
+import (
+	"sync"
+	"testing"
+)
+
+// Initialize runs on the bubbletea goroutine — reloadProjectServices reaches
+// it whenever the agent changes directory, which the agent triggers itself by
+// running `cd` in a Bash call. The agent goroutine keeps running through that:
+// the Skill tool and subagent prompt assembly both call Default() mid-turn.
+// Before registryMu the pointer swap raced those reads.
+// Run with -race; without the fix this reports DATA RACE.
+func TestDefaultRegistrySurvivesConcurrentReinitialize(t *testing.T) {
+	dir := t.TempDir()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() { // bubbletea goroutine: the agent ran `cd`
+		defer wg.Done()
+		for range 300 {
+			Initialize(Options{CWD: dir})
+		}
+	}()
+	go func() { // agent goroutine: the Skill tool resolving a name
+		defer wg.Done()
+		for range 300 {
+			if r := DefaultIfInit(); r != nil {
+				_, _ = r.Get("anything")
+			}
+			_ = Default().Count()
+		}
+	}()
+
+	wg.Wait()
+}

--- a/internal/skill/service.go
+++ b/internal/skill/service.go
@@ -9,6 +9,8 @@
 // hold *Registry as an opaque handle and call its methods.
 package skill
 
+import "sync"
+
 // PluginSkillPath describes a skill directory provided by a plugin.
 type PluginSkillPath struct {
 	Path      string
@@ -50,13 +52,15 @@ func Initialize(opts Options) {
 		}
 	}
 
-	defaultRegistry = registry
+	setDefaultRegistry(registry)
 }
 
 // Default returns the package-level *Registry. Returns an empty
 // (no-skills) registry pre-Initialize so callers that touch it before
 // Initialize don't crash.
 func Default() *Registry {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
 	return defaultRegistry
 }
 
@@ -65,30 +69,47 @@ func Default() *Registry {
 // for callers that want to distinguish "ready" from "not ready"
 // states.
 func DefaultIfInit() *Registry {
-	if defaultRegistry == nil || len(defaultRegistry.skills) == 0 {
+	r := Default()
+	if r == nil || r.Count() == 0 {
 		return nil
 	}
-	return defaultRegistry
+	return r
 }
 
 // SetDefaultRegistry replaces the package-level registry. Intended
 // for tests. A nil argument restores a fresh empty *Registry.
 func SetDefaultRegistry(r *Registry) {
 	if r == nil {
-		defaultRegistry = newEmptyRegistry()
-		return
+		r = newEmptyRegistry()
 	}
-	defaultRegistry = r
+	setDefaultRegistry(r)
 }
 
 // ResetDefaultRegistry restores a fresh empty *Registry. Intended for
 // tests.
 func ResetDefaultRegistry() {
-	defaultRegistry = newEmptyRegistry()
+	setDefaultRegistry(newEmptyRegistry())
 }
 
-// defaultRegistry is the package-level skill registry.
-var defaultRegistry = newEmptyRegistry()
+// defaultRegistry is the package-level skill registry, and registryMu guards
+// the pointer itself. The Registry it points at has its own lock for its
+// contents; what needed guarding here is the swap.
+//
+// Initialize runs on the bubbletea goroutine (reloadProjectServices, reached
+// whenever the agent changes directory with `cd`), while Default() is read on
+// the agent goroutine — the Skill tool and subagent prompt assembly both call
+// it mid-turn. Mirrors the locking internal/persona already uses for its own
+// singleton.
+var (
+	registryMu      sync.RWMutex
+	defaultRegistry = newEmptyRegistry()
+)
+
+func setDefaultRegistry(r *Registry) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	defaultRegistry = r
+}
 
 func newEmptyRegistry() *Registry {
 	return &Registry{skills: make(map[string]*Skill)}

--- a/internal/skill/service.go
+++ b/internal/skill/service.go
@@ -91,15 +91,9 @@ func ResetDefaultRegistry() {
 	setDefaultRegistry(newEmptyRegistry())
 }
 
-// defaultRegistry is the package-level skill registry, and registryMu guards
-// the pointer itself. The Registry it points at has its own lock for its
-// contents; what needed guarding here is the swap.
-//
-// Initialize runs on the bubbletea goroutine (reloadProjectServices, reached
-// whenever the agent changes directory with `cd`), while Default() is read on
-// the agent goroutine — the Skill tool and subagent prompt assembly both call
-// it mid-turn. Mirrors the locking internal/persona already uses for its own
-// singleton.
+// registryMu guards the defaultRegistry pointer swap; the Registry it points
+// at locks its own contents. Initialize (UI goroutine) and Default() (agent
+// goroutine) run concurrently, mirroring internal/persona's singleton locking.
 var (
 	registryMu      sync.RWMutex
 	defaultRegistry = newEmptyRegistry()


### PR DESCRIPTION
The package-level `skill.defaultRegistry` pointer was swapped by `Initialize` (UI goroutine, via `reloadProjectServices` after a `cd` the agent runs itself) and read by `Default()` (agent goroutine, via the Skill tool and subagent prompt assembly) with no synchronization. `-race` flags it; the old `DefaultIfInit` was doubly racy (read the pointer and the map unlocked).

Fix: guard the pointer with an RWMutex, mirroring `internal/persona`. The registry contents keep their own lock. Narrow window in practice, but a real race with a cheap correct fix.

Test drives both goroutines concurrently (DATA RACE without the fix).