### PR TITLE
refactor(subagent): drop the legacy Grep/Glob allow_tools translation

### DIFF
--- a/docs/reference/claude-permission-compat.md
+++ b/docs/reference/claude-permission-compat.md
@@ -124,11 +124,12 @@ allow_tools:
   - Bash(go test*)        # Only go test commands
 ```
 
-Legacy `Glob` and `Grep` entries (from Claude Code agent definitions) are
-still accepted: San no longer ships those tools — search runs through Bash,
-where read-only commands (`rg`, `grep`, `find`, `ls`, read-only `git`, …)
-auto-permit in every mode — so the loader translates them into the
-equivalent patterned Bash rules.
+An `allow_tools` entry naming a tool San does not ship (for example `Glob`
+or `Grep` from a Claude Code agent definition) is simply inert: no schema
+matches it, so it grants nothing. If such an agent needs to search, list
+`Bash` (optionally with patterns) — read-only commands (`rg`, `grep`,
+`find`, `ls`, read-only `git`, …) auto-permit in every mode, and a
+whitelisted agent only sees the tools its list names.
 
 #### deny_tools — Denylist (Always Wins)
 

--- a/internal/subagent/loader.go
+++ b/internal/subagent/loader.go
@@ -185,8 +185,6 @@ func parseAgentFile(filePath string) (*AgentConfig, error) {
 	}
 
 	config.PermissionMode = NormalizePermissionMode(string(config.PermissionMode))
-	config.AllowTools = translateLegacySearchTools(config.AllowTools)
-	config.DenyTools = translateLegacySearchTools(config.DenyTools)
 
 	if config.Name == "" {
 		config.Name = strings.TrimSuffix(filepath.Base(filePath), ".md")

--- a/internal/subagent/loader_priority_test.go
+++ b/internal/subagent/loader_priority_test.go
@@ -47,9 +47,7 @@ func TestParseAgentFileAcceptsFrontmatterAliases(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseAgentFile: %v", err)
 	}
-	// Grep expands into the legacy Bash search rules; Bash and Read survive.
-	got := config.AllowTools.Names()
-	if len(got) == 0 || got[0] != "Bash" || config.AllowTools.HasName("Grep") {
+	if got := config.AllowTools.Names(); len(got) != 3 || got[0] != "Bash" {
 		t.Fatalf("allowed-tools alias not applied: %#v", got)
 	}
 	if config.PermissionMode != PermissionBypass {
@@ -66,9 +64,7 @@ func TestParseAgentFileAcceptsClaudeCodeToolsKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseAgentFile: %v", err)
 	}
-	// The Claude-compat key parses, with legacy Grep expanded to Bash rules.
-	got := config.AllowTools.Names()
-	if len(got) == 0 || got[0] != "Read" || config.AllowTools.HasName("Grep") || !config.AllowTools.HasName("Bash") {
+	if got := config.AllowTools.Names(); len(got) != 2 || got[0] != "Read" || got[1] != "Grep" {
 		t.Fatalf("tools alias not applied: %#v", got)
 	}
 }

--- a/internal/subagent/types.go
+++ b/internal/subagent/types.go
@@ -200,44 +200,6 @@ func (t *ToolList) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
-// legacySearchToolBashRules stands in for the retired Grep and Glob tools in
-// agent definitions. Search now runs through Bash (read-only commands
-// auto-permit); these patterned entries keep the Bash schema visible to
-// whitelisted agents and preserve deny intent.
-var legacySearchToolBashRules = ToolList{
-	{Name: "Bash", Pattern: "rg:*"},
-	{Name: "Bash", Pattern: "grep:*"},
-	{Name: "Bash", Pattern: "find:*"},
-	{Name: "Bash", Pattern: "ls:*"},
-}
-
-// translateLegacySearchTools rewrites Grep/Glob entries from older agent
-// definitions into the equivalent Bash search rules, deduplicating against
-// rules already present.
-func translateLegacySearchTools(t ToolList) ToolList {
-	if !t.HasName("Grep") && !t.HasName("Glob") {
-		return t
-	}
-	out := make(ToolList, 0, len(t)+len(legacySearchToolBashRules))
-	seen := make(map[ToolRule]bool, len(t))
-	add := func(r ToolRule) {
-		if !seen[r] {
-			seen[r] = true
-			out = append(out, r)
-		}
-	}
-	for _, r := range t {
-		if r.Name == "Grep" || r.Name == "Glob" {
-			for _, b := range legacySearchToolBashRules {
-				add(b)
-			}
-			continue
-		}
-		add(r)
-	}
-	return out
-}
-
 // parseRuleString accepts "Read" or "Bash(git diff*)" and returns a ToolRule.
 func parseRuleString(s string) (ToolRule, bool) {
 	s = strings.TrimSpace(s)


### PR DESCRIPTION
Follow-up to #380, removing the compatibility shim it introduced.

The loader rewrote legacy `Grep`/`Glob` entries in agent frontmatter into patterned Bash rules (`rg:*`, `grep:*`, `find:*`, `ls:*`). That translation is not worth its weight:

- An `allow_tools` entry naming a tool San does not ship is already inert — no schema matches it, so it grants nothing and breaks nothing.
- Read-only Bash commands auto-permit in every mode, so any agent that lists `Bash` keeps its search capability with no rewriting.
- An agent whose whitelist named only the retired tools should update its definition; a silent rewrite that quietly grants patterned Bash access is more surprising than helpful.

Removes `translateLegacySearchTools` + `legacySearchToolBashRules`, the loader calls, restores the loader tests to plain parsing assertions, and replaces the compat-doc paragraph with an accurate description of the inert-entry behavior.

`go test ./...` green, `make lint` clean.