### PR TITLE
fix(app): bound the hooks the UI goroutine waits on

### DIFF
--- a/internal/app/hooks.go
+++ b/internal/app/hooks.go
@@ -6,6 +6,7 @@ package app
 import (
 	"context"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -95,7 +96,39 @@ func (m *model) fireIdleHooksCmd(result core.Result) tea.Cmd {
 	}
 }
 
+// defaultUIHookBudget bounds a hook that the bubbletea goroutine waits on.
+//
+// The engine's own default is 600 seconds (hook.defaultTimeout), which suits a
+// detached hook. Applied to a gate sitting between a keypress and the submit it
+// means a hook that blocks — a network call, an unreachable host, a stray
+// `read` — takes the entire UI with it for ten minutes: nothing repaints, and
+// Esc and Ctrl+C queue up behind the very loop that would dispatch them.
+//
+// The cap applies even to a hook that configured a longer timeout of its own.
+// That configuration is reasonable for a hook running off the UI goroutine; on
+// this path it amounts to asking for a frozen terminal. A hook cut short fails
+// open — the engine logs it, and the user's prompt is not blocked because their
+// hook hung. A deployment with a legitimately slow gate can raise the budget
+// via the hookUITimeout setting (see uiHookBudget).
+const defaultUIHookBudget = 5 * time.Second
+
+// uiHookBudget resolves the deadline for a hook the bubbletea goroutine waits
+// on. It honors the hookUITimeout setting so a legitimately slow prompt gate can
+// raise it, falling back to defaultUIHookBudget for an empty, unparseable, or
+// non-positive value.
+func (m *model) uiHookBudget() time.Duration {
+	if raw := m.services.Setting.HookUITimeout(); raw != "" {
+		if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultUIHookBudget
+}
+
 func (m *model) checkPromptHook(ctx context.Context, prompt string) (bool, string) {
+	ctx, cancel := context.WithTimeout(ctx, m.uiHookBudget())
+	defer cancel()
+
 	outcome := m.services.Hook.Execute(ctx, hook.UserPromptSubmit, hook.HookInput{Prompt: prompt})
 	// UserPromptSubmit hooks may return additionalContext to inject into the
 	// next turn. Enqueue as a <system-reminder> so it rides on the user

--- a/internal/app/model_lifecycle.go
+++ b/internal/app/model_lifecycle.go
@@ -262,7 +262,12 @@ func (f taskLifecycleFunc) TaskCreated(info task.TaskInfo)   { f.onCreated(info)
 func (f taskLifecycleFunc) TaskCompleted(info task.TaskInfo) { f.onCompleted(info) }
 
 func (m *model) FireSessionEnd(reason string) {
-	m.services.Hook.Execute(context.Background(), hook.SessionEnd, hook.HookInput{
+	// Bounded for the same reason as checkPromptHook: this runs on the
+	// bubbletea goroutine while the user is quitting, and a SessionEnd hook
+	// that blocks makes the quit itself look hung.
+	ctx, cancel := context.WithTimeout(context.Background(), m.uiHookBudget())
+	defer cancel()
+	m.services.Hook.Execute(ctx, hook.SessionEnd, hook.HookInput{
 		Reason: reason,
 	})
 	m.services.Hook.ClearSessionHooks()

--- a/internal/app/ui_hook_budget_test.go
+++ b/internal/app/ui_hook_budget_test.go
@@ -1,0 +1,101 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/genai-io/san/internal/hook"
+	"github.com/genai-io/san/internal/reminder"
+	"github.com/genai-io/san/internal/setting"
+)
+
+func modelWithPromptHook(t *testing.T, command string) *model {
+	t.Helper()
+	data := setting.NewData()
+	data.Hooks = map[string][]setting.Hook{
+		string(hook.UserPromptSubmit): {{
+			Hooks: []setting.HookCmd{{
+				Type:    "command",
+				Command: command,
+				// Far longer than the UI budget, and longer than a user would
+				// ever want to stare at a frozen terminal.
+				Timeout: 600,
+			}},
+		}},
+	}
+	return &model{
+		services: services{
+			Hook:     hook.NewEngine(data, "test-session", t.TempDir(), ""),
+			Reminder: reminder.NewService(),
+			Setting:  setting.New(data),
+		},
+	}
+}
+
+// A UserPromptSubmit hook is a gate between a keypress and the submit, and it
+// runs on the bubbletea goroutine. The engine's 600s default is meant for
+// detached hooks; here it froze the whole UI — no repaint, and Esc and Ctrl+C
+// queued behind the loop that would have dispatched them.
+func TestPromptHookCannotFreezeTheUI(t *testing.T) {
+	m := modelWithPromptHook(t, "sleep 30")
+
+	start := time.Now()
+	blocked, _ := m.checkPromptHook(t.Context(), "hello")
+	elapsed := time.Since(start)
+
+	if elapsed > defaultUIHookBudget+2*time.Second {
+		t.Errorf("the UI was blocked for %v; the budget is %v", elapsed, defaultUIHookBudget)
+	}
+	// Fail open: a hook that hung must not swallow the user's prompt.
+	if blocked {
+		t.Error("a hook cut short at the budget blocked the prompt")
+	}
+}
+
+// The budget must not change the answer for a hook that responds in time.
+func TestPromptHookStillBlocksWhenItSaysSo(t *testing.T) {
+	m := modelWithPromptHook(t, "echo 'nope' >&2; exit 2")
+
+	blocked, reason := m.checkPromptHook(t.Context(), "hello")
+
+	if !blocked {
+		t.Fatal("a hook exiting 2 should block the prompt")
+	}
+	if reason == "" {
+		t.Error("the block reason was lost")
+	}
+}
+
+// And a fast hook that permits the prompt still permits it.
+func TestPromptHookAllowsAFastPermit(t *testing.T) {
+	m := modelWithPromptHook(t, "exit 0")
+
+	if blocked, _ := m.checkPromptHook(t.Context(), "hello"); blocked {
+		t.Error("a successful hook blocked the prompt")
+	}
+}
+
+// The budget honors the hookUITimeout setting so a legitimately slow gate can
+// raise it, and falls back to the default for an empty, unparseable, or
+// non-positive value.
+func TestUIHookBudgetHonorsSetting(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want time.Duration
+	}{
+		{"", defaultUIHookBudget},
+		{"20s", 20 * time.Second},
+		{"1500ms", 1500 * time.Millisecond},
+		{"garbage", defaultUIHookBudget},
+		{"0s", defaultUIHookBudget},
+		{"-3s", defaultUIHookBudget},
+	}
+	for _, tc := range cases {
+		data := setting.NewData()
+		data.HookUITimeout = tc.raw
+		m := &model{services: services{Setting: setting.New(data)}}
+		if got := m.uiHookBudget(); got != tc.want {
+			t.Errorf("hookUITimeout=%q: budget=%v, want %v", tc.raw, got, tc.want)
+		}
+	}
+}

--- a/internal/setting/service.go
+++ b/internal/setting/service.go
@@ -29,6 +29,12 @@ func Default() *Settings {
 	return defaultSettings
 }
 
+// New wraps a *Data in a live *Settings handle, independent of the package-level
+// default. Intended for tests and any caller that needs an isolated instance.
+func New(d *Data) *Settings {
+	return &Settings{data: d}
+}
+
 // DefaultIfInit returns the package-level *Settings, or nil if it
 // has not been initialized with real settings yet.
 func DefaultIfInit() *Settings {
@@ -154,6 +160,15 @@ func (s *Settings) StreamIdleTimeout() string {
 		return ""
 	}
 	return s.data.StreamIdleTimeout
+}
+
+func (s *Settings) HookUITimeout() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.data == nil {
+		return ""
+	}
+	return s.data.HookUITimeout
 }
 
 // SelfLearn returns just the self-learning settings, by value. Unlike

--- a/internal/setting/settings.go
+++ b/internal/setting/settings.go
@@ -44,6 +44,11 @@ type Data struct {
 	// chunks once a stream has started. A valid time.Duration string (e.g. "60s",
 	// "120s"); empty = core default.
 	StreamIdleTimeout string `json:"streamIdleTimeout,omitempty"`
+	// HookUITimeout bounds a hook the UI goroutine waits on (UserPromptSubmit,
+	// SessionEnd) before it is cut short and the prompt proceeds. Raise it for a
+	// legitimately slow prompt gate (e.g. a network-backed secret scanner). A
+	// valid time.Duration string (e.g. "5s", "20s"); empty = the 5s default.
+	HookUITimeout string `json:"hookUITimeout,omitempty"`
 	// ContextBar toggles the visual context-usage bar ([██████░░░░] 71%) in
 	// the status line. Pointer so an explicit "off" persists distinctly from
 	// "unset"; nil (unset) means off — the bar is opt-in. The numeric
@@ -719,6 +724,7 @@ func (s *Data) Clone() *Data {
 	dst.SearchProvider = s.SearchProvider
 	dst.StreamFirstChunkTimeout = s.StreamFirstChunkTimeout
 	dst.StreamIdleTimeout = s.StreamIdleTimeout
+	dst.HookUITimeout = s.HookUITimeout
 	dst.Persona = s.Persona
 	dst.SelfLearn = s.SelfLearn // value-typed; shallow copy is correct
 	dst.AutoPilot = s.AutoPilot.Clone()


### PR DESCRIPTION
Two hooks run synchronously on the bubbletea goroutine with `context.Background()` and the engine’s 600s default: `checkPromptHook` (UserPromptSubmit) and `FireSessionEnd`. A hook that blocks — a network call, an unreachable host, a stray `read` — freezes the whole UI for up to ten minutes; Esc and Ctrl+C queue behind the loop that would dispatch them.

Fix: a 5s `uiHookBudget` on these two call sites. Fails open — a cut hook does not block the prompt, and the engine already reports the timeout.

## Trade-off (worth a look)
The cap also shortens a hook that legitimately set a longer timeout. A blocking UserPromptSubmit hook (e.g. a secret scanner) would let the prompt proceed unscanned after 5s. Defensible — a frozen terminal is worse — but the 5s constant is a policy choice; could be made settable.

Tests: a 30s hook with `timeout: 600` returns within the budget and does not block; a fast exit-2 still blocks, exit-0 still permits.