### PR TITLE
feat(bash): show a live output counter on running commands

### DIFF
--- a/internal/agent/build.go
+++ b/internal/agent/build.go
@@ -57,6 +57,7 @@ type BuildParams struct {
 	HookEngine       hook.Handler
 	AskUser          tool.AskUserFunc
 	ToolActivity     func(toolCallID string, msg string)
+	ToolProgress     func(toolCallID string, lines int, bytes int64)
 	// BashPromptResponder answers prompts a command raises *while it runs*
 	// (AutoPilot.BashPrompt plus the masked secret input) — a separate concern
 	// from the pre-execution gate above.
@@ -103,6 +104,9 @@ func buildAgent(p BuildParams) (core.Agent, *PermissionGate, error) {
 	}
 	if p.ToolActivity != nil {
 		adaptOpts = append(adaptOpts, tool.WithToolActivity(p.ToolActivity))
+	}
+	if p.ToolProgress != nil {
+		adaptOpts = append(adaptOpts, tool.WithToolProgress(p.ToolProgress))
 	}
 	if p.BashPromptResponder != nil {
 		adaptOpts = append(adaptOpts, tool.WithBashPromptResponderProvider(p.BashPromptResponder))

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -159,6 +159,9 @@ func (m *model) buildAgentParams() agent.BuildParams {
 		ToolActivity: func(toolCallID string, msg string) {
 			m.conv.AgentToUI.SendForToolCall(toolCallID, msg)
 		},
+		ToolProgress: func(toolCallID string, lines int, bytes int64) {
+			m.conv.AgentToUI.SendToolProgress(toolCallID, conv.FormatToolProgress(lines, bytes))
+		},
 		BashPromptResponder: func(ctx context.Context) tool.BashPromptResponder {
 			// Interactive answering is opt-in via the Bash steer, read live (via
 			// the synchronized snapshot — this runs on the agent goroutine) so a

--- a/internal/app/conv/agent_to_ui.go
+++ b/internal/app/conv/agent_to_ui.go
@@ -12,10 +12,15 @@ import (
 // AgentActivityMsg carries one activity line from a running agent — its model,
 // its mode, a tool it is calling, "Thinking...", or token usage. Lines
 // accumulate into the per-agent activity feed the TUI renders.
+//
+// A message with Progress set is instead a running command's latest output
+// counter (keyed by ToolCallID): it replaces the previous value rather than
+// appending, and never joins the activity feed.
 type AgentActivityMsg struct {
 	Index      int
 	ToolCallID string
 	Message    string
+	Progress   bool
 }
 
 // AgentToUITickMsg is the idle heartbeat: Check emits it when no message is
@@ -56,6 +61,16 @@ func (h *AgentToUI) SendForAgent(index int, msg string) {
 func (h *AgentToUI) SendForToolCall(toolCallID string, msg string) {
 	select {
 	case h.ch <- AgentActivityMsg{Index: -1, ToolCallID: toolCallID, Message: msg}:
+	default:
+	}
+}
+
+// SendToolProgress enqueues the latest output counter for a running tool call.
+// It is a replaceable snapshot, not a feed line: a full channel simply drops it
+// and the next tick re-sends, so a running command never blocks on the UI.
+func (h *AgentToUI) SendToolProgress(toolCallID string, text string) {
+	select {
+	case h.ch <- AgentActivityMsg{Index: -1, ToolCallID: toolCallID, Message: text, Progress: true}:
 	default:
 	}
 }
@@ -154,6 +169,9 @@ func (h *AgentToUI) Drain(taskActivity map[int][]string) map[int][]string {
 	for {
 		select {
 		case u := <-h.ch:
+			if u.Progress {
+				continue // ephemeral output counter, not a feed line
+			}
 			if taskActivity == nil {
 				taskActivity = make(map[int][]string)
 			}

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"charm.land/lipgloss/v2"
 	xansi "github.com/charmbracelet/x/ansi"
@@ -492,16 +493,19 @@ type ToolCallsParams struct {
 	TaskActivity      map[int][]string
 	PendingCalls      []core.ToolCall
 	CurrentIdx        int
-	ModelName         string
-	InputTokens       int
-	OutputTokens      int
-	Blink             int
-	AgentColors       map[string]string
-	SpinnerView       string
-	TaskOwnerMap      map[string]string
-	MDRenderer        *MDRenderer
-	Width             int
-	Interactive       bool
+	// ToolStartedAt maps a running tool call's ID to when it began executing,
+	// for the live elapsed timer on its row. Only in-flight calls appear.
+	ToolStartedAt map[string]time.Time
+	ModelName     string
+	InputTokens   int
+	OutputTokens  int
+	Blink         int
+	AgentColors   map[string]string
+	SpinnerView   string
+	TaskOwnerMap  map[string]string
+	MDRenderer    *MDRenderer
+	Width         int
+	Interactive   bool
 }
 
 // ToolResultData holds the data needed to render a tool result inline.
@@ -565,15 +569,17 @@ func RenderToolCalls(params ToolCallsParams) string {
 			if _, hasResult := params.ResultMap[tc.ID]; hasResult {
 				icon = "●"
 			}
+			var row string
 			if tc.Name == tool.ToolTaskGet && params.TaskOwnerMap != nil {
 				args := extractTaskGetDisplay(tc.Input, params.TaskOwnerMap)
-				sb.WriteString(renderToolLineWithIcon(fmt.Sprintf("%s(%s)", tc.Name, args), params.Width, icon) + "\n")
+				row = renderToolLineWithIcon(fmt.Sprintf("%s(%s)", tc.Name, args), params.Width, icon) + "\n"
 			} else if tc.Name == tool.ToolBash {
-				sb.WriteString(renderBashToolCall(tc.Input, params.Width, icon))
+				row = renderBashToolCall(tc.Input, params.Width, icon)
 			} else {
 				args := extractToolArgs(tc.Input)
-				sb.WriteString(renderToolLineWithIcon(fmt.Sprintf("%s(%s)", tc.Name, args), params.Width, icon) + "\n")
+				row = renderToolLineWithIcon(fmt.Sprintf("%s(%s)", tc.Name, args), params.Width, icon) + "\n"
 			}
+			sb.WriteString(appendRowDetail(row, runningElapsedDetail(tc, params)))
 		}
 
 		if resultData, ok := params.ResultMap[tc.ID]; ok {
@@ -618,6 +624,42 @@ func toolCallIcon(tc core.ToolCall, pendingCalls []core.ToolCall, currentIdx int
 	}
 
 	return "●"
+}
+
+// runningElapsedDetail returns a dim " · 12s" suffix for a tool call that is
+// still executing and has run at least a second — long enough to be worth
+// telling the user it is alive and how long it has taken. A call that has
+// finished (its result is in) or has not started (no start stamp) gets "".
+// The stamp map only holds in-flight calls, so membership already gates this:
+// a not-yet-current sequential call has no entry and shows nothing.
+func runningElapsedDetail(tc core.ToolCall, params ToolCallsParams) string {
+	if _, done := params.ResultMap[tc.ID]; done {
+		return ""
+	}
+	started, ok := params.ToolStartedAt[tc.ID]
+	if !ok {
+		return ""
+	}
+	elapsed := formatElapsedTime(started)
+	if elapsed == "" {
+		return ""
+	}
+	return toolResultStyle.Render(" · " + elapsed)
+}
+
+// appendRowDetail splices a trailing detail (an already-styled elapsed timer)
+// into the first line of an already-rendered tool row, right before its
+// newline — so a multi-line Bash block carries the timer on its header, not
+// buried beside the command. Newlines never sit inside an ANSI escape, so
+// slicing at the first one is safe.
+func appendRowDetail(row, detail string) string {
+	if detail == "" {
+		return row
+	}
+	if nl := strings.IndexByte(row, '\n'); nl != -1 {
+		return row[:nl] + detail + row[nl:]
+	}
+	return row + detail
 }
 
 // stripMarkdownHeading removes leading `#` markers from markdown headings.

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -496,16 +496,19 @@ type ToolCallsParams struct {
 	// ToolStartedAt maps a running tool call's ID to when it began executing,
 	// for the live elapsed timer on its row. Only in-flight calls appear.
 	ToolStartedAt map[string]time.Time
-	ModelName     string
-	InputTokens   int
-	OutputTokens  int
-	Blink         int
-	AgentColors   map[string]string
-	SpinnerView   string
-	TaskOwnerMap  map[string]string
-	MDRenderer    *MDRenderer
-	Width         int
-	Interactive   bool
+	// ToolProgress maps a running command's ID to its latest output counter,
+	// shown next to the timer. Empty for calls that have produced no output.
+	ToolProgress map[string]string
+	ModelName    string
+	InputTokens  int
+	OutputTokens int
+	Blink        int
+	AgentColors  map[string]string
+	SpinnerView  string
+	TaskOwnerMap map[string]string
+	MDRenderer   *MDRenderer
+	Width        int
+	Interactive  bool
 }
 
 // ToolResultData holds the data needed to render a tool result inline.
@@ -579,7 +582,7 @@ func RenderToolCalls(params ToolCallsParams) string {
 				args := extractToolArgs(tc.Input)
 				row = renderToolLineWithIcon(fmt.Sprintf("%s(%s)", tc.Name, args), params.Width, icon) + "\n"
 			}
-			sb.WriteString(appendRowDetail(row, runningElapsedDetail(tc, params)))
+			sb.WriteString(appendRowDetail(row, runningRowDetail(tc, params)))
 		}
 
 		if resultData, ok := params.ResultMap[tc.ID]; ok {
@@ -626,13 +629,14 @@ func toolCallIcon(tc core.ToolCall, pendingCalls []core.ToolCall, currentIdx int
 	return "●"
 }
 
-// runningElapsedDetail returns a dim " · 12s" suffix for a tool call that is
-// still executing and has run at least a second — long enough to be worth
-// telling the user it is alive and how long it has taken. A call that has
+// runningRowDetail returns a dim " · 12s · 1.2k lines" suffix for a tool call
+// that is still executing and has run at least a second — long enough to be
+// worth telling the user it is alive, how long it has taken, and (for a command
+// producing output) that output is flowing rather than hung. A call that has
 // finished (its result is in) or has not started (no start stamp) gets "".
 // The stamp map only holds in-flight calls, so membership already gates this:
 // a not-yet-current sequential call has no entry and shows nothing.
-func runningElapsedDetail(tc core.ToolCall, params ToolCallsParams) string {
+func runningRowDetail(tc core.ToolCall, params ToolCallsParams) string {
 	if _, done := params.ResultMap[tc.ID]; done {
 		return ""
 	}
@@ -644,7 +648,11 @@ func runningElapsedDetail(tc core.ToolCall, params ToolCallsParams) string {
 	if elapsed == "" {
 		return ""
 	}
-	return toolResultStyle.Render(" · " + elapsed)
+	detail := " · " + elapsed
+	if progress := params.ToolProgress[tc.ID]; progress != "" {
+		detail += " · " + progress
+	}
+	return toolResultStyle.Render(detail)
 }
 
 // appendRowDetail splices a trailing detail (an already-styled elapsed timer)

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -3,6 +3,7 @@ package conv
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"charm.land/lipgloss/v2"
 
@@ -422,6 +423,76 @@ func TestRenderToolCallsShowsRunningStateForPendingBash(t *testing.T) {
 	}
 	if strings.Contains(rendered, "running...") {
 		t.Fatalf("RenderToolCalls() = %q, should not add extra running text", rendered)
+	}
+}
+
+func TestRenderToolCallsShowsElapsedTimerOnRunningBash(t *testing.T) {
+	call := core.ToolCall{ID: "tc-1", Name: "Bash", Input: `{"command":"npm test"}`}
+	params := ToolCallsParams{
+		ToolCalls:     []core.ToolCall{call},
+		ResultMap:     map[string]ToolResultData{},
+		PendingCalls:  []core.ToolCall{call},
+		CurrentIdx:    0,
+		SpinnerView:   "⋯",
+		Width:         100,
+		ToolStartedAt: map[string]time.Time{"tc-1": time.Now().Add(-12 * time.Second)},
+	}
+
+	rendered := stripANSI(RenderToolCalls(params))
+	if !strings.Contains(rendered, "⋯ Bash(npm test)") {
+		t.Fatalf("RenderToolCalls() = %q, want spinner on the tool line", rendered)
+	}
+	if !strings.Contains(rendered, "· 12s") {
+		t.Fatalf("RenderToolCalls() = %q, want an elapsed timer on the running row", rendered)
+	}
+}
+
+func TestRenderToolCallsHidesTimerForSubSecondAndCompletedCalls(t *testing.T) {
+	call := core.ToolCall{ID: "tc-1", Name: "Bash", Input: `{"command":"npm test"}`}
+	base := ToolCallsParams{
+		ToolCalls:    []core.ToolCall{call},
+		PendingCalls: []core.ToolCall{call},
+		CurrentIdx:   0,
+		SpinnerView:  "⋯",
+		Width:        100,
+	}
+
+	// Under a second old: too brief to be worth a timer.
+	fresh := base
+	fresh.ResultMap = map[string]ToolResultData{}
+	fresh.ToolStartedAt = map[string]time.Time{"tc-1": time.Now()}
+	if got := stripANSI(RenderToolCalls(fresh)); strings.Contains(got, "·") {
+		t.Fatalf("RenderToolCalls() = %q, want no timer under a second", got)
+	}
+
+	// Finished: the result is in, so the row is static with no timer.
+	done := base
+	done.ResultMap = map[string]ToolResultData{"tc-1": {ToolName: "Bash", Content: "ok"}}
+	done.ToolStartedAt = map[string]time.Time{"tc-1": time.Now().Add(-time.Minute)}
+	if got := stripANSI(RenderToolCalls(done)); strings.Contains(got, "·") {
+		t.Fatalf("RenderToolCalls() = %q, want no timer once the call has completed", got)
+	}
+}
+
+func TestRenderToolCallsPutsTimerOnBashHeaderForMultilineCommand(t *testing.T) {
+	call := core.ToolCall{ID: "tc-1", Name: "Bash", Input: `{"command":"line one\nline two\nline three"}`}
+	params := ToolCallsParams{
+		ToolCalls:     []core.ToolCall{call},
+		ResultMap:     map[string]ToolResultData{},
+		PendingCalls:  []core.ToolCall{call},
+		CurrentIdx:    0,
+		SpinnerView:   "⋯",
+		Width:         100,
+		ToolStartedAt: map[string]time.Time{"tc-1": time.Now().Add(-90 * time.Second)},
+	}
+
+	rendered := stripANSI(RenderToolCalls(params))
+	header := strings.SplitN(rendered, "\n", 2)[0]
+	if !strings.Contains(header, "· 1m 30s") {
+		t.Fatalf("RenderToolCalls() header = %q, want the timer on the Bash header line", header)
+	}
+	if strings.Contains(rendered, "$  line one · 1m 30s") {
+		t.Fatalf("RenderToolCalls() = %q, timer must not land on the command line", rendered)
 	}
 }
 

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -447,6 +447,66 @@ func TestRenderToolCallsShowsElapsedTimerOnRunningBash(t *testing.T) {
 	}
 }
 
+func TestFormatToolProgress(t *testing.T) {
+	cases := []struct {
+		lines int
+		bytes int64
+		want  string
+	}{
+		{0, 0, ""},
+		{1, 6, "1 line"},
+		{42, 900, "42 lines"},
+		{1500, 40000, "1.5k lines"},
+		{0, 200, "200 B"},
+		{0, 2048, "2.0 KB"},
+		{0, 5 * 1024 * 1024, "5.0 MB"},
+	}
+	for _, c := range cases {
+		if got := FormatToolProgress(c.lines, c.bytes); got != c.want {
+			t.Errorf("FormatToolProgress(%d, %d) = %q, want %q", c.lines, c.bytes, got, c.want)
+		}
+	}
+}
+
+func TestRenderToolCallsShowsOutputCounterNextToTimer(t *testing.T) {
+	call := core.ToolCall{ID: "tc-1", Name: "Bash", Input: `{"command":"npm test"}`}
+	params := ToolCallsParams{
+		ToolCalls:     []core.ToolCall{call},
+		ResultMap:     map[string]ToolResultData{},
+		PendingCalls:  []core.ToolCall{call},
+		CurrentIdx:    0,
+		SpinnerView:   "⋯",
+		Width:         100,
+		ToolStartedAt: map[string]time.Time{"tc-1": time.Now().Add(-8 * time.Second)},
+		ToolProgress:  map[string]string{"tc-1": "1.2k lines"},
+	}
+
+	rendered := stripANSI(RenderToolCalls(params))
+	if !strings.Contains(rendered, "· 8s · 1.2k lines") {
+		t.Fatalf("RenderToolCalls() = %q, want the timer and output counter together", rendered)
+	}
+}
+
+func TestRenderToolCallsHidesCounterWithoutTimer(t *testing.T) {
+	call := core.ToolCall{ID: "tc-1", Name: "Bash", Input: `{"command":"npm test"}`}
+	// Output has arrived but the call is under a second old: no timer, so no
+	// counter either — a sub-second row stays clean.
+	params := ToolCallsParams{
+		ToolCalls:     []core.ToolCall{call},
+		ResultMap:     map[string]ToolResultData{},
+		PendingCalls:  []core.ToolCall{call},
+		CurrentIdx:    0,
+		SpinnerView:   "⋯",
+		Width:         100,
+		ToolStartedAt: map[string]time.Time{"tc-1": time.Now()},
+		ToolProgress:  map[string]string{"tc-1": "42 lines"},
+	}
+
+	if got := stripANSI(RenderToolCalls(params)); strings.Contains(got, "42 lines") {
+		t.Fatalf("RenderToolCalls() = %q, want no counter before the one-second timer appears", got)
+	}
+}
+
 func TestRenderToolCallsHidesTimerForSubSecondAndCompletedCalls(t *testing.T) {
 	call := core.ToolCall{ID: "tc-1", Name: "Bash", Input: `{"command":"npm test"}`}
 	base := ToolCallsParams{

--- a/internal/app/conv/tool.go
+++ b/internal/app/conv/tool.go
@@ -24,8 +24,12 @@ type ToolExecState struct {
 	// on a running row, so a long command no longer looks stuck. Only
 	// in-flight calls appear; it is cleared with every new batch.
 	StartedAt map[string]time.Time
-	Ctx       context.Context
-	Cancel    context.CancelFunc
+	// Progress holds the latest output counter of a running command ("1.2k
+	// lines"), keyed by tool-call ID — the replaceable companion to the
+	// elapsed timer, showing output is actually flowing. Cleared with StartedAt.
+	Progress map[string]string
+	Ctx      context.Context
+	Cancel   context.CancelFunc
 }
 
 func (t *ToolExecState) Begin() context.Context {
@@ -49,12 +53,14 @@ func (t *ToolExecState) Reset() {
 	}
 	t.ClearPending()
 	t.StartedAt = nil
+	t.Progress = nil
 	t.Ctx = nil
 	t.Cancel = nil
 }
 
 func (t *ToolExecState) Track(calls []core.ToolCall) {
 	t.StartedAt = nil
+	t.Progress = nil
 	if len(calls) == 0 {
 		t.ClearPending()
 		return
@@ -79,6 +85,19 @@ func (t *ToolExecState) MarkStarted(toolCallID string) {
 		t.StartedAt = make(map[string]time.Time)
 	}
 	t.StartedAt[toolCallID] = time.Now()
+}
+
+// SetProgress records the latest output counter for a running tool call. A blank
+// text clears it (nothing to show yet).
+func (t *ToolExecState) SetProgress(toolCallID, text string) {
+	if text == "" {
+		delete(t.Progress, toolCallID)
+		return
+	}
+	if t.Progress == nil {
+		t.Progress = make(map[string]string)
+	}
+	t.Progress[toolCallID] = text
 }
 
 func (t *ToolExecState) IndexOf(toolCallID string) int {

--- a/internal/app/conv/tool.go
+++ b/internal/app/conv/tool.go
@@ -19,8 +19,13 @@ import (
 type ToolExecState struct {
 	PendingCalls []core.ToolCall
 	CurrentIdx   int
-	Ctx          context.Context
-	Cancel       context.CancelFunc
+	// StartedAt stamps when each call began executing (its PreToolEvent),
+	// keyed by tool-call ID. The view reads it to show a live elapsed timer
+	// on a running row, so a long command no longer looks stuck. Only
+	// in-flight calls appear; it is cleared with every new batch.
+	StartedAt map[string]time.Time
+	Ctx       context.Context
+	Cancel    context.CancelFunc
 }
 
 func (t *ToolExecState) Begin() context.Context {
@@ -43,11 +48,13 @@ func (t *ToolExecState) Reset() {
 		t.Cancel()
 	}
 	t.ClearPending()
+	t.StartedAt = nil
 	t.Ctx = nil
 	t.Cancel = nil
 }
 
 func (t *ToolExecState) Track(calls []core.ToolCall) {
+	t.StartedAt = nil
 	if len(calls) == 0 {
 		t.ClearPending()
 		return
@@ -63,6 +70,15 @@ func (t *ToolExecState) MarkCurrent(toolCallID string) {
 			return
 		}
 	}
+}
+
+// MarkStarted stamps the moment a tool call began executing, so the view can
+// show how long it has been running. Called once per call, on its PreToolEvent.
+func (t *ToolExecState) MarkStarted(toolCallID string) {
+	if t.StartedAt == nil {
+		t.StartedAt = make(map[string]time.Time)
+	}
+	t.StartedAt[toolCallID] = time.Now()
 }
 
 func (t *ToolExecState) IndexOf(toolCallID string) int {

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -917,6 +917,29 @@ func extractParenContent(s, fallback string) string {
 	return s[start+1 : start+end]
 }
 
+// FormatToolProgress renders a running command's cumulative output as a short
+// counter for the live row: line count once any newline has arrived, falling
+// back to a byte size for output that has not broken a line yet (a progress
+// bar, a single long token). Empty output yields "" so nothing is shown.
+func FormatToolProgress(lines int, bytes int64) string {
+	switch {
+	case lines == 1:
+		return "1 line"
+	case lines >= 1000:
+		return fmt.Sprintf("%.1fk lines", float64(lines)/1000)
+	case lines > 1:
+		return fmt.Sprintf("%d lines", lines)
+	case bytes <= 0:
+		return ""
+	case bytes < 1024:
+		return fmt.Sprintf("%d B", bytes)
+	case bytes < 1024*1024:
+		return fmt.Sprintf("%.1f KB", float64(bytes)/1024)
+	default:
+		return fmt.Sprintf("%.1f MB", float64(bytes)/(1024*1024))
+	}
+}
+
 func formatLineCount(content string) string {
 	trimmed := strings.TrimSuffix(content, "\n")
 	if trimmed == "" {

--- a/internal/app/conv/update.go
+++ b/internal/app/conv/update.go
@@ -30,6 +30,9 @@ func Update(rt Runtime, m *Model, msg tea.Msg) (tea.Cmd, bool) {
 	case kit.TokenLimitResultMsg:
 		return rt.OnTokenLimitResult(msg), true
 	case AgentActivityMsg:
+		if msg.Progress {
+			return m.HandleToolProgress(msg), true
+		}
 		if msg.Index < 0 && msg.ToolCallID != "" {
 			msg.Index = m.Tool.IndexOf(msg.ToolCallID)
 		}
@@ -307,6 +310,16 @@ func (m *OutputModel) HandleActivity(msg AgentActivityMsg) tea.Cmd {
 		m.TaskActivity[msg.Index] = m.TaskActivity[msg.Index][len(m.TaskActivity[msg.Index])-maxAgentActivityHistory:]
 	}
 
+	if m.AgentToUI == nil {
+		return m.Spinner.Tick
+	}
+	return tea.Batch(m.Spinner.Tick, m.AgentToUI.Check())
+}
+
+// HandleToolProgress records a running command's latest output counter and
+// keeps the animation/poll loop alive so the row redraws with the new value.
+func (m *Model) HandleToolProgress(msg AgentActivityMsg) tea.Cmd {
+	m.Tool.SetProgress(msg.ToolCallID, msg.Message)
 	if m.AgentToUI == nil {
 		return m.Spinner.Tick
 	}

--- a/internal/app/conv/update.go
+++ b/internal/app/conv/update.go
@@ -245,6 +245,7 @@ func applyPreTool(m *Model, ev core.Event) {
 	if tc, ok := ev.ToolCall(); ok {
 		m.Stream.BuildingTool = tc.Name
 		m.Tool.MarkCurrent(tc.ID)
+		m.Tool.MarkStarted(tc.ID)
 	}
 }
 

--- a/internal/app/conv/view.go
+++ b/internal/app/conv/view.go
@@ -29,6 +29,9 @@ type RenderContext struct {
 	// ToolStartedAt maps a running tool call's ID to when it began executing,
 	// so its row can show a live elapsed timer. Only in-flight calls appear.
 	ToolStartedAt map[string]time.Time
+	// ToolProgress maps a running command's ID to its latest output counter
+	// ("1.2k lines"), shown next to the timer. Empty for calls with no output.
+	ToolProgress map[string]string
 
 	// ── Renderer / terminal env ─────────────────────────────────
 	Width      int
@@ -256,6 +259,7 @@ func renderAssistantWithTools(p RenderContext, msg core.ChatMessage, idx int, is
 		PendingCalls:      p.PendingCalls,
 		CurrentIdx:        p.CurrentIdx,
 		ToolStartedAt:     p.ToolStartedAt,
+		ToolProgress:      p.ToolProgress,
 		ModelName:         p.ModelName,
 		InputTokens:       p.InputTokens,
 		OutputTokens:      p.OutputTokens,

--- a/internal/app/conv/view.go
+++ b/internal/app/conv/view.go
@@ -2,6 +2,7 @@ package conv
 
 import (
 	"strings"
+	"time"
 
 	"github.com/genai-io/san/internal/core"
 )
@@ -25,6 +26,9 @@ type RenderContext struct {
 	BuildingTool string
 	PendingCalls []core.ToolCall
 	CurrentIdx   int
+	// ToolStartedAt maps a running tool call's ID to when it began executing,
+	// so its row can show a live elapsed timer. Only in-flight calls appear.
+	ToolStartedAt map[string]time.Time
 
 	// ── Renderer / terminal env ─────────────────────────────────
 	Width      int
@@ -251,6 +255,7 @@ func renderAssistantWithTools(p RenderContext, msg core.ChatMessage, idx int, is
 		TaskActivity:      p.TaskActivity,
 		PendingCalls:      p.PendingCalls,
 		CurrentIdx:        p.CurrentIdx,
+		ToolStartedAt:     p.ToolStartedAt,
 		ModelName:         p.ModelName,
 		InputTokens:       p.InputTokens,
 		OutputTokens:      p.OutputTokens,

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -333,10 +333,11 @@ func (m model) messageRenderParams() conv.RenderContext {
 		InlinedResults: conv.PrecomputeInlinedResults(m.conv.Messages, m.conv.CommittedCount),
 
 		// Streaming + tool execution
-		StreamActive: m.conv.Stream.Active,
-		BuildingTool: m.conv.Stream.BuildingTool,
-		PendingCalls: m.conv.Tool.PendingCalls,
-		CurrentIdx:   m.conv.Tool.CurrentIdx,
+		StreamActive:  m.conv.Stream.Active,
+		BuildingTool:  m.conv.Stream.BuildingTool,
+		PendingCalls:  m.conv.Tool.PendingCalls,
+		CurrentIdx:    m.conv.Tool.CurrentIdx,
+		ToolStartedAt: m.conv.Tool.StartedAt,
 
 		// Renderer env
 		Width:      m.env.Width,

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -338,6 +338,7 @@ func (m model) messageRenderParams() conv.RenderContext {
 		PendingCalls:  m.conv.Tool.PendingCalls,
 		CurrentIdx:    m.conv.Tool.CurrentIdx,
 		ToolStartedAt: m.conv.Tool.StartedAt,
+		ToolProgress:  m.conv.Tool.Progress,
 
 		// Renderer env
 		Width:      m.env.Width,

--- a/internal/tool/adapter.go
+++ b/internal/tool/adapter.go
@@ -46,6 +46,7 @@ type adaptConfig struct {
 	askFn           AskUserFunc
 	messagesGetter  MessagesGetter
 	activityFn      func(toolCallID string, msg string)
+	progressFn      func(toolCallID string, lines int, bytes int64)
 	promptResponder BashPromptResponderProvider
 }
 
@@ -63,6 +64,12 @@ func WithMessagesGetterProvider(fn MessagesGetter) AdaptOption {
 // WithToolActivity sets the handler for activity lines emitted by agent-like tools.
 func WithToolActivity(fn func(toolCallID string, msg string)) AdaptOption {
 	return func(c *adaptConfig) { c.activityFn = fn }
+}
+
+// WithToolProgress sets the handler for output-progress snapshots emitted by a
+// running command (currently Bash), reporting its cumulative line/byte totals.
+func WithToolProgress(fn func(toolCallID string, lines int, bytes int64)) AdaptOption {
+	return func(c *adaptConfig) { c.progressFn = fn }
 }
 
 // WithBashPromptResponderProvider sets the responder provider for tools that can
@@ -94,7 +101,7 @@ func AdaptToolRegistry(schemas []core.ToolSchema, cwd func() string, opts ...Ada
 	var adapted []core.Tool
 	for name, schema := range schemaByName {
 		if t, ok := Get(name); ok {
-			adapted = append(adapted, &toolAdapter{inner: t, schema: schema, cwd: cwd, askFn: cfg.askFn, messagesGetter: cfg.messagesGetter, activityFn: cfg.activityFn, promptResponder: cfg.promptResponder})
+			adapted = append(adapted, &toolAdapter{inner: t, schema: schema, cwd: cwd, askFn: cfg.askFn, messagesGetter: cfg.messagesGetter, activityFn: cfg.activityFn, progressFn: cfg.progressFn, promptResponder: cfg.promptResponder})
 		}
 	}
 	return core.NewTools(adapted...)
@@ -108,6 +115,7 @@ type toolAdapter struct {
 	askFn           AskUserFunc
 	messagesGetter  MessagesGetter
 	activityFn      func(toolCallID string, msg string)
+	progressFn      func(toolCallID string, lines int, bytes int64)
 	promptResponder BashPromptResponderProvider
 }
 
@@ -125,6 +133,13 @@ func (a *toolAdapter) Execute(ctx context.Context, input map[string]any) (string
 	}
 	if a.promptResponder != nil {
 		ctx = ContextWithBashPromptResponderProvider(ctx, a.promptResponder)
+	}
+	if a.progressFn != nil {
+		if callID := core.ToolCallIDFromContext(ctx); callID != "" {
+			ctx = ContextWithBashProgress(ctx, func(lines int, bytes int64) {
+				a.progressFn(callID, lines, bytes)
+			})
+		}
 	}
 	if IsAgentToolName(a.inner.Name()) {
 		if a.activityFn != nil {

--- a/internal/tool/bash_progress.go
+++ b/internal/tool/bash_progress.go
@@ -1,0 +1,31 @@
+package tool
+
+import "context"
+
+// BashProgress reports the cumulative output a running foreground command has
+// produced so far — total lines and bytes across stdout and stderr — so the UI
+// can show a live counter and a long-running command reads as making progress
+// rather than being stuck. It is called repeatedly, already throttled by the
+// caller; the same call may report the same or a growing count.
+type BashProgress func(lines int, bytes int64)
+
+type bashProgressKey struct{}
+
+// ContextWithBashProgress stores a per-execution output-progress reporter in ctx.
+// A nil reporter leaves ctx untouched, so the command runs without reporting.
+func ContextWithBashProgress(ctx context.Context, report BashProgress) context.Context {
+	if report == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, bashProgressKey{}, report)
+}
+
+// BashProgressFromContext resolves the current output-progress reporter, or nil
+// when no consumer is listening.
+func BashProgressFromContext(ctx context.Context) BashProgress {
+	if ctx == nil {
+		return nil
+	}
+	report, _ := ctx.Value(bashProgressKey{}).(BashProgress)
+	return report
+}

--- a/internal/tool/fs/bash.go
+++ b/internal/tool/fs/bash.go
@@ -117,8 +117,11 @@ func (t *BashTool) ExecuteApproved(ctx context.Context, params map[string]any, c
 	cmd.WaitDelay = 5 * time.Second
 
 	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	// Count output as it streams so the UI can show a live line counter; when
+	// nothing is listening, tee returns the bare buffer and this costs nothing.
+	progress := &outputProgress{report: tool.BashProgressFromContext(ctx)}
+	cmd.Stdout = progress.tee(&stdout)
+	cmd.Stderr = progress.tee(&stderr)
 
 	err := cmd.Run()
 	duration := time.Since(start)

--- a/internal/tool/fs/bash_progress.go
+++ b/internal/tool/fs/bash_progress.go
@@ -1,0 +1,70 @@
+package fs
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/genai-io/san/internal/tool"
+)
+
+// progressInterval throttles how often a running command reports its growing
+// output: often enough to feel live, rarely enough not to flood the UI channel.
+const progressInterval = 120 * time.Millisecond
+
+// outputProgress accumulates the line and byte totals of a running command's
+// output and forwards throttled snapshots to a reporter. stdout and stderr are
+// copied on separate goroutines, so every field is mutex-guarded and the count
+// is shared across both streams — the reporter sees one combined total.
+type outputProgress struct {
+	report tool.BashProgress
+
+	mu         sync.Mutex
+	lines      int
+	bytes      int64
+	lastReport time.Time
+}
+
+// tee wraps buf so writes to it also feed the counter. The returned writer is
+// the command's stdout or stderr; buf still receives the full output verbatim.
+func (p *outputProgress) tee(buf *bytes.Buffer) io.Writer {
+	if p == nil || p.report == nil {
+		return buf
+	}
+	return &countingWriter{buf: buf, progress: p}
+}
+
+// observe folds one chunk into the running totals and reports the new count when
+// the throttle window has elapsed. The reporter is invoked outside the lock so a
+// slow consumer never stalls the command's output copy.
+func (p *outputProgress) observe(n int, chunk []byte) {
+	p.mu.Lock()
+	p.bytes += int64(n)
+	p.lines += bytes.Count(chunk, []byte{'\n'})
+	lines, byteCount := p.lines, p.bytes
+	fire := p.lastReport.IsZero() || time.Since(p.lastReport) >= progressInterval
+	if fire {
+		p.lastReport = time.Now()
+	}
+	p.mu.Unlock()
+	if fire {
+		p.report(lines, byteCount)
+	}
+}
+
+// countingWriter forwards every write to the underlying buffer unchanged, then
+// counts it. It never alters or withholds bytes, so the command's captured
+// output is identical to writing straight to the buffer.
+type countingWriter struct {
+	buf      *bytes.Buffer
+	progress *outputProgress
+}
+
+func (w *countingWriter) Write(chunk []byte) (int, error) {
+	n, err := w.buf.Write(chunk)
+	if n > 0 {
+		w.progress.observe(n, chunk[:n])
+	}
+	return n, err
+}

--- a/internal/tool/fs/bash_progress_test.go
+++ b/internal/tool/fs/bash_progress_test.go
@@ -1,0 +1,83 @@
+package fs
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"testing"
+
+	coretool "github.com/genai-io/san/internal/tool"
+)
+
+func TestOutputProgress_countsAndForwardsVerbatim(t *testing.T) {
+	var gotLines int
+	var gotBytes int64
+	p := &outputProgress{report: func(lines int, byteCount int64) {
+		gotLines, gotBytes = lines, byteCount
+	}}
+	w := p.tee(&bytes.Buffer{})
+
+	// The first write fires the reporter (its throttle window starts fresh).
+	if _, err := w.Write([]byte("one\ntwo\n")); err != nil {
+		t.Fatal(err)
+	}
+	if gotLines != 2 || gotBytes != 8 {
+		t.Fatalf("reported lines=%d bytes=%d, want 2/8", gotLines, gotBytes)
+	}
+
+	// A later write keeps accumulating into the totals even while throttled.
+	if _, err := w.Write([]byte("three")); err != nil {
+		t.Fatal(err)
+	}
+	if p.lines != 2 || p.bytes != 13 {
+		t.Fatalf("accumulated lines=%d bytes=%d, want 2/13", p.lines, p.bytes)
+	}
+}
+
+func TestOutputProgress_forwardsBytesUnchanged(t *testing.T) {
+	var buf bytes.Buffer
+	p := &outputProgress{report: func(int, int64) {}}
+	w := p.tee(&buf)
+	for _, chunk := range []string{"alpha\n", "beta", " gamma\n"} {
+		if _, err := w.Write([]byte(chunk)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got, want := buf.String(), "alpha\nbeta gamma\n"; got != want {
+		t.Fatalf("buffer = %q, want the output verbatim %q", got, want)
+	}
+}
+
+func TestOutputProgress_teeWithoutReporterIsBareBuffer(t *testing.T) {
+	buf := &bytes.Buffer{}
+	if w := (&outputProgress{}).tee(buf); w != buf {
+		t.Fatalf("tee without a reporter = %T, want the bare buffer (zero overhead)", w)
+	}
+}
+
+func TestBashExecuteApproved_reportsOutputProgress(t *testing.T) {
+	var mu sync.Mutex
+	maxLines := 0
+	ctx := coretool.ContextWithBashProgress(context.Background(), func(lines int, _ int64) {
+		mu.Lock()
+		if lines > maxLines {
+			maxLines = lines
+		}
+		mu.Unlock()
+	})
+
+	result := (&BashTool{}).ExecuteApproved(ctx, map[string]any{
+		"command": `for i in $(seq 1 5); do echo "line $i"; sleep 0.05; done`,
+		"timeout": 5000,
+	}, t.TempDir())
+
+	if !result.Success {
+		t.Fatalf("ExecuteApproved failed: error=%q output=%q", result.Error, result.Output)
+	}
+	mu.Lock()
+	got := maxLines
+	mu.Unlock()
+	if got < 1 {
+		t.Fatalf("progress reporter never observed any line (maxLines=%d)", got)
+	}
+}


### PR DESCRIPTION
Stacked on #378 — the diff below includes that PR's timer commit until it merges; this PR's own change is the single commit for the counter. Kept as a draft; will rebase onto main and mark ready once #378 lands.

The elapsed timer (#378) says a command is alive but not whether it is progressing: a healthy build and a hung one both just tick upward. Count a foreground command's output as it streams and show it next to the timer (` · 12s · 1.2k lines`), so climbing lines mean progress and a frozen counter under a rising clock means stuck.

- `cmd.Run` is untouched: stdout/stderr are teed through a byte/line counter that forwards output verbatim, so timeout, process-group teardown, and truncation are all preserved.
- No output yet (a progress bar, one long token) falls back to a byte size.
- Snapshots are throttled and ride the existing agent→UI channel as a replaceable value; zero cost when nothing is listening.