### PR TITLE
fix(session): stop /fork writing the fork's history into the parent

### DIFF
--- a/internal/app/model_session.go
+++ b/internal/app/model_session.go
@@ -218,6 +218,18 @@ func (m *model) forkSession() (string, error) {
 	}
 	originalID := forked.Metadata.ParentSessionID
 	m.services.Session.SetID(forked.Metadata.ID)
+	// The live agent holds an onEvent closure over a Recorder bound to the
+	// parent's id, and a Recorder's session is fixed at construction. Without
+	// this stop it keeps writing the fork's messages, inferences, permissions
+	// and hooks into the parent transcript — so resuming the original, which is
+	// exactly what the UI tells the user to do, replays post-fork history and
+	// the parent is no longer frozen at the fork point.
+	//
+	// Stop rather than Reset: a fork continues the conversation under a new id,
+	// so the chain has to survive into the rebuilt agent. The next turn's
+	// ensureAgentSession rebuilds with a Recorder bound to the new id, since
+	// NewRecorder invalidates its cache on exactly that mismatch.
+	m.StopAgentSession()
 	m.services.Tracker.SetStorageDir("")
 	return originalID, nil
 }

--- a/internal/session/fork_recorder_test.go
+++ b/internal/session/fork_recorder_test.go
@@ -1,0 +1,120 @@
+package session
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/genai-io/san/internal/core"
+)
+
+// A Recorder's session is fixed at construction, so forking has to get a new
+// one. The live agent holds an onEvent closure over whichever Recorder it was
+// built with, which is why app.forkSession stops the agent: the rebuild is what
+// picks the new Recorder up. These pin the two halves of that contract.
+
+func TestNewRecorderRebindsAfterTheSessionIDChanges(t *testing.T) {
+	store, err := NewStoreWithDir(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStoreWithDir: %v", err)
+	}
+	setup := &Setup{Store: store, SessionID: "parent"}
+
+	parentRec := setup.NewRecorder("main", "anthropic", "model", 1000)
+	if parentRec == nil {
+		t.Fatal("NewRecorder returned nil for the parent session")
+	}
+	if got := parentRec.SessionID(); got != "parent" {
+		t.Fatalf("parent recorder session = %q, want %q", got, "parent")
+	}
+
+	// Forking re-points the Setup at the new session.
+	setup.SetID("fork")
+
+	forkRec := setup.NewRecorder("main", "anthropic", "model", 1000)
+	if forkRec == nil {
+		t.Fatal("NewRecorder returned nil after the session changed")
+	}
+	if got := forkRec.SessionID(); got != "fork" {
+		t.Errorf("recorder session = %q, want %q — the cache did not invalidate", got, "fork")
+	}
+	if forkRec == parentRec {
+		t.Error("the parent's Recorder was reused; records would land in the parent transcript")
+	}
+}
+
+// Setup.Recorder deliberately refuses a stale recorder rather than letting a
+// caller write into the wrong transcript. That guard is what the agent's
+// captured closure bypasses, so it is worth pinning.
+func TestSetupRecorderRefusesAStaleRecorder(t *testing.T) {
+	store, err := NewStoreWithDir(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStoreWithDir: %v", err)
+	}
+	setup := &Setup{Store: store, SessionID: "parent"}
+
+	if setup.NewRecorder("main", "anthropic", "model", 1000) == nil {
+		t.Fatal("NewRecorder returned nil for the parent session")
+	}
+	if setup.Recorder() == nil {
+		t.Fatal("Recorder() should return the recorder bound to the current session")
+	}
+
+	setup.SetID("fork")
+
+	if got := setup.Recorder(); got != nil {
+		t.Errorf("Recorder() handed back a recorder bound to %q while the session is %q",
+			got.SessionID(), "fork")
+	}
+}
+
+// Post-fork messages must land in the fork's transcript, not the parent's.
+// This drives the recorder through OnAgentEvent — the exact closure the live
+// agent captures — and reads both transcripts back.
+func TestForkRecorderWritesToTheForkNotTheParent(t *testing.T) {
+	store, err := NewStoreWithDir(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStoreWithDir: %v", err)
+	}
+	setup := &Setup{Store: store, SessionID: "parent"}
+	parentRec := setup.NewRecorder("main", "anthropic", "model", 1000)
+	// The live agent stamps an id in append(); OnAppend drops messages without
+	// one, so the harness has to do the same.
+	parentRec.OnAgentEvent(core.AppendEvent("main", core.Message{
+		ID: "m1", Role: core.RoleUser, Content: "before the fork",
+	}))
+
+	// Fork: the session id moves, and the rebuilt agent picks up a recorder
+	// bound to it. Using parentRec here instead is the bug.
+	setup.SetID("fork")
+	forkRec := setup.NewRecorder("main", "anthropic", "model", 1000)
+	forkRec.OnAgentEvent(core.AppendEvent("main", core.Message{
+		ID: "m2", Role: core.RoleUser, Content: "after the fork",
+	}))
+
+	parentBody := readTranscript(t, store, "parent")
+	forkBody := readTranscript(t, store, "fork")
+
+	if !strings.Contains(forkBody, "after the fork") {
+		t.Error("the post-fork message is missing from the fork transcript")
+	}
+	if strings.Contains(parentBody, "after the fork") {
+		t.Error("the post-fork message landed in the parent transcript; " +
+			"resuming the original would replay history from after the fork")
+	}
+	if !strings.Contains(parentBody, "before the fork") {
+		t.Error("the parent lost its own pre-fork history")
+	}
+}
+
+func readTranscript(t *testing.T, store *Store, sessionID string) string {
+	t.Helper()
+	data, err := os.ReadFile(store.transcriptStore.TranscriptPath(sessionID))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatalf("read transcript %s: %v", sessionID, err)
+	}
+	return string(data)
+}


### PR DESCRIPTION
`/fork` kept the agent running, and its `onEvent` closure is bound to a Recorder whose `sessionID` is fixed at construction. So after a fork the agent kept writing the new session’s messages, inferences, permissions and hooks into the **parent** transcript. Since the fork message tells the user to resume the original, resuming replays post-fork history — silent corruption.

`loadSessionByID` already resets the agent for this reason; `forkSession` was the one path that skipped it.

## Fix
`StopAgentSession` (not Reset — a fork continues the conversation, so the chain must survive into the rebuild). The next turn rebuilds with a Recorder bound to the fork id, since `NewRecorder` invalidates its cache on that mismatch.

Tests drive the real `OnAgentEvent` closure and read both transcripts: post-fork message in the fork, absent from the parent, parent keeps its pre-fork history.