### PR TITLE
fix(hook): stop losing plugin hooks on every reload

### DIFF
--- a/internal/app/hooks.go
+++ b/internal/app/hooks.go
@@ -14,6 +14,7 @@ import (
 	"github.com/genai-io/san/internal/core/system"
 	"github.com/genai-io/san/internal/hook"
 	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/plugin"
 )
 
 func (m *model) firePostToolHook(tr core.ToolResult, sideEffect any) {
@@ -165,8 +166,20 @@ func (m *model) refreshMemoryContext(cwd, loadReason string) {
 	m.env.CachedProjectInstructions = joinSections(projectParts)
 }
 
+// syncSettingsToHookEngine hands the engine the current settings with plugin
+// hooks folded in.
+//
+// The merge has to happen on the snapshot that is actually passed on. Settings
+// .Snapshot() deep-copies on every call, so merging into a separate one — as
+// both reload paths used to — writes the plugin hooks into a clone that is
+// immediately discarded, and the engine receives a clean copy with none of
+// them. A plugin's hooks then stopped firing after any cwd change or plugin
+// install, silently. init.go gets this right by binding the snapshot first;
+// doing the merge here means a caller cannot get it wrong.
 func (m *model) syncSettingsToHookEngine() {
-	m.services.Hook.SetSettings(m.services.Setting.Snapshot())
+	settings := m.services.Setting.Snapshot()
+	plugin.MergePluginHooksIntoSettings(settings)
+	m.services.Hook.SetSettings(settings)
 }
 
 func memoryTypeForLevel(level string) string {

--- a/internal/app/model_lifecycle.go
+++ b/internal/app/model_lifecycle.go
@@ -15,7 +15,6 @@ import (
 	"github.com/genai-io/san/internal/app/trigger"
 	"github.com/genai-io/san/internal/broker"
 	"github.com/genai-io/san/internal/hook"
-	"github.com/genai-io/san/internal/plugin"
 	"github.com/genai-io/san/internal/setting"
 	"github.com/genai-io/san/internal/task"
 	"github.com/genai-io/san/internal/todo"
@@ -145,7 +144,6 @@ func (m *model) ReloadAfterPluginChange() error {
 	// services (not the plugins themselves) and re-point at them.
 	m.reloadProjectServices(m.env.CWD)
 
-	plugin.MergePluginHooksIntoSettings(m.services.Setting.Snapshot())
 	m.syncSettingsToHookEngine()
 	m.ReconfigureAgentTool()
 	m.applyPersonaSkills()

--- a/internal/app/model_workspace.go
+++ b/internal/app/model_workspace.go
@@ -8,7 +8,6 @@ import (
 	"github.com/genai-io/san/internal/app/trigger"
 	"github.com/genai-io/san/internal/hook"
 	"github.com/genai-io/san/internal/persona"
-	"github.com/genai-io/san/internal/plugin"
 )
 
 func (m *model) changeCwd(newCwd string) {
@@ -39,7 +38,6 @@ func (m *model) ReloadProjectContext(cwd string) {
 	// feature services that depend on them and re-point at them.
 	discoverPlugins(cwd)
 	m.reloadProjectServices(cwd)
-	plugin.MergePluginHooksIntoSettings(m.services.Setting.Snapshot())
 	m.syncSettingsToHookEngine()
 }
 

--- a/internal/app/plugin_hooks_reload_test.go
+++ b/internal/app/plugin_hooks_reload_test.go
@@ -1,0 +1,78 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/genai-io/san/internal/hook"
+	"github.com/genai-io/san/internal/plugin"
+	"github.com/genai-io/san/internal/setting"
+)
+
+// A plugin's hooks have to survive a reload. Both reload paths used to merge
+// them into a throwaway Settings.Snapshot() and then hand the engine a second,
+// unmerged snapshot — so after any cwd change or plugin install the plugin's
+// hooks stopped firing, silently and permanently for that session.
+func TestSyncSettingsToHookEngineCarriesPluginHooks(t *testing.T) {
+	restore := installPluginWithPreToolUseHook(t)
+	defer restore()
+
+	m := &model{
+		services: services{
+			Setting: settingsWithNoHooks(t),
+			Hook:    hook.NewEngine(nil, "", "", ""),
+		},
+	}
+
+	m.syncSettingsToHookEngine()
+
+	if !m.services.Hook.HasHooks(hook.PreToolUse) {
+		t.Error("the engine received settings without the plugin's PreToolUse hook; " +
+			"it would never fire again after a reload")
+	}
+}
+
+// Guards the reason the old code failed: every Snapshot() is an independent
+// deep copy, so merging into one and passing another loses the merge.
+func TestSettingsSnapshotIsIndependentPerCall(t *testing.T) {
+	s := settingsWithNoHooks(t)
+
+	first := s.Snapshot()
+	first.Hooks = map[string][]setting.Hook{"PreToolUse": {{Matcher: "*"}}}
+
+	if second := s.Snapshot(); len(second.Hooks) != 0 {
+		t.Error("Snapshot() shares state between calls; the merge-then-pass-another " +
+			"pattern would silently start working and mask the real contract")
+	}
+}
+
+// settingsWithNoHooks is the zero value deliberately: it isolates the test from
+// whatever hooks the developer's own ~/.san and .san define, so the only hook
+// the engine can see is the plugin's.
+func settingsWithNoHooks(t *testing.T) *setting.Settings {
+	t.Helper()
+	s := &setting.Settings{}
+	if len(s.Snapshot().Hooks) != 0 {
+		t.Fatal("the zero-value Settings should carry no hooks")
+	}
+	return s
+}
+
+// installPluginWithPreToolUseHook registers an enabled plugin contributing one
+// PreToolUse hook, and returns a function restoring the previous registry.
+func installPluginWithPreToolUseHook(t *testing.T) func() {
+	t.Helper()
+	reg := plugin.NewRegistry()
+	reg.Register(&plugin.Plugin{
+		Manifest: plugin.Manifest{Name: "hooky"},
+		Enabled:  true,
+		Components: plugin.Components{
+			Hooks: &plugin.HooksConfig{
+				Hooks: map[string][]plugin.HookMatcher{
+					"PreToolUse": {{Matcher: "Bash"}},
+				},
+			},
+		},
+	})
+	plugin.SetDefaultRegistry(reg)
+	return func() { plugin.SetDefaultRegistry(nil) }
+}


### PR DESCRIPTION
Both reload paths merged plugin hooks into a throwaway `Settings.Snapshot()` (a deep copy), then handed the engine a *second* clean snapshot with none of them — so plugin hooks silently stopped firing after any `cd` or `/plugin install`. Startup (`init.go`) was correct; the reload paths dropped the binding.

Fix: do the merge inside `syncSettingsToHookEngine`, on the exact snapshot passed to `SetSettings`, and remove the two dead call-site merges. A caller can no longer get it wrong.

Tests: a plugin PreToolUse hook is present on the engine after sync (fails without the fix); `Snapshot` is independent per call.