### PR TITLE
fix(worktree): make the git calls cancellable

### DIFF
--- a/internal/tool/mode/enterworktree.go
+++ b/internal/tool/mode/enterworktree.go
@@ -57,8 +57,8 @@ func (t *EnterWorktreeTool) ExecuteWithResponse(_ context.Context, params map[st
 }
 
 // Execute is the non-interactive fallback (auto-approve for subagents).
-func (t *EnterWorktreeTool) Execute(_ context.Context, params map[string]any, cwd string) toolresult.ToolResult {
-	result, cleanup, err := worktree.Create(cwd, tool.GetString(params, "name"))
+func (t *EnterWorktreeTool) Execute(ctx context.Context, params map[string]any, cwd string) toolresult.ToolResult {
+	result, cleanup, err := worktree.Create(ctx, cwd, tool.GetString(params, "name"))
 	if err != nil {
 		return toolresult.NewErrorResult(t.Name(), err.Error())
 	}

--- a/internal/tool/mode/exitworktree.go
+++ b/internal/tool/mode/exitworktree.go
@@ -67,7 +67,7 @@ func (t *ExitWorktreeTool) ExecuteWithResponse(_ context.Context, _ map[string]a
 }
 
 // Execute is the non-interactive fallback.
-func (t *ExitWorktreeTool) Execute(_ context.Context, params map[string]any, cwd string) toolresult.ToolResult {
+func (t *ExitWorktreeTool) Execute(ctx context.Context, params map[string]any, cwd string) toolresult.ToolResult {
 	baseCwd, ok := worktree.OriginalPath(cwd)
 	if !ok {
 		return toolresult.NewErrorResult(t.Name(), "ExitWorktree requires an active managed worktree session")
@@ -83,10 +83,10 @@ func (t *ExitWorktreeTool) Execute(_ context.Context, params map[string]any, cwd
 
 	if action == "remove" {
 		discardChanges := tool.GetBool(params, "discard_changes")
-		if worktree.HasUncommittedChanges(cwd) && !discardChanges {
+		if worktree.HasUncommittedChanges(ctx, cwd) && !discardChanges {
 			return toolresult.NewErrorResult(t.Name(), "worktree has uncommitted changes; retry with discard_changes=true or use action=keep")
 		}
-		if err := worktree.Remove(baseCwd, cwd); err != nil {
+		if err := worktree.Remove(ctx, baseCwd, cwd); err != nil {
 			return toolresult.NewErrorResult(t.Name(), err.Error())
 		}
 	}

--- a/internal/worktree/cancel_test.go
+++ b/internal/worktree/cancel_test.go
@@ -1,0 +1,79 @@
+package worktree
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func gitRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"init"},
+		{"-c", "user.email=t@example.com", "-c", "user.name=T", "commit", "--allow-empty", "-m", "init"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Skipf("git %v failed: %s", args, out)
+		}
+	}
+	return dir
+}
+
+// Every git call in this package used exec.Command with no context, and both
+// tool entry points discarded theirs (`Execute(_ context.Context, ...)`). A
+// user pressing Esc could not interrupt the turn: the agent goroutine sat in
+// cmd.Output() until git returned on its own, which for `git worktree add`
+// behind a post-checkout hook, or `git status` behind an lfs smudge filter,
+// can be a long time.
+func TestGitCallsHonourACancelledContext(t *testing.T) {
+	repo := gitRepo(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled, as it would be after Esc
+
+	if _, _, err := Create(ctx, repo, "cancelled"); err == nil {
+		t.Error("Create ignored a cancelled context")
+	}
+	if err := Remove(ctx, repo, repo+"/.git/agent-worktrees/cancelled"); err == nil {
+		t.Error("Remove ignored a cancelled context")
+	}
+	// The predicates fail closed rather than returning an error, so assert they
+	// return promptly instead of blocking on git.
+	done := make(chan struct{})
+	go func() {
+		HasUncommittedChanges(ctx, repo)
+		HasUnmergedCommits(ctx, repo)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Error("the status predicates blocked despite a cancelled context")
+	}
+}
+
+// A live context still works end to end.
+func TestCreateAndRemoveWithALiveContext(t *testing.T) {
+	repo := gitRepo(t)
+	ctx := context.Background()
+
+	result, cleanup, err := Create(ctx, repo, "live")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	defer cleanup()
+
+	if HasUncommittedChanges(ctx, result.Path) {
+		t.Error("a fresh worktree should be clean")
+	}
+	if err := Remove(ctx, repo, result.Path); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+}

--- a/internal/worktree/hooks_test.go
+++ b/internal/worktree/hooks_test.go
@@ -1,6 +1,7 @@
 package worktree
 
 import (
+	"context"
 	"testing"
 
 	"github.com/genai-io/san/internal/hook"
@@ -13,12 +14,12 @@ func TestWorktreeHooksFire(t *testing.T) {
 
 	repo := makeRepo(t)
 
-	result, _, err := Create(repo, "hook-test")
+	result, _, err := Create(context.Background(), repo, "hook-test")
 	if err != nil {
 		t.Fatalf("Create() error: %v", err)
 	}
 
-	if err := Remove(repo, result.Path); err != nil {
+	if err := Remove(context.Background(), repo, result.Path); err != nil {
 		t.Fatalf("Remove() error: %v", err)
 	}
 }

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -4,17 +4,21 @@
 package worktree
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 
 	"github.com/genai-io/san/internal/log"
 )
+
+const gitTimeout = 30 * time.Second
 
 const worktreeDir = "agent-worktrees"
 
@@ -27,7 +31,11 @@ type Result struct {
 // Create creates a git worktree under baseCwd/.git/agent-worktrees/<slug>.
 // If slug is empty, a random short ID is used.
 // Returns the worktree path and a cleanup function that removes it.
-func Create(baseCwd, slug string) (*Result, func(), error) {
+// Every git call here takes ctx. git worktree add can sit in a post-checkout
+// hook, and git status can block on an lfs smudge filter or a network filter
+// driver, so without one an Esc did nothing: the agent goroutine stayed in
+// cmd.Output() and the turn could not be interrupted.
+func Create(ctx context.Context, baseCwd, slug string) (*Result, func(), error) {
 	if slug == "" {
 		b := make([]byte, 4)
 		if _, err := rand.Read(b); err != nil {
@@ -43,14 +51,19 @@ func Create(baseCwd, slug string) (*Result, func(), error) {
 
 	worktreePath := filepath.Join(baseCwd, ".git", worktreeDir, slug)
 
-	cmd := exec.Command("git", "worktree", "add", "--detach", worktreePath)
+	cmd := exec.CommandContext(ctx, "git", "worktree", "add", "--detach", worktreePath)
 	cmd.Dir = baseCwd
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return nil, nil, fmt.Errorf("git worktree add failed: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 
 	cleanup := func() {
-		if err := Remove(baseCwd, worktreePath); err != nil {
+		// Cleanup runs on paths where the caller's ctx may already be done
+		// (a cancelled turn is exactly when the worktree needs removing), so
+		// it gets its own bounded context rather than the caller's.
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), gitTimeout)
+		defer cancel()
+		if err := Remove(cleanupCtx, baseCwd, worktreePath); err != nil {
 			log.Logger().Warn("worktree cleanup failed",
 				zap.String("path", worktreePath),
 				zap.Error(err))
@@ -62,8 +75,8 @@ func Create(baseCwd, slug string) (*Result, func(), error) {
 }
 
 // Remove force-removes a git worktree.
-func Remove(baseCwd, worktreePath string) error {
-	cmd := exec.Command("git", "worktree", "remove", "--force", worktreePath)
+func Remove(ctx context.Context, baseCwd, worktreePath string) error {
+	cmd := exec.CommandContext(ctx, "git", "worktree", "remove", "--force", worktreePath)
 	cmd.Dir = baseCwd
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git worktree remove failed: %s: %w", strings.TrimSpace(string(out)), err)
@@ -73,8 +86,8 @@ func Remove(baseCwd, worktreePath string) error {
 }
 
 // HasUncommittedChanges returns true if the worktree has uncommitted modifications.
-func HasUncommittedChanges(worktreePath string) bool {
-	cmd := exec.Command("git", "status", "--porcelain")
+func HasUncommittedChanges(ctx context.Context, worktreePath string) bool {
+	cmd := exec.CommandContext(ctx, "git", "status", "--porcelain")
 	cmd.Dir = worktreePath
 	out, err := cmd.Output()
 	if err != nil {
@@ -84,8 +97,8 @@ func HasUncommittedChanges(worktreePath string) bool {
 }
 
 // HasUnmergedCommits returns true if the worktree has commits not present in the main repo.
-func HasUnmergedCommits(worktreePath string) bool {
-	cmd := exec.Command("git", "log", "--oneline", "HEAD", "--not", "--remotes", "--max-count=1")
+func HasUnmergedCommits(ctx context.Context, worktreePath string) bool {
+	cmd := exec.CommandContext(ctx, "git", "log", "--oneline", "HEAD", "--not", "--remotes", "--max-count=1")
 	cmd.Dir = worktreePath
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -1,6 +1,7 @@
 package worktree
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -44,7 +45,7 @@ func makeRepo(t *testing.T) string {
 func TestCreateAndRemoveWorktree(t *testing.T) {
 	repo := makeRepo(t)
 
-	result, _, err := Create(repo, "feature-slug")
+	result, _, err := Create(context.Background(), repo, "feature-slug")
 	if err != nil {
 		t.Fatalf("Create() error: %v", err)
 	}
@@ -60,7 +61,7 @@ func TestCreateAndRemoveWorktree(t *testing.T) {
 		t.Fatalf("expected detached worktree branch to be empty, got %q", result.Branch)
 	}
 
-	if err := Remove(repo, result.Path); err != nil {
+	if err := Remove(context.Background(), repo, result.Path); err != nil {
 		t.Fatalf("Remove() error: %v", err)
 	}
 	if _, err := os.Stat(result.Path); !os.IsNotExist(err) {
@@ -71,7 +72,7 @@ func TestCreateAndRemoveWorktree(t *testing.T) {
 func TestCreateRequiresGitRepo(t *testing.T) {
 	nonRepo := t.TempDir()
 
-	_, _, err := Create(nonRepo, "slug")
+	_, _, err := Create(context.Background(), nonRepo, "slug")
 	if err == nil {
 		t.Fatal("expected Create() to fail outside a git repo")
 	}
@@ -82,13 +83,13 @@ func TestCreateRequiresGitRepo(t *testing.T) {
 
 func TestHasUncommittedChanges(t *testing.T) {
 	repo := makeRepo(t)
-	result, cleanup, err := Create(repo, "dirty-check")
+	result, cleanup, err := Create(context.Background(), repo, "dirty-check")
 	if err != nil {
 		t.Fatalf("Create() error: %v", err)
 	}
 	defer cleanup()
 
-	if HasUncommittedChanges(result.Path) {
+	if HasUncommittedChanges(context.Background(), result.Path) {
 		t.Fatal("expected fresh worktree to be clean")
 	}
 
@@ -97,20 +98,20 @@ func TestHasUncommittedChanges(t *testing.T) {
 		t.Fatalf("write README in worktree: %v", err)
 	}
 
-	if !HasUncommittedChanges(result.Path) {
+	if !HasUncommittedChanges(context.Background(), result.Path) {
 		t.Fatal("expected modified worktree to be dirty")
 	}
 }
 
 func TestHasUnmergedCommits(t *testing.T) {
 	repo := makeRepo(t)
-	result, cleanup, err := Create(repo, "commit-check")
+	result, cleanup, err := Create(context.Background(), repo, "commit-check")
 	if err != nil {
 		t.Fatalf("Create() error: %v", err)
 	}
 	defer cleanup()
 
-	if HasUnmergedCommits(result.Path) {
+	if HasUnmergedCommits(context.Background(), result.Path) {
 		t.Fatal("expected fresh worktree to have no unmerged commits")
 	}
 
@@ -123,7 +124,7 @@ func TestHasUnmergedCommits(t *testing.T) {
 	runGit(t, result.Path, "add", "feature.txt")
 	runGit(t, result.Path, "commit", "-m", "feature")
 
-	if !HasUnmergedCommits(result.Path) {
+	if !HasUnmergedCommits(context.Background(), result.Path) {
 		t.Fatal("expected local worktree commit to be reported as unmerged")
 	}
 }


### PR DESCRIPTION
All four git invocations used `exec.Command` with no context:

```go
exec.Command("git", "worktree", "add", "--detach", worktreePath)   // :46
exec.Command("git", "worktree", "remove", "--force", worktreePath) // :66
exec.Command("git", "status", "--porcelain")                       // :77
exec.Command("git", "log", "--oneline", "HEAD", "--not", ...)      // :88
```

and both tool entry points **explicitly discarded** theirs:

```go
func (t *EnterWorktreeTool) Execute(_ context.Context, ...)
func (t *ExitWorktreeTool) Execute(_ context.Context, ...)
```

So pressing Esc did nothing — the agent goroutine sat in `cmd.Output()` until git returned on its own, and the turn could not be interrupted. There was no timeout anywhere either.

## Not a theoretical wait

- `git worktree add` runs the repo's `post-checkout` hook.
- `git status --porcelain` blocks on an lfs smudge filter, a network filter driver, or another process holding the index lock.

## The fix

Thread `ctx` through `Create`, `Remove`, `HasUncommittedChanges` and `HasUnmergedCommits`, and reconnect the `ctx` the two tools were dropping. `session/env.go:11` already uses `exec.CommandContext` for its git call; this brings the package in line.

`Create`'s cleanup closure gets its **own** bounded context rather than the caller's — a cancelled turn is exactly when the worktree needs removing, so inheriting an already-done ctx would leave it on disk.

## Tests

`TestGitCallsHonourACancelledContext` passes an already-cancelled context (the state after Esc) and asserts `Create`/`Remove` error rather than running, and that the two boolean predicates — which fail closed rather than returning an error — return promptly instead of blocking on git. `TestCreateAndRemoveWithALiveContext` covers the normal path end to end.

`make lint`, `gofmt -l` and the full `go test ./...` are clean.