### PR TITLE
fix(mcp): stop a server teardown freezing the TUI and the agent

### DIFF
--- a/internal/app/input/on_mcp.go
+++ b/internal/app/input/on_mcp.go
@@ -354,7 +354,7 @@ func (s *MCPSelector) HandleConnectResult(msg mcpConnectResultMsg) {
 // Marks the server as disabled so it won't auto-connect on restart.
 func (s *MCPSelector) HandleDisconnect(name string) {
 	if s.registry != nil {
-		_ = s.registry.Disconnect(name)
+		s.registry.Disconnect(name)
 		s.registry.SetDisabled(name, true)
 	}
 	s.refreshAndUpdateView()

--- a/internal/app/input/on_mcp_command.go
+++ b/internal/app/input/on_mcp_command.go
@@ -144,10 +144,7 @@ func handleMCPDisconnect(reg *coremcp.Registry, name string) (string, error) {
 		return "Usage: /mcp disconnect <server-name>", nil
 	}
 
-	if err := reg.Disconnect(name); err != nil {
-		return fmt.Sprintf("Failed to disconnect from %s: %v", name, err), nil
-	}
-
+	reg.Disconnect(name)
 	return fmt.Sprintf("Disconnected from %s", name), nil
 }
 
@@ -343,7 +340,7 @@ func handleMCPReconnect(reg *coremcp.Registry, ctx context.Context, name string)
 		return fmt.Sprintf("Server not found: %s\n\nUse /mcp list to see available servers.", name), nil
 	}
 
-	_ = reg.Disconnect(name)
+	reg.Disconnect(name)
 
 	if err := reg.Connect(ctx, name); err != nil {
 		return fmt.Sprintf("Failed to reconnect to %s: %v", name, err), nil

--- a/internal/mcp/caller.go
+++ b/internal/mcp/caller.go
@@ -65,7 +65,7 @@ func ConnectServers(ctx context.Context, servers Servers, serverNames []string) 
 
 	cleanup = func() {
 		for _, name := range connected {
-			_ = servers.Disconnect(name)
+			servers.Disconnect(name)
 		}
 	}
 	return cleanup, errs

--- a/internal/mcp/disconnect_test.go
+++ b/internal/mcp/disconnect_test.go
@@ -1,0 +1,122 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/genai-io/san/internal/mcp/transport"
+)
+
+// slowTransport takes as long to close as a wedged stdio server: Close waits on
+// the read loop (2s) and then the child's exit (5s).
+type slowTransport struct {
+	closeDelay time.Duration
+	closed     chan struct{}
+}
+
+func newSlowTransport(d time.Duration) *slowTransport {
+	return &slowTransport{closeDelay: d, closed: make(chan struct{})}
+}
+
+func (t *slowTransport) Start(context.Context) error { return nil }
+func (t *slowTransport) Send(context.Context, *transport.JSONRPCRequest) (*transport.JSONRPCResponse, error) {
+	return &transport.JSONRPCResponse{}, nil
+}
+func (t *slowTransport) SendNotification(context.Context, *transport.JSONRPCNotification) error {
+	return nil
+}
+func (t *slowTransport) Close() error {
+	time.Sleep(t.closeDelay)
+	close(t.closed)
+	return nil
+}
+func (t *slowTransport) IsAlive() bool                                        { return true }
+func (t *slowTransport) SetNotificationHandler(transport.NotificationHandler) {}
+
+// Local fixtures: deliberately not shared with other test files in this
+// package, so this change stays independent of any other in-flight one.
+func connectedRegistry(t *testing.T, servers map[string]transport.Transport) *Registry {
+	t.Helper()
+	r := newEmptyRegistry()
+	for name, tr := range servers {
+		cfg := ServerConfig{Name: name, Type: "stdio", Command: name}
+		c := NewClient(cfg)
+		c.TransportFactory = func() (transport.Transport, error) { return tr, nil }
+		c.mu.Lock()
+		c.transport = tr
+		c.connected = true
+		c.mu.Unlock()
+		r.configs[name] = cfg
+		r.clients[name] = c
+	}
+	return r
+}
+
+// Disconnect used to call Client.Disconnect while holding the registry write
+// lock, from the bubbletea Update goroutine. For up to seven seconds per
+// server the UI processed no keys and repainted nothing, and the agent
+// goroutine blocked with it — CallTool takes the read lock.
+func TestDisconnectDoesNotBlockOnATeardown(t *testing.T) {
+	tr := newSlowTransport(500 * time.Millisecond)
+	r := connectedRegistry(t, map[string]transport.Transport{"wedged": tr})
+
+	start := time.Now()
+	r.Disconnect("wedged")
+	elapsed := time.Since(start)
+
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("Disconnect blocked for %v; the UI would be frozen for that long", elapsed)
+	}
+	// The server is gone from the registry immediately, teardown or not.
+	if _, ok := r.GetClient("wedged"); ok {
+		t.Error("the server is still in the registry after Disconnect returned")
+	}
+	// And the lock is free right away, which is what the agent needs.
+	done := make(chan struct{})
+	go func() { r.GetToolSchemas(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Error("the registry lock was still held; the agent goroutine would block too")
+	}
+
+	select {
+	case <-tr.closed:
+	case <-time.After(2 * time.Second):
+		t.Error("the transport was never torn down")
+	}
+}
+
+// DisconnectAll had the same shape, serialized across every server under one
+// deferred lock.
+func TestDisconnectAllDoesNotBlockPerServer(t *testing.T) {
+	servers := map[string]transport.Transport{}
+	transports := make([]*slowTransport, 0, 3)
+	for _, name := range []string{"a", "b", "c"} {
+		tr := newSlowTransport(300 * time.Millisecond)
+		transports = append(transports, tr)
+		servers[name] = tr
+	}
+	r := connectedRegistry(t, servers)
+
+	start := time.Now()
+	r.DisconnectAll()
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Errorf("DisconnectAll blocked for %v", elapsed)
+	}
+
+	for i, tr := range transports {
+		select {
+		case <-tr.closed:
+		case <-time.After(2 * time.Second):
+			t.Errorf("transport %d was never torn down", i)
+		}
+	}
+}
+
+// Disconnecting a server that is not connected is a no-op, not a panic.
+func TestDisconnectUnknownServerIsANoop(t *testing.T) {
+	r := connectedRegistry(t, nil)
+	r.Disconnect("never-connected")
+}

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 
 	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/log"
+	"go.uber.org/zap"
 )
 
 // PluginServer describes an MCP server contributed by a plugin.
@@ -233,31 +235,52 @@ func (r *Registry) ConnectAll(ctx context.Context) []error {
 }
 
 // Disconnect disconnects from an MCP server
-func (r *Registry) Disconnect(name string) error {
+// Disconnect drops a server from the registry. The server is gone from the
+// registry's point of view when this returns; the transport teardown runs in
+// the background.
+//
+// Detached because Client.Disconnect waits on the child's read loop and then
+// its exit — up to seven seconds for a wedged server — and this is called from
+// the bubbletea Update goroutine (the /mcp panel, /mcp disconnect). Doing it
+// inline froze the UI for that whole time, and doing it under r.mu froze the
+// agent goroutine with it, since CallTool takes the read lock.
+func (r *Registry) Disconnect(name string) {
 	r.mu.Lock()
 	client, ok := r.clients[name]
+	if ok {
+		delete(r.clients, name)
+	}
+	r.mu.Unlock()
 	if !ok {
-		r.mu.Unlock()
-		return nil
+		return
 	}
 
-	err := client.Disconnect()
-	delete(r.clients, name)
-	r.mu.Unlock()
-
+	closeInBackground(name, client)
 	r.notifyToolsChanged()
-	return err
 }
 
 // DisconnectAll disconnects from all MCP servers
 func (r *Registry) DisconnectAll() {
 	r.mu.Lock()
-	defer r.mu.Unlock()
+	clients := r.clients
+	r.clients = make(map[string]*Client)
+	r.mu.Unlock()
 
-	for name, client := range r.clients {
-		_ = client.Disconnect()
-		delete(r.clients, name)
+	for name, client := range clients {
+		closeInBackground(name, client)
 	}
+}
+
+// closeInBackground tears a client down off the caller's goroutine, reporting
+// a failure to the log — the caller cannot act on it, and waiting for it is
+// what froze the UI.
+func closeInBackground(name string, client *Client) {
+	go func() {
+		if err := client.Disconnect(); err != nil {
+			log.Logger().Warn("mcp: disconnect failed",
+				zap.String("server", name), zap.Error(err))
+		}
+	}()
 }
 
 // GetClient returns a client by name

--- a/internal/mcp/service.go
+++ b/internal/mcp/service.go
@@ -49,7 +49,7 @@ type Tools interface {
 type Servers interface {
 	List() []Server
 	Connect(ctx context.Context, name string) error
-	Disconnect(name string) error
+	Disconnect(name string)
 	ConnectAll(ctx context.Context) []error
 	DisconnectAll()
 	GetConfig(name string) (ServerConfig, bool)

--- a/tests/integration/mcp/mcp_test.go
+++ b/tests/integration/mcp/mcp_test.go
@@ -1132,10 +1132,9 @@ func TestRealMCP_Registry_EndToEnd(t *testing.T) {
 		t.Errorf("expected echoed message, got: %q", result.Content[0].Text)
 	}
 
-	// Disconnect
-	if err := registry.Disconnect("everything"); err != nil {
-		t.Errorf("Disconnect() error: %v", err)
-	}
+	// Disconnect. The registry drops the server synchronously; the transport
+	// teardown is detached, so nothing to wait on here.
+	registry.Disconnect("everything")
 
 	// After disconnect, tool schemas should be empty
 	schemas = registry.GetToolSchemas()


### PR DESCRIPTION
`Registry.Disconnect` called `Client.Disconnect` (up to 7s for a wedged stdio server) while holding the registry write lock, on the bubbletea Update goroutine. For those seconds the UI processed no keys and repainted nothing, and the agent goroutine stalled too — `CallTool` takes the read lock. `DisconnectAll` was worse: serialized under one lock.

Trigger: `/mcp` → Disable a server whose process is wedged. Everyday action.

Fix: drop the client from the map under the lock (a map delete), tear the transport down in the background. The server is gone from the registry when `Disconnect` returns, which is what callers wait for. The error return is dropped — it only ever carried the transport-close error, not caller-actionable, now logged.

Tests: `Disconnect` returns immediately, the lock is free (a concurrent `GetToolSchemas` completes), the transport still tears down.