### PR TITLE
fix(hook): stop swallowing a hook that exited non-zero

### DIFF
--- a/internal/hook/command_failure_test.go
+++ b/internal/hook/command_failure_test.go
@@ -1,0 +1,79 @@
+package hook
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/genai-io/san/internal/setting"
+)
+
+func engineRunning(t *testing.T, command string) *Engine {
+	t.Helper()
+	data := setting.NewData()
+	data.Hooks = map[string][]setting.Hook{
+		string(PreToolUse): {{
+			Matcher: "Bash",
+			Hooks:   []setting.HookCmd{{Type: "command", Command: command}},
+		}},
+	}
+	return NewEngine(data, "test-session", t.TempDir(), "")
+}
+
+// A hook that never worked — a typo, a missing interpreter — used to be
+// indistinguishable from one that succeeded: Error stayed nil, so Execute took
+// neither the warn branch nor the audit-error branch and the run was recorded
+// as "ran", with stderr discarded. The user got nothing.
+func TestNonZeroExitIsReportedNotSwallowed(t *testing.T) {
+	engine := engineRunning(t, "echo 'jq: command not found' >&2; exit 127")
+
+	var audited []HookFiredAudit
+	engine.SetAuditCallback(func(a HookFiredAudit) { audited = append(audited, a) })
+
+	outcome := engine.Execute(context.Background(), PreToolUse, HookInput{ToolName: "Bash"})
+
+	if outcome.ShouldContinue != true {
+		t.Error("a failed hook is not a blocking one; the turn should carry on")
+	}
+	if len(audited) != 1 {
+		t.Fatalf("expected one audit record, got %d", len(audited))
+	}
+	if audited[0].Outcome != outcomeError {
+		t.Errorf("audit outcome = %q, want %q — the failure was recorded as success",
+			audited[0].Outcome, outcomeError)
+	}
+	if !strings.Contains(audited[0].Reason, "command not found") {
+		t.Errorf("audit reason = %q, want the hook's stderr", audited[0].Reason)
+	}
+}
+
+// Exit 2 is the blocking convention and keeps its own path.
+func TestExitTwoStillBlocks(t *testing.T) {
+	engine := engineRunning(t, "echo 'not allowed' >&2; exit 2")
+
+	outcome := engine.Execute(context.Background(), PreToolUse, HookInput{ToolName: "Bash"})
+
+	if outcome.ShouldContinue {
+		t.Error("exit 2 should block the tool call")
+	}
+	if !strings.Contains(outcome.BlockReason, "not allowed") {
+		t.Errorf("BlockReason = %q, want the hook's stderr", outcome.BlockReason)
+	}
+}
+
+// A hook that succeeds must stay clean — no error, no audit noise.
+func TestZeroExitStaysSuccessful(t *testing.T) {
+	engine := engineRunning(t, "exit 0")
+
+	var audited []HookFiredAudit
+	engine.SetAuditCallback(func(a HookFiredAudit) { audited = append(audited, a) })
+
+	outcome := engine.Execute(context.Background(), PreToolUse, HookInput{ToolName: "Bash"})
+
+	if !outcome.ShouldContinue {
+		t.Error("a successful hook should not stop the turn")
+	}
+	if len(audited) != 1 || audited[0].Outcome != outcomeRan {
+		t.Errorf("audit = %+v, want a single %q record", audited, outcomeRan)
+	}
+}

--- a/internal/hook/executors_command.go
+++ b/internal/hook/executors_command.go
@@ -63,9 +63,31 @@ func (e *Engine) executeCommand(ctx context.Context, hookCmd setting.HookCmd, in
 		return handleBlockingExit(&stderr)
 	}
 	if exitCode != 0 {
+		// Report it. Leaving Error nil recorded the run as "ran" and dropped
+		// stderr on the floor, so a hook that never worked — a typo, a missing
+		// interpreter, exit 127 — looked identical to one that succeeded. The
+		// user got no log line, no transcript record and no notice.
+		//
+		// ShouldContinue stays true: a non-zero exit that is not 2 is a failed
+		// hook, not a blocking one, so the turn carries on.
+		outcome.Error = commandFailure(exitCode, &stderr)
 		return outcome
 	}
 	return e.parseOutput(strings.TrimSpace(stdout.String()), outcome)
+}
+
+// commandFailure describes a hook that exited non-zero, carrying the first
+// line of its stderr — which is where the reason lives ("jq: command not
+// found") and was previously discarded.
+func commandFailure(exitCode int, stderr *bytes.Buffer) error {
+	reason := strings.TrimSpace(stderr.String())
+	if i := strings.IndexByte(reason, '\n'); i >= 0 {
+		reason = reason[:i]
+	}
+	if reason == "" {
+		return fmt.Errorf("hook exited %d", exitCode)
+	}
+	return fmt.Errorf("hook exited %d: %s", exitCode, reason)
 }
 
 func (e *Engine) executeCommandBidirectional(ctx context.Context, hookCmd setting.HookCmd, input HookInput) HookOutcome {


### PR DESCRIPTION
A hook exiting non-zero (other than 2) returned a clean outcome with `Error` nil, so `Engine.Execute` audited it as `"ran"` and dropped its stderr. A broken hook — a typo, a missing interpreter, exit 127 — was indistinguishable from a successful one: no log, no transcript record, no notice.

## Severity
Observability, not behavior: the hook did run and the agent keeps working — the failure was just silently mis-recorded as success. Legitimate to fix, but not a functional break.

## Fix
Set `outcome.Error` from the exit code plus the first stderr line. `ShouldContinue` stays true, so `outcomeOf` maps it to `"error"` (warn + audit) without making the hook blocking. This matches `executors_http.go`, which already sets Error on failure while staying non-blocking. Exit 2 keeps its blocking path; exit 0 is untouched.

Tests: non-zero surfaces as an error audit without blocking; exit 2 still blocks; exit 0 stays clean.