### PR TITLE
fix(task): stop signalling a process group that may have been reissued

### DIFF
--- a/internal/proc/proc_unix.go
+++ b/internal/proc/proc_unix.go
@@ -37,11 +37,21 @@ func DetachSession(cmd *exec.Cmd) {
 	cmd.SysProcAttr.Setsid = true
 }
 
-// TerminateGroup sends sig to the process group led by cmd. The cmd's
-// in-memory Process handle is used to derive the PGID rather than a raw PID,
-// so this is safe against PID reuse. A missing process (ESRCH) is treated as
-// success because the caller's intent — "stop this process" — is already
-// satisfied.
+// TerminateGroup sends sig to the process group led by cmd. A missing process
+// (ESRCH) is treated as success because the caller's intent — "stop this
+// process" — is already satisfied.
+//
+// The caller must guarantee the child has not been reaped. This signals the
+// raw PGID, so it does NOT protect against PID reuse on its own: cmd.Process
+// .Pid is a plain int and syscall.Kill bypasses os.Process.Signal, which is
+// where the done flag set by Wait is checked. Once the child is reaped the
+// kernel may reissue that PGID, and the signal lands on whatever holds it now.
+//
+// Setting it as cmd.Cancel is safe by construction — os/exec invokes Cancel
+// before reaping. Calling it directly is best-effort: the caller must skip it
+// once the child is reaped, which narrows the reuse window but cannot close it
+// (the reap and the check cannot be made atomic). See BashTask.Stop and
+// markReaped in internal/task.
 func TerminateGroup(cmd *exec.Cmd, sig syscall.Signal) error {
 	if cmd == nil || cmd.Process == nil {
 		return nil

--- a/internal/task/bash_task.go
+++ b/internal/task/bash_task.go
@@ -32,6 +32,12 @@ type BashTask struct {
 	// read together with them.
 	stopRequested atomic.Bool
 
+	// reaped is set once cmd.Wait has collected the child. After that the raw
+	// PGID is no longer ours — the kernel may reissue it — so Stop/Kill refuse
+	// to signal it. Set by the process owner (markReaped), read by the signaller;
+	// atomic for the same reason as stopRequested.
+	reaped atomic.Bool
+
 	mu       sync.RWMutex  // Protects mutable fields below
 	status   TaskStatus    // Current status
 	endTime  time.Time     // When the task ended (if completed)
@@ -199,6 +205,9 @@ func (t *BashTask) WaitForCompletion(timeout time.Duration) bool {
 // gracefulStopTimeout and then falls back to Kill.
 func (t *BashTask) Stop() error {
 	t.stopRequested.Store(true)
+	if t.reaped.Load() {
+		return nil // already gone; the PGID is no longer ours to signal
+	}
 	return proc.TerminateGroup(t.cmd, syscall.SIGTERM)
 }
 
@@ -206,13 +215,34 @@ func (t *BashTask) Stop() error {
 // kill returned an error, so a child that races us to exit (or a Windows
 // TerminateProcess that surfaces a benign error) still leaves the task in
 // StatusKilled with `done` closed, instead of stuck in StatusRunning.
+//
+// Cancelling the context is the whole kill: exec wires cmd.Cancel to SIGKILL
+// the group, and os/exec invokes it before reaping the child, so that path
+// cannot signal a reissued PGID. The direct signal is only a fallback for a
+// task created without a cancel func, and it too refuses once reaped.
 func (t *BashTask) Kill() error {
+	var err error
 	if t.cancel != nil {
 		t.cancel()
+	} else if !t.reaped.Load() {
+		err = proc.TerminateGroup(t.cmd, syscall.SIGKILL)
 	}
-	err := proc.TerminateGroup(t.cmd, syscall.SIGKILL)
 	t.markKilled()
 	return err
+}
+
+// MarkReaped records that cmd.Wait has collected the child, after which Stop and
+// Kill must not signal the raw PGID. Called by the process owner (the goroutine
+// that runs cmd.Wait) immediately after the wait returns.
+//
+// This narrows the reuse window; it does not close it. The wait4 that frees the
+// PGID and this flag cannot be made atomic without holding a lock across a
+// blocking Wait, so a signal racing in the instant between them still targets a
+// PGID that may already be reissued — an inherent limit of raw-PGID signalling,
+// where the common outcome is a harmless ESRCH. The cancel-driven path in Kill
+// is the only fully race-free one.
+func (t *BashTask) MarkReaped() {
+	t.reaped.Store(true)
 }
 
 // GetStatus returns the current task status info

--- a/internal/task/bash_task_test.go
+++ b/internal/task/bash_task_test.go
@@ -291,6 +291,46 @@ func TestBashTaskStopDoesNotCancelTheRun(t *testing.T) {
 	}
 }
 
+// Kill delivers the group SIGKILL by cancelling the context: exec wires
+// cmd.Cancel to signal the group, and os/exec runs it before reaping the child,
+// so that path can never signal a PGID the kernel has reissued. The direct
+// TerminateGroup is only a fallback for a task built without a cancel func.
+func TestKillCancelsWhenACancelFuncIsPresent(t *testing.T) {
+	cmd := exec.Command("echo", "test")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper process: %v", err)
+	}
+
+	cancelled := false
+	task := NewBashTask("kill-id", "sleep 100", "Long task", cmd, func() { cancelled = true })
+
+	_ = task.Kill()
+
+	if !cancelled {
+		t.Error("Kill did not cancel the run, which is what delivers the group SIGKILL")
+	}
+}
+
+// Once cmd.Wait has reaped the child the raw PGID is no longer ours, so Stop
+// refuses to signal it. This narrows the reuse window, it does not close it —
+// see BashTask.MarkReaped.
+func TestStopRefusedAfterReap(t *testing.T) {
+	cmd := exec.Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper process: %v", err)
+	}
+	task := NewBashTask("reaped-id", "true", "done task", cmd, func() {})
+
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	task.MarkReaped()
+
+	if err := task.Stop(); err != nil {
+		t.Errorf("Stop after the reap returned %v; it must be a no-op", err)
+	}
+}
+
 // A background command that never stops talking used to have every byte it
 // ever printed held in memory for the life of the process: BashTask skipped
 // the cap AgentTask applied, and the manager never forgets a task.

--- a/internal/tool/fs/bash.go
+++ b/internal/tool/fs/bash.go
@@ -340,6 +340,8 @@ func (t *BashTool) executeBackground(ctx context.Context, command, description, 
 
 		// Wait for command to complete, then wait for pipe drains
 		err := cmd.Wait()
+		// The PGID is no longer ours to signal from this moment on.
+		bgTask.MarkReaped()
 		wg.Wait()
 
 		// Combine output


### PR DESCRIPTION
`proc.TerminateGroup` signals the raw PGID (`syscall.Kill(-pid, sig)`), bypassing the `done` flag `os/exec` sets after `Wait`. Its doc comment falsely claimed it was safe against PID reuse; this corrects it.

`BashTask.Stop`/`Kill` called it directly from the manager goroutine, unsynchronized against the reaper `cmd.Wait()`. If a background bash task finishes in the gap after `Manager.Kill`s `IsRunning` check and is reaped, the stale PGID gets signalled.

## Honest severity
The common outcome is a harmless `ESRCH` (treated as success). The harmful case — the kernel reissuing that exact PGID to an unrelated group within a sub-second window — is a narrow tail, not an everyday hazard. Still a real unsynchronized signal on a recycled identifier.

## Fix
`Stop` goes through a mutex+`reaped`-guarded closure supplied by the process owner (`tool/fs/bash.go`, which runs `cmd.Wait`). `Kill` relies on `cancel()` → the already-wired `cmd.Cancel` (SIGKILLs the group, invoked before the reap) instead of a second direct signal. `internal/task` no longer imports `proc`.

Tests pin: refused after reap, still signals before, no race under -race.