### PR TITLE
fix(transcript): survive a torn final record instead of losing the session

### DIFF
--- a/internal/session/transcript/fs_store.go
+++ b/internal/session/transcript/fs_store.go
@@ -11,6 +11,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/genai-io/san/internal/log"
+	"go.uber.org/zap"
 )
 
 const transcriptIndexFile = "transcripts-index.json"
@@ -827,7 +830,21 @@ func (s *FileStore) loadRecordsLocked(path string) ([]Record, error) {
 		}
 		var rec Record
 		if err := json.Unmarshal([]byte(line), &rec); err != nil {
-			return nil, fmt.Errorf("decode transcript record: %w", err)
+			// The file is append-only and appendRecord fsyncs only on turn
+			// boundaries, so a crash mid-append leaves a partial final line.
+			// That is the one place a torn record can be, and rejecting the
+			// whole file for it means an interrupted turn costs the user the
+			// entire session — every record before it is intact.
+			//
+			// A malformed line anywhere else is not a crash, and silently
+			// dropping it would leave a hole in the replayed conversation with
+			// nothing to show for it, so that still fails loudly.
+			if scanner.Scan() {
+				return nil, fmt.Errorf("decode transcript record: %w", err)
+			}
+			log.Logger().Warn("transcript: dropping torn final record",
+				zap.String("path", path), zap.Error(err))
+			break
 		}
 		records = append(records, rec)
 	}

--- a/internal/session/transcript/torn_record_test.go
+++ b/internal/session/transcript/torn_record_test.go
@@ -1,0 +1,97 @@
+package transcript
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeTwoTurns lays down a transcript with a few complete records.
+func writeTwoTurns(t *testing.T, fs *FileStore, id string) {
+	t.Helper()
+	if err := fs.Start(context.Background(), StartCommand{
+		SessionID: id, ProjectID: "proj", Provider: "anthropic", Model: "model", Time: time.Now(),
+	}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	for _, text := range []string{"first", "second"} {
+		if err := fs.AppendMessage(context.Background(), AppendMessageCommand{
+			SessionID: id, MessageID: id + "-" + text, Time: time.Now(),
+			Role: "user", Content: []ContentBlock{{Type: "text", Text: text}},
+		}); err != nil {
+			t.Fatalf("AppendMessage(%s): %v", text, err)
+		}
+	}
+}
+
+// A crash mid-append leaves a partial final line — appendRecord uses O_APPEND
+// and only fsyncs on turn boundaries. Rejecting the whole file for it meant one
+// interrupted turn cost the user the entire session, even though every record
+// before the tear was intact.
+func TestLoadRecoversFromATornFinalRecord(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := NewFileStore(dir, "proj")
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	writeTwoTurns(t, fs, "crashed")
+
+	// Simulate the tear: the process died partway through writing a record.
+	path := fs.TranscriptPath("crashed")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+	if err := os.WriteFile(path, append(body, []byte(`{"id":"partial","sessi`)...), 0o644); err != nil {
+		t.Fatalf("write torn transcript: %v", err)
+	}
+
+	reopened, err := NewFileStore(dir, "proj")
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	tr, err := reopened.Load(context.Background(), "crashed")
+	if err != nil {
+		t.Fatalf("Load rejected a session whose only damage is a torn tail: %v", err)
+	}
+	if len(tr.Messages) == 0 {
+		t.Fatal("the intact records before the tear were lost")
+	}
+}
+
+// Damage in the middle is not a crash signature. Dropping it silently would
+// leave a hole in the replayed conversation with nothing to show for it, so it
+// must still fail loudly.
+func TestLoadStillRejectsDamageInTheMiddle(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := NewFileStore(dir, "proj")
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	writeTwoTurns(t, fs, "corrupt")
+
+	path := fs.TranscriptPath("corrupt")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(body), "\n"), "\n")
+	if len(lines) < 3 {
+		t.Fatalf("expected at least 3 records, got %d", len(lines))
+	}
+	lines[1] = `{"id":"broken","typ` // damage a record that is not the last
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write corrupt transcript: %v", err)
+	}
+
+	reopened, err := NewFileStore(dir, "proj")
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if _, err := reopened.Load(context.Background(), "corrupt"); err == nil {
+		t.Error("a damaged record in the middle was skipped silently; " +
+			"the replayed conversation would have an invisible hole")
+	}
+}


### PR DESCRIPTION
One torn final JSONL record made a whole session unresumable, even though every record before it was intact. The transcript is append-only and fsyncs only on turn boundaries, so a crash mid-append can only leave a partial *last* line. The write path (`warmupCachesLocked`) already tolerates a bad line; the read path (`loadRecordsLocked`, on the resume path) hard-failed on it — the two were asymmetric.

Fix: drop a torn final line and keep the rest. Damage anywhere but the end is not a crash signature and still fails loudly (a `scanner.Scan()` lookahead distinguishes the two). The dropped line is logged.

Tests: recovers from a torn tail; still rejects mid-file damage.