### PR TITLE
fix(cron): stop one san window deleting another's scheduled jobs

### DIFF
--- a/internal/cron/cross_instance_test.go
+++ b/internal/cron/cross_instance_test.go
@@ -1,0 +1,137 @@
+package cron
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// instanceOn models a san process attached to a project's storage file.
+func instanceOn(t *testing.T, path string) *Scheduler {
+	t.Helper()
+	s := NewScheduler()
+	s.SetStoragePath(path)
+	if err := s.LoadDurable(); err != nil {
+		t.Fatalf("LoadDurable: %v", err)
+	}
+	return s
+}
+
+func durableIDsOnDisk(t *testing.T, path string) map[string]bool {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]bool{}
+		}
+		t.Fatalf("read storage: %v", err)
+	}
+	var jobs []*Job
+	if err := json.Unmarshal(data, &jobs); err != nil {
+		t.Fatalf("parse storage: %v", err)
+	}
+	ids := make(map[string]bool, len(jobs))
+	for _, j := range jobs {
+		ids[j.ID] = true
+	}
+	return ids
+}
+
+// The storage path is per-project, not per-process, so two san windows open on
+// one repo share it. LoadDurable runs once at startup, so a job created in the
+// other window was simply absent from this one's view — and the next save
+// erased it from disk, with neither user having touched it.
+func TestSavePreservesAnotherInstancesJob(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "scheduled_tasks.json")
+
+	windowA := instanceOn(t, path)
+	windowB := instanceOn(t, path) // booted before A creates anything
+
+	jobA, err := windowA.Create("*/10 * * * *", "check the tests", true, true)
+	if err != nil {
+		t.Fatalf("Create in window A: %v", err)
+	}
+
+	// Anything that changes B's durable set rewrites the file from B's view.
+	jobB, err := windowB.Create("*/5 * * * *", "run the linter", true, true)
+	if err != nil {
+		t.Fatalf("Create in window B: %v", err)
+	}
+
+	ids := durableIDsOnDisk(t, path)
+	if !ids[jobA.ID] {
+		t.Error("window A's job was erased by window B's save")
+	}
+	if !ids[jobB.ID] {
+		t.Error("window B's own job is missing from disk")
+	}
+}
+
+// Preserving another instance's jobs must not resurrect ones this instance
+// deliberately removed — the naive "merge with disk" would do exactly that.
+func TestDeleteIsNotUndoneByThePreservation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "scheduled_tasks.json")
+
+	window := instanceOn(t, path)
+	job, err := window.Create("*/10 * * * *", "check the tests", true, true)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if ids := durableIDsOnDisk(t, path); !ids[job.ID] {
+		t.Fatal("the job was never written")
+	}
+
+	if err := window.Delete(job.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if ids := durableIDsOnDisk(t, path); ids[job.ID] {
+		t.Error("a deleted job came back from disk")
+	}
+}
+
+// A job adopted at boot belongs to this process, so removing it is a removal
+// rather than another instance's job to carry over.
+func TestDeleteAfterRestartStillRemoves(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "scheduled_tasks.json")
+
+	first := instanceOn(t, path)
+	job, err := first.Create("*/10 * * * *", "check the tests", true, true)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// A fresh process picks the job up from disk, then the user deletes it.
+	restarted := instanceOn(t, path)
+	if !restarted.Remove(job.ID) {
+		t.Fatal("the restarted process did not find the job it loaded")
+	}
+
+	if ids := durableIDsOnDisk(t, path); ids[job.ID] {
+		t.Error("the job survived a delete made after a restart")
+	}
+}
+
+// Session-only jobs never reach the file, whoever else is writing it.
+func TestSessionJobsStayOutOfTheSharedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "scheduled_tasks.json")
+
+	window := instanceOn(t, path)
+	durable, err := window.Create("*/10 * * * *", "durable", true, true)
+	if err != nil {
+		t.Fatalf("Create durable: %v", err)
+	}
+	session, err := window.Create("*/10 * * * *", "session only", true, false)
+	if err != nil {
+		t.Fatalf("Create session: %v", err)
+	}
+
+	ids := durableIDsOnDisk(t, path)
+	if !ids[durable.ID] {
+		t.Error("the durable job is missing")
+	}
+	if ids[session.ID] {
+		t.Error("a session-only job was persisted")
+	}
+}

--- a/internal/cron/store.go
+++ b/internal/cron/store.go
@@ -51,12 +51,18 @@ type Scheduler struct {
 	mu          sync.RWMutex
 	jobs        map[string]*Job
 	storagePath string // file path for durable job persistence (empty = disabled)
+	// knownDurable records every durable job id this process has held, so a
+	// save can tell "I removed this" from "another instance created it". The
+	// storage file is per-project, not per-process, and two san windows open on
+	// one repo share it.
+	knownDurable map[string]bool
 }
 
 // NewScheduler creates a new in-memory *Scheduler.
 func NewScheduler() *Scheduler {
 	return &Scheduler{
-		jobs: make(map[string]*Job),
+		jobs:         make(map[string]*Job),
+		knownDurable: make(map[string]bool),
 	}
 }
 
@@ -299,6 +305,35 @@ func (s *Scheduler) SetStoragePath(path string) {
 	s.storagePath = path
 }
 
+// foreignDurableLocked returns the durable jobs currently on disk that belong
+// to another instance: ones this process has never held. Read failures yield
+// nothing, which degrades to the previous behaviour rather than refusing the
+// save.
+func (s *Scheduler) foreignDurableLocked(mine []*Job) []*Job {
+	data, err := os.ReadFile(s.storagePath)
+	if err != nil {
+		return nil
+	}
+	var onDisk []*Job
+	if err := json.Unmarshal(data, &onDisk); err != nil {
+		return nil
+	}
+
+	held := make(map[string]bool, len(mine))
+	for _, job := range mine {
+		held[job.ID] = true
+	}
+
+	var foreign []*Job
+	for _, job := range onDisk {
+		if held[job.ID] || s.knownDurable[job.ID] {
+			continue
+		}
+		foreign = append(foreign, job)
+	}
+	return foreign
+}
+
 // LoadDurable reads durable jobs from the storage file and merges them into the store.
 func (s *Scheduler) LoadDurable() error {
 	s.mu.Lock()
@@ -351,6 +386,9 @@ func (s *Scheduler) LoadDurable() error {
 		}
 		job.Durable = true
 		s.jobs[job.ID] = job
+		// Adopted at boot, so this process owns it: a later removal here is a
+		// removal, not another instance's job to preserve.
+		s.knownDurable[job.ID] = true
 	}
 
 	return nil
@@ -404,6 +442,21 @@ func estimateRecurringPeriod(expr *expression, base time.Time) time.Duration {
 
 // saveDurableLocked writes all durable jobs to the storage file.
 // Must be called with s.mu held.
+// saveDurableLocked writes this process's durable jobs, preserving any the
+// file holds that belong to another instance.
+//
+// The storage path is per-project, so two san windows open on one repo write
+// the same file. Writing only the in-memory view erased whatever the other
+// instance had added since this one booted — LoadDurable runs once, at
+// startup, so a job created in the other window was simply not in this view.
+// A durable job could vanish from disk without either user doing anything to
+// it.
+//
+// Jobs this process never knew about are carried over verbatim: their
+// schedule state belongs to the instance that owns them, and adopting them
+// into s.jobs would put them through LoadDurable's boot-time NextFire
+// recalculation, which is wrong mid-session. Jobs it did know about and no
+// longer holds were deliberately removed, so they stay removed.
 func (s *Scheduler) saveDurableLocked() {
 	if s.storagePath == "" {
 		return
@@ -413,8 +466,10 @@ func (s *Scheduler) saveDurableLocked() {
 	for _, job := range s.jobs {
 		if job.Durable {
 			durable = append(durable, job)
+			s.knownDurable[job.ID] = true
 		}
 	}
+	durable = append(durable, s.foreignDurableLocked(durable)...)
 
 	data, err := json.MarshalIndent(durable, "", "  ")
 	if err != nil {

--- a/internal/cron/store.go
+++ b/internal/cron/store.go
@@ -440,8 +440,6 @@ func estimateRecurringPeriod(expr *expression, base time.Time) time.Duration {
 	return next.Sub(base)
 }
 
-// saveDurableLocked writes all durable jobs to the storage file.
-// Must be called with s.mu held.
 // saveDurableLocked writes this process's durable jobs, preserving any the
 // file holds that belong to another instance.
 //


### PR DESCRIPTION
The durable-job file is **per-project, not per-process**: `<project>/.san/scheduled_tasks.json`. Two san windows open on the same repo write it.

`LoadDurable` runs once, at startup (`app/init.go:54`), and `saveDurableLocked` rewrote the file from the in-memory view. So a job created in one window was simply absent from the other's view, and the other's next save erased it from disk.

```
window A:  /loop 10m check the tests   -> file becomes [X]
window B:  any durable change          -> file becomes [B's jobs], X gone
```

Any durable change triggers that save — including a job **firing or expiring** (`store.go:166`, `:184`). Neither user has to touch the vanished job for it to go.

## The fix

A save now carries over the durable jobs on disk that this process has never held. Two things it deliberately is **not**:

**Not a merge into memory.** Their schedule state belongs to the instance that owns them, and adopting them into `s.jobs` would put them through `LoadDurable`'s boot-time `NextFire` recalculation. That recalculation is right for a restart — it stops a long-lived schedule replaying missed intervals — but applied mid-session it pushes a recurring job's next fire out on every save, and the job never runs.

**Not a merge with disk.** The obvious "re-read and union" resurrects a job this window deliberately deleted, because disk still has it. `knownDurable` records every durable id this process has held, which is what separates *"I removed this"* from *"another instance created it"*.

## Not addressed

**Double firing.** Two windows that were both running when a job was created each hold it and each tick it, so its prompt is injected twice. Fixing that means sharing fire state across processes, which needs the schedule-ownership question above answered first — a bigger design call than this data-loss fix, and separable from it.

## Tests

`TestSavePreservesAnotherInstancesJob` runs two schedulers on one file and asserts neither erases the other — reverting the fix fails it with *"window A's job was erased by window B's save"*. `TestDeleteIsNotUndoneByThePreservation` pins that a delete is not resurrected, `TestDeleteAfterRestartStillRemoves` covers a job adopted at boot and then removed, and `TestSessionJobsStayOutOfTheSharedFile` checks session-only jobs never reach it.

`make lint`, `gofmt -l` and the full `go test ./...` are clean.