### PR TITLE
fix(mcp): keep servers connected across a cwd change

### DIFF
--- a/internal/mcp/adopt_clients_test.go
+++ b/internal/mcp/adopt_clients_test.go
@@ -1,0 +1,146 @@
+package mcp
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/genai-io/san/internal/mcp/transport"
+)
+
+// liveTransport stands in for a running MCP server: alive until Close.
+type liveTransport struct {
+	mu     sync.Mutex
+	closed bool
+}
+
+func (t *liveTransport) Start(context.Context) error { return nil }
+func (t *liveTransport) Send(context.Context, *transport.JSONRPCRequest) (*transport.JSONRPCResponse, error) {
+	return &transport.JSONRPCResponse{}, nil
+}
+func (t *liveTransport) SendNotification(context.Context, *transport.JSONRPCNotification) error {
+	return nil
+}
+func (t *liveTransport) Close() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.closed = true
+	return nil
+}
+func (t *liveTransport) IsAlive() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return !t.closed
+}
+func (t *liveTransport) SetNotificationHandler(transport.NotificationHandler) {}
+
+func (t *liveTransport) isClosed() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.closed
+}
+
+// connectedClient builds a Client already in the connected state, backed by tr.
+func connectedClient(t *testing.T, cfg ServerConfig, tr transport.Transport) *Client {
+	t.Helper()
+	c := NewClient(cfg)
+	c.TransportFactory = func() (transport.Transport, error) { return tr, nil }
+	c.mu.Lock()
+	c.transport = tr
+	c.connected = true
+	c.mu.Unlock()
+	return c
+}
+
+func registryWith(configs map[string]ServerConfig, clients map[string]*Client) *Registry {
+	r := newEmptyRegistry()
+	for name, cfg := range configs {
+		r.configs[name] = cfg
+	}
+	for name, c := range clients {
+		r.clients[name] = c
+	}
+	return r
+}
+
+// A user-level MCP server is configured in both the old project and the new
+// one. Replacing the registry on a cwd change used to drop its connection, so
+// every mcp__* tool disappeared from the agent for the rest of the session with
+// nothing to reconnect it — AutoConnect only runs at startup.
+func TestAdoptLiveClientsKeepsUnchangedServersConnected(t *testing.T) {
+	cfg := ServerConfig{Name: "docs", Type: "stdio", Command: "docs-server", Args: []string{"--stdio"}}
+	tr := &liveTransport{}
+	old := registryWith(
+		map[string]ServerConfig{"docs": cfg},
+		map[string]*Client{"docs": connectedClient(t, cfg, tr)},
+	)
+
+	// Same server still configured after the cwd change.
+	fresh := registryWith(map[string]ServerConfig{"docs": cfg}, nil)
+	fresh.adoptLiveClients(old)
+
+	if _, ok := fresh.clients["docs"]; !ok {
+		t.Fatal("the live connection was not carried across; mcp__docs__* tools would vanish")
+	}
+	if tr.isClosed() {
+		t.Error("an unchanged server's transport was closed")
+	}
+	if len(old.clients) != 0 {
+		t.Error("the outgoing registry still owns the client; both would think they own it")
+	}
+}
+
+// A project-scoped server that the new project does not configure must be torn
+// down — it was previously dropped still running, leaking the subprocess.
+func TestAdoptLiveClientsDisconnectsServersTheNewProjectDropped(t *testing.T) {
+	cfg := ServerConfig{Name: "old-proj", Type: "stdio", Command: "old-server"}
+	tr := &liveTransport{}
+	old := registryWith(
+		map[string]ServerConfig{"old-proj": cfg},
+		map[string]*Client{"old-proj": connectedClient(t, cfg, tr)},
+	)
+
+	fresh := registryWith(map[string]ServerConfig{}, nil) // new project configures nothing
+	fresh.adoptLiveClients(old)
+
+	if _, ok := fresh.clients["old-proj"]; ok {
+		t.Error("a server the new project does not configure was adopted")
+	}
+	waitFor(t, "the dropped server's transport to close", tr.isClosed)
+}
+
+// Same name, different command: the config changed, so the old process is not
+// the server the new project asked for.
+func TestAdoptLiveClientsRejectsAChangedConfig(t *testing.T) {
+	oldCfg := ServerConfig{Name: "docs", Type: "stdio", Command: "docs-server", Args: []string{"--v1"}}
+	newCfg := ServerConfig{Name: "docs", Type: "stdio", Command: "docs-server", Args: []string{"--v2"}}
+	tr := &liveTransport{}
+	old := registryWith(
+		map[string]ServerConfig{"docs": oldCfg},
+		map[string]*Client{"docs": connectedClient(t, oldCfg, tr)},
+	)
+
+	fresh := registryWith(map[string]ServerConfig{"docs": newCfg}, nil)
+	fresh.adoptLiveClients(old)
+
+	if _, ok := fresh.clients["docs"]; ok {
+		t.Error("adopted a connection whose configuration no longer matches")
+	}
+	waitFor(t, "the stale server's transport to close", tr.isClosed)
+}
+
+// waitFor polls cond, since the teardown of servers that did not survive runs
+// detached — Disconnect can block for seconds and Initialize is on the UI
+// goroutine.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Errorf("timed out waiting for %s", what)
+}

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 
@@ -53,7 +54,57 @@ type mcpState struct {
 }
 
 // defaultRegistry is the package-level MCP registry.
-var defaultRegistry = newEmptyRegistry()
+// defaultRegistry is the package-level registry; registryMu guards the pointer
+// itself. The Registry it points at locks its own contents — what needed
+// guarding is the swap, which Initialize performs on the bubbletea goroutine
+// (reloadProjectServices) while DefaultRegistry() is read elsewhere.
+var (
+	registryMu      sync.RWMutex
+	defaultRegistry = newEmptyRegistry()
+)
+
+// adoptLiveClients moves connections from the outgoing registry into this one
+// for every server whose configuration is unchanged, and tears down the rest.
+//
+// Without it a cwd change replaced the registry with a fresh, zero-client one:
+// GetToolSchemas returned nothing, so every mcp__* tool silently vanished from
+// the agent for the rest of the session, and the outgoing registry's stdio
+// subprocesses were dropped on the floor still running.
+//
+// The teardown of servers that did NOT survive runs detached: Client.Disconnect
+// waits on the child's read loop and exit, up to seven seconds per server, and
+// Initialize is called from the bubbletea goroutine.
+func (r *Registry) adoptLiveClients(old *Registry) {
+	if old == nil || old == r {
+		return
+	}
+
+	old.mu.Lock()
+	adopted := make(map[string]*Client)
+	var stale []*Client
+	for name, client := range old.clients {
+		cfg, stillConfigured := r.configs[name]
+		if stillConfigured && reflect.DeepEqual(cfg, old.configs[name]) && client.IsConnected() {
+			adopted[name] = client
+			continue
+		}
+		stale = append(stale, client)
+	}
+	old.clients = make(map[string]*Client)
+	old.mu.Unlock()
+
+	r.mu.Lock()
+	maps.Copy(r.clients, adopted)
+	r.mu.Unlock()
+
+	if len(stale) > 0 {
+		go func() {
+			for _, c := range stale {
+				_ = c.Disconnect()
+			}
+		}()
+	}
+}
 
 func newEmptyRegistry() *Registry {
 	return &Registry{

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -53,7 +53,6 @@ type mcpState struct {
 	Disabled []string `json:"disabled,omitempty"`
 }
 
-// defaultRegistry is the package-level MCP registry.
 // defaultRegistry is the package-level registry; registryMu guards the pointer
 // itself. The Registry it points at locks its own contents — what needed
 // guarding is the swap, which Initialize performs on the bubbletea goroutine

--- a/internal/mcp/service.go
+++ b/internal/mcp/service.go
@@ -82,7 +82,13 @@ func Initialize(opts Options) error {
 		reg.PluginServers = opts.PluginServers
 		reg.configs = reg.mergePluginMCPConfigs(reg.configs)
 	}
-	defaultRegistry = reg
+	// Carry live connections across the swap. Initialize runs on every cwd
+	// change and plugin reload, and a user-level server is configured in both
+	// the old project and the new one — tearing it down would drop every
+	// mcp__* tool from the agent mid-session, with nothing to reconnect it
+	// (AutoConnect only runs at startup).
+	reg.adoptLiveClients(DefaultRegistry())
+	setDefaultRegistry(reg)
 	return nil
 }
 
@@ -95,21 +101,28 @@ func Initialize(opts Options) error {
 // through NewCaller(reg). Config editing uses the free functions
 // PrepareServerEdit / ApplyServerEdit.
 func DefaultRegistry() *Registry {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
 	return defaultRegistry
+}
+
+func setDefaultRegistry(reg *Registry) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	defaultRegistry = reg
 }
 
 // SetDefaultRegistry replaces the package-level registry. Intended for
 // tests. A nil argument restores the empty pre-Initialize registry.
 func SetDefaultRegistry(reg *Registry) {
 	if reg == nil {
-		defaultRegistry = newEmptyRegistry()
-		return
+		reg = newEmptyRegistry()
 	}
-	defaultRegistry = reg
+	setDefaultRegistry(reg)
 }
 
 // ResetDefaultRegistry restores the empty pre-Initialize registry.
 // Intended for tests.
 func ResetDefaultRegistry() {
-	defaultRegistry = newEmptyRegistry()
+	setDefaultRegistry(newEmptyRegistry())
 }


### PR DESCRIPTION
A `cd` (which the agent triggers itself via a Bash call) re-runs `mcp.Initialize`, replacing the registry with a fresh one that has zero connected clients. Nothing reconnects — `AutoConnect` is startup-only. So on the next agent rebuild every `mcp__*` tool silently vanishes for the rest of the session, and the old registry’s stdio subprocesses are dropped still running.

## Fix
`adoptLiveClients` carries connections across the swap when the server config is unchanged (compared by `reflect.DeepEqual` on the plain-data `ServerConfig`), and tears down only the servers the new project no longer configures. Teardown is detached — `Disconnect` can block seconds and `Initialize` is on the UI goroutine.

Also guards the `defaultRegistry` pointer, unsynchronized before (same shape as #358).

Tests cover: unchanged server kept connected, dropped server torn down, changed config rejected.