### PR TITLE
refactor(tui): trim transient status and tool-header decoration

### DIFF
--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -142,9 +142,9 @@ func Test_renderBashToolCallMultiLineShowsEveryLine(t *testing.T) {
 			t.Fatalf("multi-line command should show %q in place, got %q", want, out)
 		}
 	}
-	// The description rides the header as a caption.
-	if !strings.Contains(out, "loop over files") {
-		t.Fatalf("multi-line command should show its description, got %q", out)
+	// The description stays on the header in normal text, separated by a dash.
+	if !strings.Contains(stripANSI(out), "Bash - loop over files") {
+		t.Fatalf("multi-line command should show its description on the header, got %q", out)
 	}
 	// The raw command is never crammed into the Bash(...) one-line label.
 	if strings.Contains(out, "Bash(for f") {

--- a/internal/app/conv/status_bar.go
+++ b/internal/app/conv/status_bar.go
@@ -122,22 +122,6 @@ func RenderContextLabel(used, limit int) string {
 	return contextLabel(kit.FormatTokenCount(used), kit.FormatTokenCount(limit))
 }
 
-// renderStableContextLabel renders the status-bar context segment with a stable
-// width for the used-token side. The status line re-renders on every spinner
-// tick; without this padding, values like "0", "8.5k", and "10.0k" shift the
-// right-aligned cluster horizontally and read as flicker.
-func renderStableContextLabel(used, limit int) string {
-	usedText := kit.FormatTokenCount(used)
-	if limit <= 0 {
-		return contextLabel(usedText, "")
-	}
-	limitText := kit.FormatTokenCount(limit)
-	if pad := lipgloss.Width(limitText) - lipgloss.Width(usedText); pad > 0 {
-		usedText = strings.Repeat(" ", pad) + usedText
-	}
-	return contextLabel(usedText, limitText)
-}
-
 // compressionBadgeStyle escalates color with count (PRD §7.5):
 //
 //	<5     muted
@@ -283,7 +267,7 @@ func renderStatusCluster(p OperationModeParams) string {
 	// The numeric label always renders — it falls back to "ctx X/--" when the
 	// limit is unknown, so the slot stays visible instead of silently hiding.
 	segments = append(segments, statusSegment{
-		text:     renderStableContextLabel(p.InputTokens, p.InputLimit),
+		text:     RenderContextLabel(p.InputTokens, p.InputLimit),
 		priority: 3,
 	})
 

--- a/internal/app/conv/status_bar_test.go
+++ b/internal/app/conv/status_bar_test.go
@@ -4,8 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"charm.land/lipgloss/v2"
-
 	"github.com/genai-io/san/internal/setting"
 )
 
@@ -107,16 +105,18 @@ func TestRenderContextLabel(t *testing.T) {
 	}
 }
 
-func TestRenderStableContextLabelKeepsWidth(t *testing.T) {
-	a := stripANSI(renderStableContextLabel(8_500, 272_000))
-	b := stripANSI(renderStableContextLabel(10_000, 272_000))
-
-	if lipgloss.Width(a) != lipgloss.Width(b) {
-		t.Fatalf("stable context labels should have same width: %q (%d), %q (%d)",
-			a, lipgloss.Width(a), b, lipgloss.Width(b))
+func TestRenderContextLabelStaysCompact(t *testing.T) {
+	visible := stripANSI(RenderModeStatus(OperationModeParams{
+		ModelName:   "gpt-test",
+		InputTokens: 0,
+		InputLimit:  272_000,
+		Width:       120,
+	}))
+	if !strings.Contains(visible, "ctx 0/272.0k") {
+		t.Fatalf("RenderModeStatus() = %q, want compact ctx label", visible)
 	}
-	if !strings.Contains(a, "8.5k/272.0k") || !strings.Contains(b, "10.0k/272.0k") {
-		t.Fatalf("stable labels lost expected token text: %q / %q", a, b)
+	if strings.Contains(visible, "ctx       0/272.0k") {
+		t.Fatalf("RenderModeStatus() = %q, ctx label must not pad the usage value", visible)
 	}
 }
 

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -49,15 +49,6 @@ var (
 
 	errorStyle = lipgloss.NewStyle().
 			Foreground(kit.CurrentTheme.Error)
-
-	// A multi-line Bash command renders as an indented block below the header. The
-	// command itself is drawn in the shared dim result tone (toolResultStyle) —
-	// the same tone as the "$" prompt and the "⎿" trailer — so the whole block
-	// reads as quiet code, one step below body prose. Only the description differs:
-	// italic, so it reads as a prose caption distinct from the code.
-	bashDescStyle = lipgloss.NewStyle().
-			Foreground(kit.CurrentTheme.TextDim).
-			Italic(true)
 )
 
 // RenderToolResult renders a complete tool result with header and content.
@@ -837,12 +828,12 @@ func renderBashToolCall(input string, width int, icon string) string {
 
 	var sb strings.Builder
 
-	// Header line: ● Bash, trailed by the optional description as a dim caption.
-	// The caption may be shortened (it's metadata); the command below never is.
+	// Header line: ● Bash - description. The description may be shortened
+	// (it's metadata); the command below never is.
 	iconCell := toolCallStyle.Width(2).Render(icon)
 	header := toolCallStyle.Render(tool.ToolBash)
 	if description != "" {
-		header += "  " + bashDescStyle.Render(kit.TruncateText(description, budget))
+		header += " - " + kit.TruncateText(description, budget)
 	}
 	sb.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, iconCell, header) + "\n")
 

--- a/internal/app/update_key_test.go
+++ b/internal/app/update_key_test.go
@@ -46,14 +46,14 @@ func TestCtrlTCyclesThinkingEffort(t *testing.T) {
 	if !handled {
 		t.Fatal("Ctrl+T was not handled")
 	}
-	if cmd == nil {
-		t.Fatal("Ctrl+T should return a status timer command")
+	if cmd != nil {
+		t.Fatal("Ctrl+T should update the model label without a status message")
 	}
 	if m.env.ThinkingEffort != "low" {
 		t.Fatalf("ThinkingEffort = %q, want low", m.env.ThinkingEffort)
 	}
-	if m.userInput.Provider.StatusMessage != "thinking: low" {
-		t.Fatalf("StatusMessage = %q, want thinking: low", m.userInput.Provider.StatusMessage)
+	if m.userInput.Provider.StatusMessage != "" {
+		t.Fatalf("StatusMessage = %q, want empty", m.userInput.Provider.StatusMessage)
 	}
 	if m.conv.ShowTasks {
 		t.Fatal("Ctrl+T should not toggle the task panel")
@@ -86,8 +86,8 @@ func TestCtrlTUsesCachedModelReasoningMetadata(t *testing.T) {
 	}
 
 	cmd, handled := m.handleTextareaShortcut(tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl})
-	if !handled || cmd == nil {
-		t.Fatal("Ctrl+T should be handled and return a status timer")
+	if !handled || cmd != nil {
+		t.Fatal("Ctrl+T should be handled without a status timer")
 	}
 	if m.env.ThinkingEffort != "ultra" {
 		t.Fatalf("ThinkingEffort = %q, want dynamic next effort ultra", m.env.ThinkingEffort)

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -193,12 +193,7 @@ func (m *model) cycleThinkingEffort() tea.Cmd {
 	}
 
 	m.env.SetThinkingEffort(next)
-	status := "thinking: " + next
-	if current != "" && current == next {
-		status += " (only supported)"
-	}
-	token := m.userInput.Provider.SetStatusMessage(status)
-	return kit.StatusTimer(3*time.Second, token)
+	return nil
 }
 
 func (m *model) handleCtrlO() tea.Cmd {


### PR DESCRIPTION
Three small TUI rendering cleanups.

- **Status bar**: drop `renderStableContextLabel`'s width padding; the context segment renders compactly via `RenderContextLabel`.
- **Bash tool call**: show the description inline as `Bash - <desc>` instead of an italic dim caption, dropping `bashDescStyle`.
- **Ctrl+T (thinking effort)**: update the model label silently instead of flashing a `thinking: <effort>` status message.
