### PR TITLE
fix(conv): drop the streaming caret that stranded a vertical line

### DIFF
--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -50,6 +50,15 @@ func toolResultIcon(isError bool) string {
 // construction.
 const InputPrompt = "❭ "
 
+// streamCursor is the block caret drawn at the live streaming tail. It is a
+// reverse-video space, not a block glyph like "▌": U+258C and its kin are
+// East-Asian *ambiguous* width — measured as one cell by lipgloss/bubbletea but
+// painted two cells wide by CJK terminals. Redrawn every frame at the growing
+// edge of streaming text, the half-cell the differ never reclaims strands a
+// stale caret mid-line (issue #374). A space is unambiguously one cell in every
+// mode; reverse video gives it the same block-caret look without the drift.
+var streamCursor = lipgloss.NewStyle().Reverse(true).Render(" ")
+
 var (
 	userMsgStyle = lipgloss.NewStyle()
 
@@ -391,7 +400,7 @@ func formatAssistantContent(params AssistantParams) string {
 		// Plain-wrap the streaming tail so its \n-line count matches the height
 		// calc; reserve streamWrapReserve cols (gutter + last-column slack).
 		wrapWidth := max(params.Width-streamWrapReserve, minWrapWidth)
-		return lipgloss.NewStyle().Width(wrapWidth).Render(params.Content + "▌")
+		return lipgloss.NewStyle().Width(wrapWidth).Render(params.Content + streamCursor)
 	}
 
 	if params.Content == "" {


### PR DESCRIPTION
The live streaming tail appended a `▌` caret (U+258C) after the text — an East-Asian ambiguous-width glyph that lipgloss/bubbletea measure as one cell but CJK terminals paint two. Redrawn every frame at the growing edge, the half-cell the differ never reclaims stranded a stale caret mid-line: the unexpected vertical bar in #374.

Drop the caret entirely; the leading spinner already signals a live turn. In the momentary gap right after a block commits (empty remainder) a lone space keeps that spinner on screen, so nothing trails the streamed text.

Closes #374
