### PR TITLE
fix(plugin): stop handing out live pointers to lock-protected state

### DIFF
--- a/internal/plugin/installer.go
+++ b/internal/plugin/installer.go
@@ -24,7 +24,10 @@ type Installer struct {
 // NewInstaller creates a new plugin installer.
 func NewInstaller(registry *Registry, cwd string) *Installer {
 	if registry != nil {
-		registry.cwd = cwd
+		// plugin.Install builds an Installer inside a tea.Cmd goroutine, so a
+		// concurrent cwd change (discoverPlugins -> Load) would race a bare
+		// assignment here.
+		registry.SetCwd(cwd)
 	}
 	return &Installer{
 		registry:           registry,

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -130,6 +130,30 @@ func (r *Registry) loadEnabledPlugins(cwd string) (map[string]bool, error) {
 	return result, nil
 }
 
+// snapshotLocked copies a plugin for a caller to read outside the lock.
+//
+// Enable/Disable write p.Enabled under r.mu, and they run on a tea.Cmd
+// goroutine during /plugin install — after a git clone that can take the full
+// 120s timeout. Handing out the live pointer let the UI read that field while
+// it was being written. The Components slices and maps are shared: they are
+// built once at load time and never mutated after.
+func snapshotLocked(p *Plugin) *Plugin {
+	if p == nil {
+		return nil
+	}
+	cp := *p
+	return &cp
+}
+
+// SetCwd re-points the registry at a working directory. r.cwd is written
+// under r.mu by Load and read under it by saveEnabledState, so a caller
+// outside the package cannot assign it directly.
+func (r *Registry) SetCwd(cwd string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cwd = cwd
+}
+
 // Get returns a plugin by name.
 func (r *Registry) Get(name string) (*Plugin, bool) {
 	r.mu.RLock()
@@ -137,17 +161,17 @@ func (r *Registry) Get(name string) (*Plugin, bool) {
 
 	// Try exact match first
 	if p, ok := r.plugins[name]; ok {
-		return p, true
+		return snapshotLocked(p), true
 	}
 
 	// Try partial match (name without marketplace)
 	for key, p := range r.plugins {
 		if p.Name() == name {
-			return p, true
+			return snapshotLocked(p), true
 		}
 		// Match the prefix before @
 		if idx := len(name); idx < len(key) && key[:idx] == name && key[idx] == '@' {
-			return p, true
+			return snapshotLocked(p), true
 		}
 	}
 
@@ -161,7 +185,7 @@ func (r *Registry) List() []*Plugin {
 
 	plugins := make([]*Plugin, 0, len(r.plugins))
 	for _, p := range r.plugins {
-		plugins = append(plugins, p)
+		plugins = append(plugins, snapshotLocked(p))
 	}
 
 	sort.Slice(plugins, func(i, j int) bool {
@@ -179,7 +203,7 @@ func (r *Registry) GetEnabled() []*Plugin {
 	var enabled []*Plugin
 	for _, p := range r.plugins {
 		if p.Enabled {
-			enabled = append(enabled, p)
+			enabled = append(enabled, snapshotLocked(p))
 		}
 	}
 
@@ -344,7 +368,7 @@ func (r *Registry) GetByScope(scope Scope) []*Plugin {
 	var result []*Plugin
 	for _, p := range r.plugins {
 		if p.Scope == scope {
-			result = append(result, p)
+			result = append(result, snapshotLocked(p))
 		}
 	}
 	return result

--- a/internal/plugin/registry_race_test.go
+++ b/internal/plugin/registry_race_test.go
@@ -1,0 +1,90 @@
+package plugin
+
+import (
+	"sync"
+	"testing"
+)
+
+// Enable/Disable write p.Enabled under r.mu, but the read surface used to hand
+// out the live *Plugin, so callers dereferenced it outside the lock.
+//
+// Reached by: /plugin -> install from a marketplace -> Esc while the clone runs
+// -> reopen /plugin. The install goroutine is still in Enable (after a git
+// clone plus a settings write) while refreshInstalledPlugins reads p.Enabled on
+// the UI goroutine. Run with -race; without the fix this reports DATA RACE.
+func TestReadSurfaceIsSafeAgainstConcurrentEnable(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&Plugin{Manifest: Manifest{Name: "alpha"}})
+	r.Register(&Plugin{Manifest: Manifest{Name: "beta"}, Enabled: true})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() { // the install goroutine
+		defer wg.Done()
+		for range 500 {
+			r.mu.Lock()
+			r.plugins["alpha"].Enabled = !r.plugins["alpha"].Enabled
+			r.mu.Unlock()
+		}
+	}()
+	go func() { // the UI goroutine refreshing the panel
+		defer wg.Done()
+		for range 500 {
+			for _, p := range r.List() {
+				_ = p.Enabled
+			}
+			for _, p := range r.GetEnabled() {
+				_ = p.Enabled
+			}
+			if p, ok := r.Get("alpha"); ok {
+				_ = p.Enabled
+			}
+			for _, p := range r.GetByScope(ScopeUser) {
+				_ = p.Enabled
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
+// A snapshot is a copy, so mutating what a caller was handed must not reach
+// back into the registry.
+func TestReadSurfaceHandsOutCopies(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&Plugin{Manifest: Manifest{Name: "alpha"}, Enabled: true})
+
+	got, ok := r.Get("alpha")
+	if !ok {
+		t.Fatal("Get(alpha) not found")
+	}
+	got.Enabled = false
+
+	again, _ := r.Get("alpha")
+	if !again.Enabled {
+		t.Error("mutating a returned plugin changed the registry's own copy")
+	}
+}
+
+// SetCwd exists so a caller outside the package cannot assign the
+// lock-protected field directly; NewInstaller used to.
+func TestSetCwdIsSafeAgainstConcurrentLoad(t *testing.T) {
+	r := NewRegistry()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range 500 {
+			r.SetCwd("/one")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 500 {
+			r.SetCwd("/two")
+		}
+	}()
+	wg.Wait()
+}


### PR DESCRIPTION
The registry read methods (`Get`/`List`/`GetEnabled`/`GetByScope`) returned the live `*Plugin`, whose `Enabled` field is written under lock by `Enable`/`Disable`. Those writers run in a `tea.Cmd` goroutine during `/plugin install` (after a git clone), while the UI reads `p.Enabled` in `refreshInstalledPlugins` — a genuine race the detector flags. Narrow window, cheap fix.

Fix: read methods return copies. `Enable`/`Disable` mutate the registry’s own map entry by name, so handing out copies changes nothing for them. `Components` slices/maps stay shared (built once at load, never mutated). Also adds a locked `SetCwd` for the same-shaped `NewInstaller` write.

Tests: all four read methods vs a concurrent writer (DATA RACE without the fix); copies do not reach back into the registry.