### PR TITLE
fix(tui): measure panel layout in display columns, not bytes or runes

### DIFF
--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -756,10 +756,7 @@ func conciseAgentDescription(desc string) string {
 	if len(words) > 10 {
 		return strings.Join(words[:10], " ") + "..."
 	}
-	if len(desc) > 60 {
-		return desc[:57] + "..."
-	}
-	return desc
+	return kit.TruncateText(desc, 60)
 }
 
 func displayAgentName(agentType, mode string) string {

--- a/internal/app/input/config_appearance.go
+++ b/internal/app/input/config_appearance.go
@@ -196,7 +196,7 @@ func (p *appearancePanel) Render(width, _ int) string {
 // renderAppearanceSection renders a section heading followed by a rule that
 // fills the remaining width.
 func renderAppearanceSection(title string, width int) string {
-	ruleLen := max(width-len(title)-1, 1)
+	ruleLen := max(width-lipgloss.Width(title)-1, 1)
 	return appearanceSectionStyle.Render(title) + " " + appearanceRuleStyle.Render(strings.Repeat("─", ruleLen))
 }
 

--- a/internal/app/input/on_agent.go
+++ b/internal/app/input/on_agent.go
@@ -196,8 +196,8 @@ func (s *AgentSelector) renderItemList(sb *strings.Builder, panel kit.Panel) {
 	// columns align nicely while still adapting to long names.
 	maxNameLen := 12
 	for i := startIdx; i < endIdx; i++ {
-		if l := len(s.list.filtered[i].Name); l > maxNameLen {
-			maxNameLen = l
+		if w := lipgloss.Width(s.list.filtered[i].Name); w > maxNameLen {
+			maxNameLen = w
 		}
 	}
 	maxNameLen = min(maxNameLen, 28)
@@ -218,14 +218,16 @@ func (s *AgentSelector) renderItemList(sb *strings.Builder, panel kit.Panel) {
 			statusStyle = kit.SelectorStatusNone()
 		}
 
+		// Pad by display width, not bytes: one CJK agent name would otherwise
+		// shift the model, mode and badge columns on that row only.
 		name := kit.TruncateText(a.Name, maxNameLen)
-		paddedName := name + strings.Repeat(" ", max(0, maxNameLen-len(name)))
+		paddedName := name + strings.Repeat(" ", max(0, maxNameLen-lipgloss.Width(name)))
 
 		model := kit.TruncateText(a.Model, 14)
-		paddedModel := model + strings.Repeat(" ", max(0, 14-len(model)))
+		paddedModel := model + strings.Repeat(" ", max(0, 14-lipgloss.Width(model)))
 
 		mode := kit.TruncateText(a.PermissionMode, 8)
-		paddedMode := mode + strings.Repeat(" ", max(0, 8-len(mode)))
+		paddedMode := mode + strings.Repeat(" ", max(0, 8-lipgloss.Width(mode)))
 
 		// Reserve room for an inline source badge on the right.
 		badgeText := ""

--- a/internal/app/input/on_approval.go
+++ b/internal/app/input/on_approval.go
@@ -470,10 +470,9 @@ func (p *approvalAgentPreview) render(width int) string {
 	sb.WriteString(labelStyle.Render("Task:"))
 	sb.WriteString("\n")
 
-	prompt := p.agentMeta.Prompt
-	if len(prompt) > 500 {
-		prompt = prompt[:500] + "..."
-	}
+	// A subagent prompt is model-authored and may be any language, so the cap
+	// is applied in display columns and cut on a rune boundary.
+	prompt := kit.TruncateText(p.agentMeta.Prompt, 500)
 
 	lines := strings.Split(prompt, "\n")
 	for i, line := range lines {
@@ -484,11 +483,9 @@ func (p *approvalAgentPreview) render(width int) string {
 			break
 		}
 		sb.WriteString("   ")
-		if len(line) > width-6 {
-			sb.WriteString(dimStyle.Render(line[:width-9] + "..."))
-		} else {
-			sb.WriteString(dimStyle.Render(line))
-		}
+		// max(...) guards a terminal too narrow for the budget, which the old
+		// line[:width-9] would have sliced out of range.
+		sb.WriteString(dimStyle.Render(kit.TruncateText(line, max(width-6, 1))))
 		sb.WriteString("\n")
 	}
 

--- a/internal/app/input/on_memory.go
+++ b/internal/app/input/on_memory.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"unicode/utf8"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -540,7 +539,9 @@ func (s *memoryListState) writeMemoryFileLine(sb *strings.Builder, path string, 
 }
 
 func memoryFormatBoxLine(content string) string {
-	visibleLen := utf8.RuneCountInString(content)
+	// Display columns, not runes: a CJK rune occupies two, so a rune count
+	// under-pads and pushes the closing border past the box corner.
+	visibleLen := lipgloss.Width(content)
 	padding := max(memoryBoxWidth-visibleLen-2, 0)
 	return fmt.Sprintf("│ %s%s│\n", content, strings.Repeat(" ", padding))
 }
@@ -554,32 +555,33 @@ func memoryShortenPathForDisplay(path, cwd string, isProject bool) string {
 	return kit.ShortenPath(path)
 }
 
+// memoryTruncatePathKeepFilename trims a path to maxLen display columns,
+// spending the budget on the filename first. All measurements are columns, and
+// every cut goes through kit.TruncateText so it lands on a rune boundary — a
+// path like ~/项目/笔记/说明.md would otherwise be sliced mid-character.
 func memoryTruncatePathKeepFilename(path string, maxLen int) string {
-	if len(path) <= maxLen {
+	if lipgloss.Width(path) <= maxLen {
 		return path
 	}
 
 	base := filepath.Base(path)
-	if len(base) >= maxLen-3 {
-		return base[:maxLen-3] + "..."
+	if lipgloss.Width(base) >= maxLen-3 {
+		return kit.TruncateText(base, maxLen)
 	}
 
-	remaining := maxLen - len(base) - 4
+	remaining := maxLen - lipgloss.Width(base) - 4
 	if remaining > 0 {
-		dir := filepath.Dir(path)
-		if len(dir) > remaining {
-			dir = dir[len(dir)-remaining:]
-		}
+		dir := kit.TruncateKeepEnd(filepath.Dir(path), remaining)
 		return "..." + dir + "/" + base
 	}
 	return base
 }
 
 func memoryPadRight(s string, length int) string {
-	if len(s) >= length {
-		return s[:length]
+	if w := lipgloss.Width(s); w >= length {
+		return kit.TruncateText(s, length)
 	}
-	return s + strings.Repeat(" ", length-len(s))
+	return s + strings.Repeat(" ", length-lipgloss.Width(s))
 }
 
 // handleMemoryShow shows the current loaded memory content.

--- a/internal/app/input/on_session.go
+++ b/internal/app/input/on_session.go
@@ -161,10 +161,10 @@ func sessionTruncateToFirstLine(content string, maxLen int) string {
 	if first, _, found := strings.Cut(content, "\n"); found {
 		content = first
 	}
-	if len(content) > maxLen {
-		return content[:maxLen-3] + "..."
-	}
-	return content
+	// maxLen is a column budget from calculateSessionPreviewLength; measuring
+	// it in bytes cuts a Chinese prompt to a third of the row and can land
+	// mid-rune.
+	return kit.TruncateText(content, maxLen)
 }
 
 func (s *SessionSelector) getLastMessage(sess *session.SessionMetadata) string {

--- a/internal/app/input/on_skill.go
+++ b/internal/app/input/on_skill.go
@@ -224,10 +224,12 @@ func (s *SkillSelector) renderItemList(sb *strings.Builder, panel kit.Panel) {
 		sb.WriteString("\n")
 	}
 
+	// Display columns throughout: the column has to be as wide as the widest
+	// name renders, and a CJK name renders at twice its byte-count intuition.
 	maxNameLen := 12
 	for i := startIdx; i < endIdx; i++ {
-		if l := len(s.list.filtered[i].FullName()); l > maxNameLen {
-			maxNameLen = l
+		if w := lipgloss.Width(s.list.filtered[i].FullName()); w > maxNameLen {
+			maxNameLen = w
 		}
 	}
 	maxNameLen = min(maxNameLen, 32)
@@ -253,7 +255,7 @@ func (s *SkillSelector) renderItemList(sb *strings.Builder, panel kit.Panel) {
 		}
 
 		name := kit.TruncateText(sk.FullName(), maxNameLen)
-		paddedName := name + strings.Repeat(" ", max(0, maxNameLen-len(name)))
+		paddedName := name + strings.Repeat(" ", max(0, maxNameLen-lipgloss.Width(name)))
 
 		badgeText := ""
 		if scopeIsPlugin(sk.Scope) && sk.Namespace != "" {

--- a/internal/app/input/on_tool_selector.go
+++ b/internal/app/input/on_tool_selector.go
@@ -241,7 +241,7 @@ func (s *ToolSelector) Render() string {
 				desc = desc[:idx]
 			}
 			if len(desc) > maxDescLen {
-				desc = desc[:maxDescLen-3] + "..."
+				desc = kit.TruncateText(desc, maxDescLen)
 			}
 
 			descStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)

--- a/internal/app/kit/cjk_width_test.go
+++ b/internal/app/kit/cjk_width_test.go
@@ -1,0 +1,74 @@
+package kit
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+)
+
+// A CJK rune occupies two terminal columns but is one rune and three bytes.
+// Panels that measure a column budget with len() or utf8.RuneCountInString
+// misalign their columns and push box borders past the corner, so these pin
+// that the shared helpers answer in columns.
+
+func TestTruncateTextBudgetsDisplayColumns(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		text string
+		max  int
+	}{
+		{"ascii", "git-commit-helper", 10},
+		{"cjk", "代码审查助手", 10},
+		{"mixed", "review-代码审查", 10},
+	} {
+		got := TruncateText(tc.text, tc.max)
+		if w := lipgloss.Width(got); w > tc.max {
+			t.Errorf("%s: TruncateText(%q, %d) renders %d columns, over budget: %q",
+				tc.name, tc.text, tc.max, w, got)
+		}
+	}
+}
+
+// TruncateKeepEnd spends the budget on the tail — a path's filename identifies
+// it, the leading directories do not.
+func TestTruncateKeepEndBudgetsDisplayColumnsAndKeepsTheTail(t *testing.T) {
+	got := TruncateKeepEnd("项目/笔记/说明文档.md", 12)
+	if w := lipgloss.Width(got); w > 12 {
+		t.Errorf("renders %d columns, over budget: %q", w, got)
+	}
+	if !strings.HasSuffix(got, ".md") {
+		t.Errorf("lost the tail that identifies the path: %q", got)
+	}
+	if !strings.HasPrefix(got, "…") {
+		t.Errorf("want a leading ellipsis marking the elision: %q", got)
+	}
+}
+
+// Padding a name to a column width has to measure the name in columns too, or
+// a CJK row's following columns start further left than every ASCII row's.
+// This is the shape the skill and agent panels use.
+func TestColumnPaddingAlignsCJKWithASCII(t *testing.T) {
+	const col = 16
+	for _, name := range []string{"git-commit", "代码审查", "review-审查"} {
+		truncated := TruncateText(name, col)
+		padded := truncated + strings.Repeat(" ", max(0, col-lipgloss.Width(truncated)))
+		if w := lipgloss.Width(padded); w != col {
+			t.Errorf("%q padded to %d columns, want exactly %d", name, w, col)
+		}
+	}
+}
+
+// FormatAlignedRow is the canonical helper; it already measures in columns.
+func TestFormatAlignedRowKeepsTheInfoColumnStable(t *testing.T) {
+	ascii := FormatAlignedRow("●", "git-commit", 16, "info")
+	cjk := FormatAlignedRow("●", "代码审查", 16, "info")
+	if strings.Index(ascii, "info") == 0 || strings.Index(cjk, "info") == 0 {
+		t.Fatal("test setup: info marker not found")
+	}
+	aw := lipgloss.Width(ascii[:strings.Index(ascii, "info")])
+	cw := lipgloss.Width(cjk[:strings.Index(cjk, "info")])
+	if aw != cw {
+		t.Errorf("info column starts at %d for ASCII but %d for CJK", aw, cw)
+	}
+}

--- a/internal/app/kit/suggest/suggest.go
+++ b/internal/app/kit/suggest/suggest.go
@@ -487,7 +487,7 @@ func (s *State) renderCommandSuggestions(width int) string {
 	// one visible, then a 2-space gutter, so the descriptions read as a list.
 	nameWidth := 0
 	for _, cmd := range items {
-		if w := len([]rune(cmd.Name)) + 1; w > nameWidth { // +1 for the leading "/"
+		if w := lipgloss.Width(cmd.Name) + 1; w > nameWidth { // +1 for the leading "/"
 			nameWidth = w
 		}
 	}
@@ -496,7 +496,7 @@ func (s *State) renderCommandSuggestions(width int) string {
 	maxDescLen := max(contentWidth-nameWidth-6, 10)
 	for i, cmd := range items {
 		cmdName := "/" + cmd.Name
-		pad := strings.Repeat(" ", max(0, nameWidth-len([]rune(cmdName))))
+		pad := strings.Repeat(" ", max(0, nameWidth-lipgloss.Width(cmdName)))
 		desc := kit.TruncateText(cmd.Description, maxDescLen)
 
 		if start+i == s.selectedIdx {

--- a/internal/app/kit/util.go
+++ b/internal/app/kit/util.go
@@ -61,6 +61,32 @@ func TruncateText(text string, maxLen int) string {
 	return b.String() + "…"
 }
 
+// TruncateKeepEnd trims text to maxLen display columns keeping its tail, with
+// a leading ellipsis — the mirror of TruncateText, for values whose end
+// identifies them (a path's filename, a long id). Measured in columns and cut
+// on rune boundaries, so CJK neither overflows the slot nor splits.
+func TruncateKeepEnd(text string, maxLen int) string {
+	if maxLen <= 0 || lipgloss.Width(text) <= maxLen {
+		return text
+	}
+	if maxLen == 1 {
+		return "…"
+	}
+	budget := maxLen - 1
+	runes := []rune(text)
+	width := 0
+	i := len(runes)
+	for i > 0 {
+		rw := lipgloss.Width(string(runes[i-1]))
+		if width+rw > budget {
+			break
+		}
+		width += rw
+		i--
+	}
+	return "…" + string(runes[i:])
+}
+
 func ShortenPath(path string) string {
 	home, err := os.UserHomeDir()
 	if err != nil {


### PR DESCRIPTION
A CJK character is one rune, three bytes, and **two terminal columns**. Panel layout code mixed those up, so selectors misrender once a name, path, or prompt contains Chinese.

Measured, same input:
```
before:  box=35 cols  │ 项目/说明.md          │   (border past corner)
after:   box=31 cols  │ 项目/说明.md      │
```

## The real, user-visible sites
Session-picker preview (`on_session.go`), `/memory` box padding and path elision (`on_memory.go`), skill/agent name-column padding (`on_skill.go`, `on_agent.go`, where a CJK name shifts every later column), and the subagent-prompt preview (`on_approval.go`, which also fixes an out-of-range slice on a very narrow terminal). All now go through `lipgloss.Width` / `kit.TruncateText`.

## Two defensive-only sites
`config_appearance.go` and `suggest.go` operate on hardcoded-ASCII strings today (`len == Width`), so those two are consistency, not bug fixes — happy to drop them if preferred.

`kit.TruncateKeepEnd` is a justified addition: keeps the identifying tail with a leading ellipsis, which no existing helper does.

Tests pin the column-budget properties for ASCII / CJK / mixed input.