### PR TITLE
fix(subagent): keep the task tracker parent-only

### DIFF
--- a/internal/tool/set.go
+++ b/internal/tool/set.go
@@ -9,10 +9,21 @@ import (
 // parentOnlyTools are tools that only the main conversation can use.
 // Subagents never get these regardless of their allow list. Agent is here
 // because the agent model is flat: only main spawns workers.
+//
+// The task tracker tools are parent-only for the same reason: the tracker is
+// the main conversation's plan, and every conversation shares the one
+// process-global todo store. A subagent calling TaskCreate/TaskUpdate would
+// leak its private planning into the main panel (showing up as extra rows next
+// to the worker item that already represents it), and TaskList/TaskGet would
+// hand it back the main plan it has no business reading.
 var parentOnlyTools = map[string]bool{
 	ToolAgent:         true,
 	ToolEnterWorktree: true,
 	ToolExitWorktree:  true,
+	ToolTaskCreate:    true,
+	ToolTaskUpdate:    true,
+	ToolTaskList:      true,
+	ToolTaskGet:       true,
 }
 
 // Set provides tools for a conversation turn.

--- a/internal/tool/set_test.go
+++ b/internal/tool/set_test.go
@@ -1,0 +1,32 @@
+package tool
+
+import "testing"
+
+// The task tracker is the main conversation's plan, and every conversation
+// shares one process-global todo store. Letting a subagent call the tracker
+// tools leaks its private planning into the main panel, so they must be
+// parent-only — even an explicit allow list cannot opt a subagent back in.
+func TestSubagentsCannotUseTrackerTools(t *testing.T) {
+	trackerTools := []string{ToolTaskCreate, ToolTaskUpdate, ToolTaskList, ToolTaskGet}
+
+	main := (&Set{}).Tools()
+	for _, name := range trackerTools {
+		if !schemasContain(main, name) {
+			t.Errorf("main conversation should keep %s", name)
+		}
+	}
+
+	agentAll := (&Set{IsAgent: true}).Tools()
+	for _, name := range trackerTools {
+		if schemasContain(agentAll, name) {
+			t.Errorf("subagent (all tools) must not get %s", name)
+		}
+	}
+
+	agentAllow := (&Set{IsAgent: true, Allow: trackerTools}).Tools()
+	for _, name := range trackerTools {
+		if schemasContain(agentAllow, name) {
+			t.Errorf("subagent must not get %s even when it is allow-listed", name)
+		}
+	}
+}

--- a/internal/tool/set_test.go
+++ b/internal/tool/set_test.go
@@ -30,3 +30,15 @@ func TestSubagentsCannotUseTrackerTools(t *testing.T) {
 		}
 	}
 }
+
+// Dropping the tracker tools from a subagent's schema also drops their
+// executors: the subagent's runnable tool set is built from that schema, so a
+// hallucinated TaskCreate call hits "unknown tool" instead of creating a row.
+func TestSubagentToolExecutorsExcludeTracker(t *testing.T) {
+	tools := AdaptToolRegistry((&Set{IsAgent: true}).Tools(), func() string { return "" })
+	for _, name := range []string{ToolTaskCreate, ToolTaskUpdate, ToolTaskList, ToolTaskGet} {
+		if tools.Get(name) != nil {
+			t.Errorf("subagent must have no executor for %s", name)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Launch three background research agents and the task panel shows extra rows —
up to six entries for three agents:

```
Tasks (0%)
 ●  #1  Sandbox: 调研 sandbox 现状      17s
 ●  #2  Guardrails: 调研 guardrails 现状  ...
 ●  #3  Infra: 调研 agent infra 现状     ...
 ◌  #4  正在调研 agent infra 现状  [stalled]   ← leaked from the infra subagent
```

`#4` is not something the main conversation created. Every conversation shares
one process-global `todo.Default()` store, and subagents get the tracker tools
by default. When a background subagent calls `TaskCreate` to plan its own work,
that item lands in the **main** session's panel — right next to the worker item
(`#3`) that already represents the same subagent. The `[stalled]` label is the
liveness gate correctly reporting that nothing in the main session is executing
that row; it simply should never have appeared.

## Fix

Add `TaskCreate` / `TaskUpdate` / `TaskList` / `TaskGet` to `parentOnlyTools`,
next to `Agent` and the worktree tools. The task tracker is the main
conversation's plan; subagents have no business writing to it (leaks) or
reading it (exposes the main plan). Both tool-resolution paths already honor
`parentOnlyTools`, so this holds regardless of a subagent's allow list. A
subagent's progress is still surfaced by the worker item the main conversation
creates for it.

## Test

`TestSubagentsCannotUseTrackerTools` asserts the main conversation keeps the
four tracker tools, an all-tools subagent gets none of them, and an explicit
allow list cannot opt a subagent back in. Full `internal/tool` and
`internal/subagent` suites pass; `go vet`, `gofmt`, and layercheck are clean.
