### PR TITLE
feat(tracker): tint agent-owned rows and fold finished overflow

### DIFF
--- a/internal/app/conv/tracker_view.go
+++ b/internal/app/conv/tracker_view.go
@@ -37,6 +37,11 @@ type TrackerListParams struct {
 	// Blink is the shared frame-tick counter (see FrameClock.Frame) that
 	// drives the in-progress pulse via trackerPulseTicks.
 	Blink int
+	// AgentColors maps an agent's name to its display color. An item owned by a
+	// background agent (Owner set) is tinted with that color, matching the
+	// agent's launch line in the flow. Plain user todos have no owner and keep
+	// the status palette.
+	AgentColors map[string]string
 }
 
 // RenderTrackerList renders the tracker panel above the input area.
@@ -70,10 +75,14 @@ func RenderTrackerList(params TrackerListParams) string {
 		mutedStyle.Render(fmt.Sprintf("(%d%%)", ended*100/len(params.Items))))
 	sb.WriteString("\n")
 
-	visible := params.Items[max(0, len(params.Items)-maxVisibleItems):]
-	if hidden := len(params.Items) - len(visible); hidden > 0 {
-		// Name the drop; a silent truncation reads as the whole list.
-		sb.WriteString("  " + overflowStyle.Render(fmt.Sprintf("+%d more above", hidden)) + "\n")
+	// Items stay in ID order so rows hold their place as work advances — no
+	// reshuffle churn. When the list overflows the row budget, the oldest
+	// cleanly-finished items fold into one summary line: active and pending
+	// work, which is what the panel exists to surface, is never hidden.
+	folded := leadingFinishedToFold(params.Items)
+	visible := params.Items[folded:]
+	if folded > 0 {
+		sb.WriteString(renderFoldedLine(folded))
 	}
 
 	idWidth := itemIDWidth(visible)
@@ -83,10 +92,33 @@ func RenderTrackerList(params TrackerListParams) string {
 	// no worker can still be advancing.
 	for _, t := range visible {
 		phase := phaseOf(t, params.Executing != nil && params.Executing(t))
-		sb.WriteString(renderItem(t, phase, params.Width, idWidth, params.Blockers, params.Blink))
+		sb.WriteString(renderItem(t, phase, params.Width, idWidth, params.Blockers, params.Blink, params.AgentColors))
 	}
 
 	return sb.String()
+}
+
+// leadingFinishedToFold reports how many items at the front of the list should
+// collapse into a summary line: the contiguous run of cleanly-finished items,
+// capped at the overflow past maxVisibleItems. An aborted/failed item breaks the
+// run, so a failure is never folded out of sight.
+func leadingFinishedToFold(items []*todo.Item) int {
+	if len(items) <= maxVisibleItems {
+		return 0
+	}
+	overflow := len(items) - maxVisibleItems
+	folded := 0
+	for folded < overflow && phaseOf(items[folded], false) == itemFinished {
+		folded++
+	}
+	return folded
+}
+
+// renderFoldedLine renders the collapsed-finished summary row that stands in for
+// the leading run of completed items.
+func renderFoldedLine(n int) string {
+	mutedStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
+	return "  " + trackerCompletedStyle.Render("●") + "  " + mutedStyle.Render(fmt.Sprintf("%d completed", n)) + "\n"
 }
 
 // itemPhase is how an item reads to the user. It collapses the recorded status,
@@ -132,12 +164,24 @@ func activeText(t *todo.Item, maxTextLen int) string {
 	return kit.TruncateText(text, maxTextLen)
 }
 
-func renderItem(t *todo.Item, phase itemPhase, width, idWidth int, blockers func(string) []string, blink int) string {
+func renderItem(t *todo.Item, phase itemPhase, width, idWidth int, blockers func(string) []string, blink int, agentColors map[string]string) string {
 	indent := "  "
 	idTag := fmt.Sprintf("%-*s", idWidth, "#"+t.ID)
 	maxTextLen := max(width-len(indent)-idWidth-8, 12)
 	subject := kit.TruncateText(t.Subject, maxTextLen)
 	mutedStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
+
+	// A row owned by a background agent wears that agent's color (icon + text),
+	// mirroring its launch line in the flow; a plain todo keeps the status
+	// palette. Aborted rows stay error-red and stalled rows stay muted — those
+	// states carry more meaning than whose agent produced them.
+	agentFg, owned := agentForeground(t, agentColors)
+	tint := func(s lipgloss.Style) lipgloss.Style {
+		if owned {
+			return s.Foreground(agentFg)
+		}
+		return s
+	}
 
 	switch phase {
 	case itemAborted:
@@ -146,7 +190,7 @@ func renderItem(t *todo.Item, phase itemPhase, width, idWidth int, blockers func
 		return renderItemLine(indent, abortedStyle.Render("!"), idTag, subject, detail)
 
 	case itemFinished:
-		return renderItemLine(indent, trackerCompletedStyle.Render("●"), idTag, subject, "")
+		return renderItemLine(indent, tint(trackerCompletedStyle).Render("●"), idTag, tint(lipgloss.NewStyle()).Render(subject), "")
 
 	case itemStalled:
 		// Nothing is executing this item, so draw it at rest. Reaching here
@@ -160,7 +204,7 @@ func renderItem(t *todo.Item, phase itemPhase, width, idWidth int, blockers func
 		// rather than the wall clock, which only sampled on redraws and so
 		// flickered irregularly.
 		activeIcon := "●"
-		activeStyle := trackerInProgressStyle
+		activeStyle := tint(trackerInProgressStyle)
 		if (blink/trackerPulseTicks)%2 == 1 {
 			activeIcon = "◌"
 			activeStyle = mutedStyle
@@ -169,7 +213,7 @@ func renderItem(t *todo.Item, phase itemPhase, width, idWidth int, blockers func
 		if elapsed := formatElapsedTime(t.StatusChangedAt); elapsed != "" {
 			detail = mutedStyle.Render(elapsed)
 		}
-		return renderItemLine(indent, activeStyle.Render(activeIcon), idTag, activeText(t, maxTextLen), detail)
+		return renderItemLine(indent, activeStyle.Render(activeIcon), idTag, tint(lipgloss.NewStyle()).Render(activeText(t, maxTextLen)), detail)
 
 	default:
 		detail := ""
@@ -183,8 +227,22 @@ func renderItem(t *todo.Item, phase itemPhase, width, idWidth int, blockers func
 				detail = blockedStyle.Render("← " + strings.Join(blockerRefs, ", "))
 			}
 		}
-		return renderItemLine(indent, trackerPendingStyle.Render("○"), idTag, subject, detail)
+		return renderItemLine(indent, tint(trackerPendingStyle).Render("○"), idTag, tint(lipgloss.NewStyle()).Render(subject), detail)
 	}
+}
+
+// agentForeground returns the owning agent's display color for an item, and
+// whether the item is owned by a colored agent at all — a plain user todo has no
+// owner, and an owner with no configured color resolves to nothing.
+func agentForeground(t *todo.Item, agentColors map[string]string) (kit.AdaptiveColor, bool) {
+	if t.Owner == "" || len(agentColors) == 0 {
+		return kit.AdaptiveColor{}, false
+	}
+	color, ok := agentColors[strings.ToLower(t.Owner)]
+	if !ok || color == "" {
+		return kit.AdaptiveColor{}, false
+	}
+	return agentColor(color), true
 }
 
 func renderItemLine(indent, icon, id, subject, detail string) string {

--- a/internal/app/conv/tracker_view_test.go
+++ b/internal/app/conv/tracker_view_test.go
@@ -71,7 +71,7 @@ func TestRenderTaskAnimatesInProgressItem(t *testing.T) {
 	// both the solid (●) and dim (◌) phases.
 	var hasSolid, hasDim bool
 	for blink := range 4 * trackerPulseTicks {
-		frame := stripANSI(renderItem(task, itemRunning, 80, 2, nil, blink))
+		frame := stripANSI(renderItem(task, itemRunning, 80, 2, nil, blink, nil))
 		if strings.Contains(frame, "●") {
 			hasSolid = true
 		}
@@ -123,9 +123,9 @@ func TestRenderTrackerListOrdersByID(t *testing.T) {
 func TestRenderTaskHoldsStillWhenStalled(t *testing.T) {
 	task := &todo.Item{ID: "1", Subject: "Fix auth module", Status: todo.StatusInProgress}
 
-	first := stripANSI(renderItem(task, itemStalled, 80, 2, nil, 0))
+	first := stripANSI(renderItem(task, itemStalled, 80, 2, nil, 0, nil))
 	for blink := range 4 * trackerPulseTicks {
-		if frame := stripANSI(renderItem(task, itemStalled, 80, 2, nil, blink)); frame != first {
+		if frame := stripANSI(renderItem(task, itemStalled, 80, 2, nil, blink, nil)); frame != first {
 			t.Fatalf("stalled task animated across frames:\n%q\n%q", first, frame)
 		}
 	}
@@ -169,9 +169,10 @@ func TestRenderTrackerListVisibility(t *testing.T) {
 	}
 }
 
-// The list outlives the turn that filled it, so windowing from the front would
-// pin the panel to the turn that stalled and hide everything since.
-func TestRenderTrackerListWindowsOnNewestTasks(t *testing.T) {
+// When the list overflows the row budget, the oldest cleanly-finished items
+// fold into one summary line; the active and pending tail — the work still in
+// flight — always stays on screen.
+func TestRenderTrackerListFoldsLeadingFinished(t *testing.T) {
 	tasks := make([]*todo.Item, 0, maxVisibleItems+3)
 	for i := 1; i <= maxVisibleItems+3; i++ {
 		id := strconv.Itoa(i)
@@ -181,14 +182,16 @@ func TestRenderTrackerListWindowsOnNewestTasks(t *testing.T) {
 			Status:  todo.StatusCompleted,
 		})
 	}
-	// The oldest task is the one left open, so it is what keeps the list alive.
-	tasks[0].Status = todo.StatusInProgress
+	// The tail is the work still in flight — it must never fold away.
+	tasks[len(tasks)-3].Status = todo.StatusInProgress // #9
+	tasks[len(tasks)-2].Status = todo.StatusPending    // #10
+	tasks[len(tasks)-1].Status = todo.StatusPending    // #11
 
 	plain := stripANSI(RenderTrackerList(TrackerListParams{
 		Items:        tasks,
 		StreamActive: true,
 		Width:        120,
-		Executing:    func(*todo.Item) bool { return false },
+		Executing:    func(*todo.Item) bool { return true },
 	}))
 
 	ids := taskIDRe.FindAllString(plain, -1)
@@ -196,8 +199,42 @@ func TestRenderTrackerListWindowsOnNewestTasks(t *testing.T) {
 	if !slices.Equal(ids, want) {
 		t.Fatalf("visible tasks:\n  got:  %v\n  want: %v\n\nfull output:\n%s", ids, want, plain)
 	}
-	if !strings.Contains(plain, "+3 more above") {
-		t.Fatalf("hidden tasks should be counted, not dropped silently:\n%s", plain)
+	if !strings.Contains(plain, "3 completed") {
+		t.Fatalf("folded finished items should be summarized, not dropped silently:\n%s", plain)
+	}
+}
+
+// A row owned by a background agent is tinted with that agent's color; a plain
+// todo keeps the status palette. The tint changes only color, never the text.
+func TestRenderItemTintsAgentOwnedRows(t *testing.T) {
+	item := &todo.Item{ID: "1", Subject: "Audit deps", Status: todo.StatusInProgress, Owner: "explorer"}
+	colors := map[string]string{"explorer": "yellow"}
+
+	plain := renderItem(item, itemRunning, 80, 2, nil, 0, nil)
+	tinted := renderItem(item, itemRunning, 80, 2, nil, 0, colors)
+
+	if stripANSI(plain) != stripANSI(tinted) {
+		t.Fatalf("agent tint changed the row text, not just its color:\n  %q\n  %q", stripANSI(plain), stripANSI(tinted))
+	}
+	if plain == tinted {
+		t.Fatalf("agent-owned row should be tinted with the agent color, got identical output:\n%q", tinted)
+	}
+}
+
+func TestAgentForeground(t *testing.T) {
+	colors := map[string]string{"explorer": "yellow"}
+
+	if _, ok := agentForeground(&todo.Item{Owner: "explorer"}, colors); !ok {
+		t.Fatal("agent-owned item should resolve its color")
+	}
+	if _, ok := agentForeground(&todo.Item{Owner: "Explorer"}, colors); !ok {
+		t.Fatal("owner lookup should be case-insensitive")
+	}
+	if _, ok := agentForeground(&todo.Item{Owner: ""}, colors); ok {
+		t.Fatal("a plain todo (no owner) must not resolve a color")
+	}
+	if _, ok := agentForeground(&todo.Item{Owner: "ghost"}, colors); ok {
+		t.Fatal("an owner with no configured color must not resolve one")
 	}
 }
 

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -268,6 +268,7 @@ func (m *model) renderTrackerList() string {
 		Blockers:     m.services.Tracker.OpenBlockers,
 		Executing:    m.executingTrackerItem,
 		Blink:        m.conv.Spinner.Frame(),
+		AgentColors:  m.agentColors(),
 	})
 }
 


### PR DESCRIPTION
## What

Two changes to the tracker panel (`internal/app/conv/tracker_view.go`):

### 1. Tint agent-owned rows with the agent's color

A tracker row created for a background agent (`Owner` set by `TrackWorker`)
now renders its icon **and** text in that agent's color, resolved from
`AgentColors` via the existing `agentColor` mapping. This mirrors the
agent-colored launch line already shown in the conversation flow, so a
running/completed agent reads as the same color everywhere.

Plain user todos (no owner) keep the existing status palette. Aborted rows
stay error-red and stalled rows stay muted — those states carry more meaning
than whose agent produced them, so the tint deliberately skips them.

### 2. Fold the leading finished run on overflow

Replaces the newest-window overflow (`+N more above`) with a fold: when the
list exceeds `maxVisibleItems`, the leading run of cleanly-finished items
collapses into one `● N completed` summary line. Rows stay in ID order and
the active/pending tail — the work the panel exists to surface — is never
hidden behind the fold. A failed/killed item breaks the run, so a failure is
never folded out of sight.

This is a deliberate change of overflow policy: the previous behavior pinned
the window to the newest rows and could drop an in-progress item that sat
near the front. Folding keeps in-flight work visible while still bounding the
oldest completed noise.

## Tests

- `TestRenderTrackerListFoldsLeadingFinished` — leading finished items fold
  into `N completed`; active/pending tail stays visible (replaces the old
  windows-on-newest test).
- `TestRenderItemTintsAgentOwnedRows` — agent tint changes only color, not
  text; unowned rows are untouched.
- `TestAgentForeground` — owner→color resolution, case-insensitive, and the
  no-owner / unknown-owner negative cases.

Existing tracker tests (phase classification, stalled hold-still, visibility
gate, ID ordering) pass unchanged. `go build ./...`, `go vet`, and the full
`internal/app/conv` suite are green.
