### PR TITLE
fix(permission): bypass widens to a root/home-removal circuit breaker

### DIFF
--- a/docs/concepts/permission-model.md
+++ b/docs/concepts/permission-model.md
@@ -43,10 +43,11 @@ chain must be on the read-only list (`rg`, `grep`, `find`, `ls`, read-only
 This replaces the retired Grep/Glob tools — search runs through Bash
 without approval prompts, in every mode including explore. Deny/ask rules
 and the safety checks still run first and override it. The safety checks
-have two tiers: the bypass-immune floor (destructive commands, sensitive
-paths, data exfiltration) holds in every mode; the recoverable
-confirmation tier (work-discarding git, out-of-working-dir writes) is
-skipped by `bypassPermissions` mode.
+are layered: the circuit breaker (a recursive removal of the filesystem
+root or the home directory) holds in every mode, bypass included; the
+confirmation tiers — unrecoverable (destructive commands, sensitive paths,
+data exfiltration) and recoverable (work-discarding git,
+out-of-working-dir writes) — are skipped by `bypassPermissions` mode.
 
 ## Subagent Permission Resolution
 
@@ -65,7 +66,7 @@ requests that would require a user prompt.
   - `acceptEdits` (spelled `edit` on the Agent tool) — Edit/Write
     auto-allow; other gated tools are denied.
   - `bypassPermissions` — everything allowed after `deny_tools` and the
-    bypass-immune floor; parent-only tools stay blocked.
+    root/home-removal circuit breaker; parent-only tools stay blocked.
 
 Both gates share the same mode table (`setting.ModeDefault`); the subagent
 side only swaps "prompt the user" for "deny".

--- a/docs/concepts/permission-model.md
+++ b/docs/concepts/permission-model.md
@@ -42,8 +42,11 @@ chain must be on the read-only list (`rg`, `grep`, `find`, `ls`, read-only
 `git`, …) with no output redirection, substitution, or env-var prefix.
 This replaces the retired Grep/Glob tools — search runs through Bash
 without approval prompts, in every mode including explore. Deny/ask rules
-and the confirmation safety checks still run first and override it;
-`bypassPermissions` mode skips the confirmation checks entirely.
+and the safety checks still run first and override it. The safety checks
+have two tiers: the bypass-immune floor (destructive commands, sensitive
+paths, data exfiltration) holds in every mode; the recoverable
+confirmation tier (work-discarding git, out-of-working-dir writes) is
+skipped by `bypassPermissions` mode.
 
 ## Subagent Permission Resolution
 
@@ -61,8 +64,8 @@ requests that would require a user prompt.
   - `default` — reads auto-allow; everything that would ask is denied.
   - `acceptEdits` (spelled `edit` on the Agent tool) — Edit/Write
     auto-allow; other gated tools are denied.
-  - `bypassPermissions` — everything allowed after `deny_tools`;
-    parent-only tools stay blocked.
+  - `bypassPermissions` — everything allowed after `deny_tools` and the
+    bypass-immune floor; parent-only tools stay blocked.
 
 Both gates share the same mode table (`setting.ModeDefault`); the subagent
 side only swaps "prompt the user" for "deny".

--- a/docs/guides/writing-a-subagent.md
+++ b/docs/guides/writing-a-subagent.md
@@ -91,7 +91,7 @@ controls what happens when a tool call would normally `ask`:
 | `explore` | Read-only; mutating tools are unavailable. |
 | `default` | Reads allowed; `ask` becomes `deny`, unless allowed by `allow_tools`. |
 | `edit` (= `acceptEdits`) | Edit/Write allowed; other gated tools, such as unrestricted Bash, are denied. |
-| `bypassPermissions` | Allows everything after `deny_tools` — no confirmation floor. Use only for trusted agents. |
+| `bypassPermissions` | Allows everything after `deny_tools` and the bypass-immune floor (destructive/sensitive calls stay denied). Use only for trusted agents. |
 
 Subagents cannot spawn subagents. `SendMessage(to="main", ...)` follows the
 normal mode rules.

--- a/docs/guides/writing-a-subagent.md
+++ b/docs/guides/writing-a-subagent.md
@@ -91,7 +91,7 @@ controls what happens when a tool call would normally `ask`:
 | `explore` | Read-only; mutating tools are unavailable. |
 | `default` | Reads allowed; `ask` becomes `deny`, unless allowed by `allow_tools`. |
 | `edit` (= `acceptEdits`) | Edit/Write allowed; other gated tools, such as unrestricted Bash, are denied. |
-| `bypassPermissions` | Allows everything after `deny_tools` and the bypass-immune floor (destructive/sensitive calls stay denied). Use only for trusted agents. |
+| `bypassPermissions` | Allows everything after `deny_tools`; only a root/home-directory removal stays denied (circuit breaker). Use only for trusted agents. |
 
 Subagents cannot spawn subagents. `SendMessage(to="main", ...)` follows the
 normal mode rules.

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -207,9 +207,14 @@ func (m *model) buildAgentParams() agent.BuildParams {
 				return agent.PermReviewResult{}
 			}
 			cfg := m.liveAutopilotConfig()
-			// Defense in depth: no steer may approve an unrecoverable action, even
-			// if one somehow reaches here. The recoverable git tier is deliberately
-			// not checked — weighing it is exactly what the judge is for.
+			// Defense in depth: no steer may approve an unrecoverable action —
+			// circuit-breaker tier included — even if one somehow reaches here.
+			// The recoverable git tier is deliberately not checked — weighing it
+			// is exactly what the judge is for.
+			if r := setting.CircuitBreakerReason(name, args); r != "" {
+				m.recordDecision(ctx, false, r)
+				return agent.PermReviewResult{}
+			}
 			if r := setting.UnrecoverableReason(name, args); r != "" {
 				m.recordDecision(ctx, false, r)
 				return agent.PermReviewResult{}

--- a/internal/setting/bash_ast.go
+++ b/internal/setting/bash_ast.go
@@ -589,8 +589,8 @@ func hasNestedCmdSubst(node syntax.Node) bool {
 // ---------------------------------------------------------------------------
 // Network egress & remote-code-execution detection
 //
-// These land in the bypass-immune floor (Step 2 of the permission pipeline,
-// held even in bypass mode), so they escalate to the user and are never
+// These land in the unrecoverable confirmation tier (Step 4 of the permission
+// pipeline; bypass mode skips it), so they escalate to the user and are never
 // delegated to the auto-review agent.
 // They are the two categories where a wrong "allow" is both irreversible and a
 // prime prompt-injection payload: shipping local data off the machine, and

--- a/internal/setting/bash_ast.go
+++ b/internal/setting/bash_ast.go
@@ -589,9 +589,9 @@ func hasNestedCmdSubst(node syntax.Node) bool {
 // ---------------------------------------------------------------------------
 // Network egress & remote-code-execution detection
 //
-// These land in the confirmation band (Step 3 of the permission pipeline;
-// bypass mode skips it), so they escalate to the user and are never delegated
-// to the auto-review agent.
+// These land in the bypass-immune floor (Step 2 of the permission pipeline,
+// held even in bypass mode), so they escalate to the user and are never
+// delegated to the auto-review agent.
 // They are the two categories where a wrong "allow" is both irreversible and a
 // prime prompt-injection payload: shipping local data off the machine, and
 // executing code fetched from the network.

--- a/internal/setting/permission.go
+++ b/internal/setting/permission.go
@@ -34,11 +34,13 @@ func decide(b perm.Decision, reason string) PermissionDecision {
 // Decision pipeline (inspired by Claude Code's hasPermissionsToUseTool):
 //
 //  1. Deny rules
-//  2. Bypass-immune floor — unrecoverable calls only (destructive bash,
-//     sensitive paths, data exfiltration); held even in bypass mode
+//  2. Circuit breaker — recursive removal of the filesystem root or the home
+//     directory; the one check held even in bypass mode
 //  3. BypassPermissions mode → allow everything else
-//  4. Confirmation checks — recoverable tier (work-discarding git,
-//     out-of-working-dir writes); skipped by bypass
+//  4. Confirmation checks (skipped by bypass): the unrecoverable tier
+//     (destructive bash, sensitive paths, data exfiltration — never
+//     judge-reviewable) and the recoverable tier (work-discarding git,
+//     out-of-working-dir writes — the AutoPilot judge may weigh git)
 //  5. Session permissions (runtime overrides)
 //  6. Ask rules
 //  7. Allow rules
@@ -64,12 +66,11 @@ func (s *Data) HasPermissionToUseTool(toolName string, args map[string]any, sess
 		}
 	}
 
-	// ── Step 2: Bypass-immune floor ──
-	// Only the unrecoverable tier is immune to bypass: real destruction, a
-	// sensitive path, data exfiltration. Recoverable operations (the git tier
-	// below) are deliberately NOT held here, so bypass mode runs them freely.
-	if reason := UnrecoverableReason(toolName, args); reason != "" {
-		return coerceAsk(decide(perm.Prompt, "bypass-immune: "+reason), session)
+	// ── Step 2: Circuit breaker ──
+	// The one check no mode may skip: a recursive removal of the filesystem
+	// root or the home directory. A guard against model error, not policy.
+	if reason := CircuitBreakerReason(toolName, args); reason != "" {
+		return coerceAsk(decide(perm.Prompt, "circuit breaker: "+reason), session)
 	}
 
 	// ── Step 3: BypassPermissions mode ──
@@ -77,7 +78,7 @@ func (s *Data) HasPermissionToUseTool(toolName string, args map[string]any, sess
 		return decide(perm.Permit, "mode: bypass permissions")
 	}
 
-	// ── Step 4: Confirmation checks (recoverable tier) ──
+	// ── Step 4: Confirmation checks ──
 	if reason, reviewable := s.confirmationPromptReason(toolName, args, session); reason != "" {
 		d := decide(perm.Prompt, reason)
 		d.Reviewable = reviewable
@@ -111,11 +112,14 @@ func (s *Data) HasPermissionToUseTool(toolName string, args map[string]any, sess
 }
 
 // confirmationPromptReason reports why a call requires confirmation and whether
-// the AutoPilot judge may weigh it. It carries only the recoverable tier — the
-// unrecoverable floor already ran (bypass-immune, step 2), and bypass mode
-// skips this step entirely. The git tier is the judge's to weigh; a write
-// reaching outside the working directory stays the human's call.
+// the AutoPilot judge may weigh it. Bypass mode skips this step entirely. Only
+// the recoverable git tier is the judge's to weigh; every other reason here —
+// real destruction, a sensitive path, a write reaching outside the working
+// directory — stays the human's call.
 func (s *Data) confirmationPromptReason(toolName string, args map[string]any, session *SessionPermissions) (reason string, reviewable bool) {
+	if reason := UnrecoverableReason(toolName, args); reason != "" {
+		return "confirmation: " + reason, false
+	}
 	if reason := ConfirmationReason(toolName, args); reason != "" {
 		return "confirmation: " + reason, true
 	}
@@ -233,10 +237,10 @@ func (s *Data) ResolveHookAllow(toolName string, args map[string]any, session *S
 			return false
 		}
 	}
-	// A hook cannot vouch for anything a safety check holds — neither the
-	// bypass-immune floor nor the recoverable confirmation tier: there is no
-	// judge in this path to weigh the recoverable one.
-	if reason := UnrecoverableReason(toolName, args); reason != "" {
+	// A hook cannot vouch for anything a safety check holds — the circuit
+	// breaker or either confirmation tier: there is no judge in this path to
+	// weigh the recoverable one.
+	if reason := CircuitBreakerReason(toolName, args); reason != "" {
 		return false
 	}
 	if reason, _ := s.confirmationPromptReason(toolName, args, session); reason != "" {
@@ -545,6 +549,17 @@ func MatchAllowList(toolName string, args map[string]any, patterns []string) (st
 	return firstMatch, true
 }
 
+// CircuitBreakerReason returns a non-empty reason when the call is the one
+// thing no mode may run silently: a recursive removal of the filesystem root
+// or the home directory. It is the only check bypass mode cannot skip — a
+// circuit breaker against model error, not a permission policy.
+func CircuitBreakerReason(toolName string, args map[string]any) string {
+	if cmd, ok := bashCommandArg(toolName, args); ok && isRootOrHomeRemoval(cmd) {
+		return "removal targets the filesystem root or home directory"
+	}
+	return ""
+}
+
 // ConfirmationReason returns a non-empty reason if the call sits in the
 // recoverable confirmation tier (work-discarding git commands) — the tier the
 // AutoPilot judge may weigh and bypass mode skips. Gates that cannot ask —
@@ -556,10 +571,11 @@ func ConfirmationReason(toolName string, args map[string]any) string {
 	return ""
 }
 
-// UnrecoverableReason is the bypass-immune floor: the calls whose effect
-// nothing can bring back. It holds in every mode, bypass included, and the
-// AutoPilot judge can never approve it — the judge may only weigh the
-// recoverable tier (ConfirmationReason).
+// UnrecoverableReason is the unrecoverable confirmation tier: the calls whose
+// effect nothing can bring back. Bypass mode skips it (only the circuit
+// breaker survives bypass); in every other mode it prompts, and the AutoPilot
+// judge can never approve it — the judge may only weigh the recoverable tier
+// (ConfirmationReason).
 func UnrecoverableReason(toolName string, args map[string]any) string {
 	switch toolName {
 	case "Edit", "Write", "NotebookEdit":

--- a/internal/setting/permission.go
+++ b/internal/setting/permission.go
@@ -117,11 +117,8 @@ func (s *Data) HasPermissionToUseTool(toolName string, args map[string]any, sess
 // real destruction, a sensitive path, a write reaching outside the working
 // directory — stays the human's call.
 func (s *Data) confirmationPromptReason(toolName string, args map[string]any, session *SessionPermissions) (reason string, reviewable bool) {
-	if reason := UnrecoverableReason(toolName, args); reason != "" {
-		return "confirmation: " + reason, false
-	}
-	if reason := ConfirmationReason(toolName, args); reason != "" {
-		return "confirmation: " + reason, true
+	if reason, recoverable := ConfirmationTier(toolName, args); reason != "" {
+		return "confirmation: " + reason, recoverable
 	}
 
 	if session != nil && len(session.WorkingDirectories) > 0 {
@@ -240,7 +237,7 @@ func (s *Data) ResolveHookAllow(toolName string, args map[string]any, session *S
 	// A hook cannot vouch for anything a safety check holds — the circuit
 	// breaker or either confirmation tier: there is no judge in this path to
 	// weigh the recoverable one.
-	if reason := CircuitBreakerReason(toolName, args); reason != "" {
+	if CircuitBreakerReason(toolName, args) != "" {
 		return false
 	}
 	if reason, _ := s.confirmationPromptReason(toolName, args, session); reason != "" {
@@ -560,11 +557,25 @@ func CircuitBreakerReason(toolName string, args map[string]any) string {
 	return ""
 }
 
-// ConfirmationReason returns a non-empty reason if the call sits in the
-// recoverable confirmation tier (work-discarding git commands) — the tier the
-// AutoPilot judge may weigh and bypass mode skips. Gates that cannot ask —
-// the subagent gate outside bypass mode — turn the reason into a hard deny.
-func ConfirmationReason(toolName string, args map[string]any) string {
+// ConfirmationTier classifies a call against both confirmation tiers in one
+// pass: why it is held, and whether it is the recoverable tier the AutoPilot
+// judge may weigh. The tier travels with the reason rather than being
+// re-derived at each gate, so a reason added later cannot land in the judge's
+// lap by omission. Gates that cannot ask — the subagent gate outside bypass
+// mode — turn any reason into a hard deny.
+func ConfirmationTier(toolName string, args map[string]any) (reason string, recoverable bool) {
+	if reason := UnrecoverableReason(toolName, args); reason != "" {
+		return reason, false
+	}
+	if reason := RecoverableReason(toolName, args); reason != "" {
+		return reason, true
+	}
+	return "", false
+}
+
+// RecoverableReason is the recoverable confirmation tier (work-discarding git
+// commands) — the tier the AutoPilot judge may weigh and bypass mode skips.
+func RecoverableReason(toolName string, args map[string]any) string {
 	if cmd, ok := bashCommandArg(toolName, args); ok && isGitDiscardingCommand(cmd) {
 		return "git command that discards work"
 	}
@@ -575,7 +586,7 @@ func ConfirmationReason(toolName string, args map[string]any) string {
 // effect nothing can bring back. Bypass mode skips it (only the circuit
 // breaker survives bypass); in every other mode it prompts, and the AutoPilot
 // judge can never approve it — the judge may only weigh the recoverable tier
-// (ConfirmationReason).
+// (RecoverableReason).
 func UnrecoverableReason(toolName string, args map[string]any) string {
 	switch toolName {
 	case "Edit", "Write", "NotebookEdit":

--- a/internal/setting/permission.go
+++ b/internal/setting/permission.go
@@ -34,13 +34,16 @@ func decide(b perm.Decision, reason string) PermissionDecision {
 // Decision pipeline (inspired by Claude Code's hasPermissionsToUseTool):
 //
 //  1. Deny rules
-//  2. BypassPermissions mode → allow (explicit denies still reject)
-//  3. Confirmation safety checks
-//  4. Session permissions (runtime overrides)
-//  5. Ask rules
-//  6. Allow rules
-//  7. Mode default
-//  8. Headless / DontAsk coercion: Ask → Deny
+//  2. Bypass-immune floor — unrecoverable calls only (destructive bash,
+//     sensitive paths, data exfiltration); held even in bypass mode
+//  3. BypassPermissions mode → allow everything else
+//  4. Confirmation checks — recoverable tier (work-discarding git,
+//     out-of-working-dir writes); skipped by bypass
+//  5. Session permissions (runtime overrides)
+//  6. Ask rules
+//  7. Allow rules
+//  8. Mode default
+//  9. Headless / DontAsk coercion: Ask → Deny
 
 // HasPermissionToUseTool is the central permission gate that determines
 // whether a tool invocation should be allowed, denied, or prompted.
@@ -61,22 +64,27 @@ func (s *Data) HasPermissionToUseTool(toolName string, args map[string]any, sess
 		}
 	}
 
-	// ── Step 2: BypassPermissions mode ──
-	// Bypass is intentionally unconditional once explicit deny rules have run:
-	// it suppresses every confirmation, including the normal safety and working
-	// directory checks below.
+	// ── Step 2: Bypass-immune floor ──
+	// Only the unrecoverable tier is immune to bypass: real destruction, a
+	// sensitive path, data exfiltration. Recoverable operations (the git tier
+	// below) are deliberately NOT held here, so bypass mode runs them freely.
+	if reason := UnrecoverableReason(toolName, args); reason != "" {
+		return coerceAsk(decide(perm.Prompt, "bypass-immune: "+reason), session)
+	}
+
+	// ── Step 3: BypassPermissions mode ──
 	if session != nil && session.Mode == ModeBypassPermissions {
 		return decide(perm.Permit, "mode: bypass permissions")
 	}
 
-	// ── Step 3: Confirmation safety checks ──
+	// ── Step 4: Confirmation checks (recoverable tier) ──
 	if reason, reviewable := s.confirmationPromptReason(toolName, args, session); reason != "" {
 		d := decide(perm.Prompt, reason)
 		d.Reviewable = reviewable
 		return coerceAsk(d, session)
 	}
 
-	// ── Step 4: Session permissions ──
+	// ── Step 5: Session permissions ──
 	if session != nil {
 		if session.IsToolAllowed(toolName) {
 			return decide(perm.Permit, "session: allow all "+toolName)
@@ -86,32 +94,30 @@ func (s *Data) HasPermissionToUseTool(toolName string, args map[string]any, sess
 		}
 	}
 
-	// ── Step 5: Ask rules ──
+	// ── Step 6: Ask rules ──
 	for _, pattern := range s.Permissions.Ask {
 		if MatchesToolPattern(toolName, args, rule, pattern) {
 			return coerceAsk(decide(perm.Prompt, "ask rule: "+pattern), session)
 		}
 	}
 
-	// ── Step 6: Allow rules ──
+	// ── Step 7: Allow rules ──
 	if pattern, ok := MatchAllowList(toolName, args, s.Permissions.Allow); ok {
 		return decide(perm.Permit, "allow rule: "+pattern)
 	}
 
-	// ── Step 7/8: Mode default + headless coercion ──
+	// ── Step 8/9: Mode default + headless coercion ──
 	return coerceAsk(modeDefaultDecision(toolName, args, session), session)
 }
 
 // confirmationPromptReason reports why a call requires confirmation and whether
-// the AutoPilot judge may weigh it. Bypass Permissions mode runs before this
-// check and deliberately skips it. Only the recoverable git tier is the judge's
-// to weigh; every other reason here — real destruction, a sensitive path, a
-// write reaching outside the working directory — stays the human's call. The
-// tier travels with the reason rather than being re-derived, so a reason added
-// later cannot land in the judge's lap by omission.
+// the AutoPilot judge may weigh it. It carries only the recoverable tier — the
+// unrecoverable floor already ran (bypass-immune, step 2), and bypass mode
+// skips this step entirely. The git tier is the judge's to weigh; a write
+// reaching outside the working directory stays the human's call.
 func (s *Data) confirmationPromptReason(toolName string, args map[string]any, session *SessionPermissions) (reason string, reviewable bool) {
-	if reason, recoverable := confirmationFloor(toolName, args); reason != "" {
-		return "confirmation: " + reason, recoverable
+	if reason := ConfirmationReason(toolName, args); reason != "" {
+		return "confirmation: " + reason, true
 	}
 
 	if session != nil && len(session.WorkingDirectories) > 0 {
@@ -217,9 +223,9 @@ func coerceAsk(decision PermissionDecision, session *SessionPermissions) Permiss
 }
 
 // ResolveHookAllow checks if a hook's "allow" decision should be honored.
-// Returns false if a deny rule, confirmation safety check, or explicit ask
-// rule overrides the hook's decision. This implements the safety invariant:
-// deny rules > confirmation safety checks > ask rules > hook allow.
+// Returns false if a deny rule, a safety check (either tier), or an explicit
+// ask rule overrides the hook's decision. This implements the safety
+// invariant: deny rules > safety checks > ask rules > hook allow.
 func (s *Data) ResolveHookAllow(toolName string, args map[string]any, session *SessionPermissions) bool {
 	rule := BuildRule(toolName, args)
 	for _, pattern := range s.Permissions.Deny {
@@ -227,8 +233,12 @@ func (s *Data) ResolveHookAllow(toolName string, args map[string]any, session *S
 			return false
 		}
 	}
-	// A hook cannot vouch for anything a confirmation safety check holds,
-	// either tier: there is no judge in this path to weigh the recoverable one.
+	// A hook cannot vouch for anything a safety check holds — neither the
+	// bypass-immune floor nor the recoverable confirmation tier: there is no
+	// judge in this path to weigh the recoverable one.
+	if reason := UnrecoverableReason(toolName, args); reason != "" {
+		return false
+	}
 	if reason, _ := s.confirmationPromptReason(toolName, args, session); reason != "" {
 		return false
 	}
@@ -535,32 +545,21 @@ func MatchAllowList(toolName string, args map[string]any, patterns []string) (st
 	return firstMatch, true
 }
 
-// ConfirmationReason returns a non-empty reason if the call would hit a
-// confirmation safety check (sensitive file path, destructive or
-// work-discarding command). Gates that cannot ask — the subagent gate outside
-// bypass mode — turn the reason into a hard deny.
+// ConfirmationReason returns a non-empty reason if the call sits in the
+// recoverable confirmation tier (work-discarding git commands) — the tier the
+// AutoPilot judge may weigh and bypass mode skips. Gates that cannot ask —
+// the subagent gate outside bypass mode — turn the reason into a hard deny.
 func ConfirmationReason(toolName string, args map[string]any) string {
-	reason, _ := confirmationFloor(toolName, args)
-	return reason
-}
-
-// confirmationFloor classifies a call against both tiers of the floor in one
-// pass: why it is held, and whether it is the recoverable tier the AutoPilot
-// judge may weigh.
-func confirmationFloor(toolName string, args map[string]any) (reason string, recoverable bool) {
-	if reason := UnrecoverableReason(toolName, args); reason != "" {
-		return reason, false
-	}
 	if cmd, ok := bashCommandArg(toolName, args); ok && isGitDiscardingCommand(cmd) {
-		return "git command that discards work", true
+		return "git command that discards work"
 	}
-	return "", false
+	return ""
 }
 
-// UnrecoverableReason is the inner tier of the confirmation floor: the calls
-// whose effect nothing can bring back. It is what the AutoPilot judge checks,
-// so the judge may weigh a recoverable git operation against the session's
-// intent while still being unable to approve real destruction.
+// UnrecoverableReason is the bypass-immune floor: the calls whose effect
+// nothing can bring back. It holds in every mode, bypass included, and the
+// AutoPilot judge can never approve it — the judge may only weigh the
+// recoverable tier (ConfirmationReason).
 func UnrecoverableReason(toolName string, args map[string]any) string {
 	switch toolName {
 	case "Edit", "Write", "NotebookEdit":

--- a/internal/setting/permission_test.go
+++ b/internal/setting/permission_test.go
@@ -327,8 +327,8 @@ func TestGitDiscardingTierIsFlooredButReviewable(t *testing.T) {
 	}
 	for _, cmd := range discarding {
 		args := map[string]any{"command": cmd}
-		if reason, _ := confirmationFloor("Bash", args); reason == "" {
-			t.Errorf("%q left the confirmation floor entirely", cmd)
+		if ConfirmationReason("Bash", args) == "" {
+			t.Errorf("%q left the confirmation tier entirely", cmd)
 		}
 		if r := UnrecoverableReason("Bash", args); r != "" {
 			t.Errorf("%q read as unrecoverable (%s); the judge can never weigh it", cmd, r)
@@ -340,7 +340,7 @@ func TestGitDiscardingTierIsFlooredButReviewable(t *testing.T) {
 	}
 
 	// A lease-guarded push never enters the tier at all.
-	if reason, _ := confirmationFloor("Bash", map[string]any{"command": "git push --force-with-lease"}); reason != "" {
+	if ConfirmationReason("Bash", map[string]any{"command": "git push --force-with-lease"}) != "" {
 		t.Error("--force-with-lease should not be floored")
 	}
 
@@ -664,12 +664,12 @@ func TestCheckPermissionWithReason(t *testing.T) {
 		{
 			"sensitive path has reason",
 			"Edit", map[string]any{"path": "/repo/.git/hooks/pre-commit"},
-			perm.Prompt, "confirmation: .git/ directory",
+			perm.Prompt, "bypass-immune: .git/ directory",
 		},
 		{
 			"destructive has reason",
 			"Bash", map[string]any{"command": "rm -rf /"},
-			perm.Prompt, "confirmation: destructive command",
+			perm.Prompt, "bypass-immune: destructive command",
 		},
 	}
 
@@ -742,9 +742,10 @@ func TestDenialTracking(t *testing.T) {
 func TestBypassPermissionsMode(t *testing.T) {
 	settings := &Data{}
 	session := &SessionPermissions{
-		Mode:            ModeBypassPermissions,
-		AllowedTools:    make(map[string]bool),
-		AllowedPatterns: make(map[string]bool),
+		Mode:               ModeBypassPermissions,
+		AllowedTools:       make(map[string]bool),
+		AllowedPatterns:    make(map[string]bool),
+		WorkingDirectories: []string{"/repo"},
 	}
 
 	tests := []struct {
@@ -764,24 +765,34 @@ func TestBypassPermissionsMode(t *testing.T) {
 			perm.Permit,
 		},
 		{
-			"bypass permits protected path without confirmation",
-			"Edit", map[string]any{"path": "/repo/.git/hooks/pre-commit"},
+			"bypass permits work-discarding git without confirmation",
+			"Bash", map[string]any{"command": "git reset --hard HEAD"},
 			perm.Permit,
 		},
 		{
-			"bypass permits destructive bash without confirmation",
-			"Bash", map[string]any{"command": "rm -rf /"},
-			perm.Permit,
-		},
-		{
-			"bypass permits suspicious bash without confirmation",
-			"Bash", map[string]any{"command": "zmodload zsh/system"},
+			"bypass permits force push without confirmation",
+			"Bash", map[string]any{"command": "git push --force origin main"},
 			perm.Permit,
 		},
 		{
 			"bypass permits writes outside working directories without confirmation",
 			"Write", map[string]any{"file_path": "/etc/san-test", "content": "x"},
 			perm.Permit,
+		},
+		{
+			"bypass-immune: protected path still prompts",
+			"Edit", map[string]any{"path": "/repo/.git/hooks/pre-commit"},
+			perm.Prompt,
+		},
+		{
+			"bypass-immune: destructive bash still prompts",
+			"Bash", map[string]any{"command": "rm -rf /"},
+			perm.Prompt,
+		},
+		{
+			"bypass-immune: suspicious bash still prompts",
+			"Bash", map[string]any{"command": "zmodload zsh/system"},
+			perm.Prompt,
 		},
 	}
 

--- a/internal/setting/permission_test.go
+++ b/internal/setting/permission_test.go
@@ -664,12 +664,17 @@ func TestCheckPermissionWithReason(t *testing.T) {
 		{
 			"sensitive path has reason",
 			"Edit", map[string]any{"path": "/repo/.git/hooks/pre-commit"},
-			perm.Prompt, "bypass-immune: .git/ directory",
+			perm.Prompt, "confirmation: .git/ directory",
 		},
 		{
 			"destructive has reason",
+			"Bash", map[string]any{"command": "rm -rf /tmp/x"},
+			perm.Prompt, "confirmation: destructive command",
+		},
+		{
+			"root removal has circuit-breaker reason",
 			"Bash", map[string]any{"command": "rm -rf /"},
-			perm.Prompt, "bypass-immune: destructive command",
+			perm.Prompt, "circuit breaker: removal targets the filesystem root or home directory",
 		},
 	}
 
@@ -739,6 +744,31 @@ func TestDenialTracking(t *testing.T) {
 	}
 }
 
+func TestIsRootOrHomeRemoval(t *testing.T) {
+	trips := []string{
+		"rm -rf /", "rm -fr /", "rm -r /", "rm --recursive /",
+		"rm -rf /*", "rm -rf ~", "rm -rf ~/", "rm -rf ~/*",
+		"rm -rf $HOME", "rm -rf ${HOME}/",
+		"sudo rm -rf /", "git diff && rm -rf ~",
+		`echo "$(rm -rf ~)"`, "echo `rm -rf /`",
+	}
+	for _, cmd := range trips {
+		if !isRootOrHomeRemoval(cmd) {
+			t.Errorf("%q should trip the circuit breaker", cmd)
+		}
+	}
+
+	passes := []string{
+		"rm -rf /tmp/x", "rm -rf ~/project", "rm file.txt", "rm -rf ./build",
+		"echo rm -rf /", "ls /", "git push --force origin main",
+	}
+	for _, cmd := range passes {
+		if isRootOrHomeRemoval(cmd) {
+			t.Errorf("%q should NOT trip the circuit breaker", cmd)
+		}
+	}
+}
+
 func TestBypassPermissionsMode(t *testing.T) {
 	settings := &Data{}
 	session := &SessionPermissions{
@@ -780,18 +810,38 @@ func TestBypassPermissionsMode(t *testing.T) {
 			perm.Permit,
 		},
 		{
-			"bypass-immune: protected path still prompts",
-			"Edit", map[string]any{"path": "/repo/.git/hooks/pre-commit"},
-			perm.Prompt,
+			"bypass permits destructive bash on a subpath",
+			"Bash", map[string]any{"command": "rm -rf /tmp/example"},
+			perm.Permit,
 		},
 		{
-			"bypass-immune: destructive bash still prompts",
+			"bypass permits sudo",
+			"Bash", map[string]any{"command": "sudo systemctl restart nginx"},
+			perm.Permit,
+		},
+		{
+			"bypass permits protected path writes",
+			"Edit", map[string]any{"path": "/repo/.git/hooks/pre-commit"},
+			perm.Permit,
+		},
+		{
+			"bypass permits suspicious bash",
+			"Bash", map[string]any{"command": "zmodload zsh/system"},
+			perm.Permit,
+		},
+		{
+			"circuit breaker: rm -rf / still prompts in bypass",
 			"Bash", map[string]any{"command": "rm -rf /"},
 			perm.Prompt,
 		},
 		{
-			"bypass-immune: suspicious bash still prompts",
-			"Bash", map[string]any{"command": "zmodload zsh/system"},
+			"circuit breaker: rm -rf ~ still prompts in bypass",
+			"Bash", map[string]any{"command": "rm -rf ~"},
+			perm.Prompt,
+		},
+		{
+			"circuit breaker: substitution form still prompts in bypass",
+			"Bash", map[string]any{"command": `echo "$(rm -rf ~)"`},
 			perm.Prompt,
 		},
 	}

--- a/internal/setting/permission_test.go
+++ b/internal/setting/permission_test.go
@@ -327,7 +327,7 @@ func TestGitDiscardingTierIsFlooredButReviewable(t *testing.T) {
 	}
 	for _, cmd := range discarding {
 		args := map[string]any{"command": cmd}
-		if ConfirmationReason("Bash", args) == "" {
+		if RecoverableReason("Bash", args) == "" {
 			t.Errorf("%q left the confirmation tier entirely", cmd)
 		}
 		if r := UnrecoverableReason("Bash", args); r != "" {
@@ -340,7 +340,7 @@ func TestGitDiscardingTierIsFlooredButReviewable(t *testing.T) {
 	}
 
 	// A lease-guarded push never enters the tier at all.
-	if ConfirmationReason("Bash", map[string]any{"command": "git push --force-with-lease"}) != "" {
+	if RecoverableReason("Bash", map[string]any{"command": "git push --force-with-lease"}) != "" {
 		t.Error("--force-with-lease should not be floored")
 	}
 
@@ -749,7 +749,7 @@ func TestIsRootOrHomeRemoval(t *testing.T) {
 		"rm -rf /", "rm -fr /", "rm -r /", "rm --recursive /",
 		"rm -rf /*", "rm -rf ~", "rm -rf ~/", "rm -rf ~/*",
 		"rm -rf $HOME", "rm -rf ${HOME}/",
-		"sudo rm -rf /", "git diff && rm -rf ~",
+		"sudo rm -rf /", "sudo timeout 5 rm -rf /", "git diff && rm -rf ~",
 		`echo "$(rm -rf ~)"`, "echo `rm -rf /`",
 	}
 	for _, cmd := range trips {
@@ -830,18 +830,10 @@ func TestBypassPermissionsMode(t *testing.T) {
 			perm.Permit,
 		},
 		{
+			// Input variants live in TestIsRootOrHomeRemoval; this case pins
+			// the wiring — the breaker outranks bypass in the pipeline.
 			"circuit breaker: rm -rf / still prompts in bypass",
 			"Bash", map[string]any{"command": "rm -rf /"},
-			perm.Prompt,
-		},
-		{
-			"circuit breaker: rm -rf ~ still prompts in bypass",
-			"Bash", map[string]any{"command": "rm -rf ~"},
-			perm.Prompt,
-		},
-		{
-			"circuit breaker: substitution form still prompts in bypass",
-			"Bash", map[string]any{"command": `echo "$(rm -rf ~)"`},
 			perm.Prompt,
 		},
 	}

--- a/internal/setting/security.go
+++ b/internal/setting/security.go
@@ -245,7 +245,7 @@ var sensitiveFiles = map[string]string{
 }
 
 // isSensitivePath checks if a file path points to a sensitive location that
-// requires user confirmation (skipped only in bypass mode).
+// always requires user confirmation (bypass-immune floor).
 // Returns a human-readable reason if sensitive, or empty string if safe.
 func isSensitivePath(filePath string) string {
 	// Resolve symlinks to prevent bypass via symlink chains

--- a/internal/setting/security.go
+++ b/internal/setting/security.go
@@ -56,6 +56,89 @@ func isDestructiveCommand(cmd string) bool {
 	return matchesBashPatterns(cmd, destructiveCommands)
 }
 
+// isRootOrHomeRemoval reports whether the command contains a recursive rm
+// aimed at the filesystem root or the home directory — the circuit breaker
+// that even bypass mode cannot skip (CircuitBreakerReason). Substitution
+// forms ($(rm -rf ~), backticks) are caught because extractCommandsAST
+// descends into them; a command that fails to parse falls back to a coarse
+// token scan rather than passing silently.
+func isRootOrHomeRemoval(cmd string) bool {
+	file := parseBashAST(cmd)
+	if file == nil {
+		return crudeRootOrHomeRemovalScan(cmd)
+	}
+	for _, c := range extractCommandsAST(file) {
+		name, args := c.Name, c.Args
+		// Unwrap sudo and the neutral wrappers so "sudo rm -rf /" trips too.
+		for (name == "sudo" || safeWrapperCommands[name]) && len(args) > 0 {
+			for len(args) > 0 && strings.HasPrefix(args[0], "-") {
+				args = args[1:]
+			}
+			if len(args) == 0 {
+				break
+			}
+			name, args = args[0], args[1:]
+		}
+		if name != "rm" {
+			continue
+		}
+		recursive := false
+		var targets []string
+		for _, a := range args {
+			if strings.HasPrefix(a, "-") {
+				if a == "--recursive" || (!strings.HasPrefix(a, "--") && strings.ContainsAny(a, "rR")) {
+					recursive = true
+				}
+				continue
+			}
+			targets = append(targets, a)
+		}
+		if recursive && slices.ContainsFunc(targets, isRootOrHomePath) {
+			return true
+		}
+	}
+	return false
+}
+
+// crudeRootOrHomeRemovalScan is the parse-failure fallback for
+// isRootOrHomeRemoval: a flat token scan that trades precision for never
+// letting an unparseable root/home removal through.
+func crudeRootOrHomeRemovalScan(cmd string) bool {
+	hasRM, recursive, rootHome := false, false, false
+	for _, f := range strings.Fields(cmd) {
+		switch {
+		case f == "rm" || strings.HasSuffix(f, "/rm"):
+			hasRM = true
+		case strings.HasPrefix(f, "-") && strings.ContainsAny(f, "rR"):
+			recursive = true
+		case isRootOrHomePath(f):
+			rootHome = true
+		}
+	}
+	return hasRM && recursive && rootHome
+}
+
+// isRootOrHomePath reports whether an rm target denotes the filesystem root
+// or the home directory itself (including ~/*-style glob forms). Paths BELOW
+// home ("~/project") are ordinary destructive targets, not circuit-breaker ones.
+func isRootOrHomePath(target string) bool {
+	if target == "/" || target == "/*" {
+		return true
+	}
+	t := strings.TrimSuffix(target, "/*")
+	t = strings.TrimSuffix(t, "/")
+	switch t {
+	case "~", "$HOME", "${HOME}":
+		return true
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if t == strings.TrimSuffix(home, "/") {
+			return true
+		}
+	}
+	return false
+}
+
 // isGitDiscardingCommand reports whether the command is a git operation that
 // discards work — confirmation-worthy, but recoverable, so the judge may weigh
 // it. "git push --force" is matched by parsing the flags rather than by pattern,
@@ -245,7 +328,7 @@ var sensitiveFiles = map[string]string{
 }
 
 // isSensitivePath checks if a file path points to a sensitive location that
-// always requires user confirmation (bypass-immune floor).
+// requires user confirmation (unrecoverable tier; bypass mode skips it).
 // Returns a human-readable reason if sensitive, or empty string if safe.
 func isSensitivePath(filePath string) string {
 	// Resolve symlinks to prevent bypass via symlink chains

--- a/internal/setting/security.go
+++ b/internal/setting/security.go
@@ -69,15 +69,18 @@ func isRootOrHomeRemoval(cmd string) bool {
 	}
 	for _, c := range extractCommandsAST(file) {
 		name, args := c.Name, c.Args
-		// Unwrap sudo and the neutral wrappers so "sudo rm -rf /" trips too.
+		// Unwrap sudo, and after it any neutral wrapper it exposed, so
+		// "sudo rm -rf /" and "sudo timeout 5 rm -rf /" trip too. Arg skipping
+		// reuses looksLikeCommand — the same heuristic extractFromCall applies
+		// when it strips wrappers — so the two paths cannot drift.
 		for (name == "sudo" || safeWrapperCommands[name]) && len(args) > 0 {
-			for len(args) > 0 && strings.HasPrefix(args[0], "-") {
+			for len(args) > 0 && !looksLikeCommand(args[0]) {
 				args = args[1:]
 			}
 			if len(args) == 0 {
 				break
 			}
-			name, args = args[0], args[1:]
+			name, args = filepath.Base(args[0]), args[1:]
 		}
 		if name != "rm" {
 			continue

--- a/internal/setting/settings.go
+++ b/internal/setting/settings.go
@@ -564,7 +564,7 @@ type OperationMode int
 const (
 	ModeNormal            OperationMode = iota
 	ModeAutoAccept                      // auto-approve edits/writes
-	ModeBypassPermissions               // allow all except deny rules and the bypass-immune floor
+	ModeBypassPermissions               // allow all except deny rules and the root/home-removal circuit breaker
 	ModeDontAsk                         // convert ask → deny (never prompt)
 	ModeReadOnly                        // safe tools only; everything else denied (subagent explore)
 	ModeAutoPilot                       // auto-approve edits; delegate the rest to the review agent

--- a/internal/setting/settings.go
+++ b/internal/setting/settings.go
@@ -564,7 +564,7 @@ type OperationMode int
 const (
 	ModeNormal            OperationMode = iota
 	ModeAutoAccept                      // auto-approve edits/writes
-	ModeBypassPermissions               // allow all after deny rules (no confirmation checks)
+	ModeBypassPermissions               // allow all except deny rules and the bypass-immune floor
 	ModeDontAsk                         // convert ask → deny (never prompt)
 	ModeReadOnly                        // safe tools only; everything else denied (subagent explore)
 	ModeAutoPilot                       // auto-approve edits; delegate the rest to the review agent

--- a/internal/subagent/executor.go
+++ b/internal/subagent/executor.go
@@ -516,11 +516,11 @@ func (e *Executor) skillsDirectoryFor(config *AgentConfig) string {
 }
 
 // subagentPermissionFunc returns the subagent permission gate. The pipeline
-// matches docs/concepts/permission-model.md: deny_tools, bypass-immune floor,
-// confirmation tier, allow_tools, mode default, with Prompt collapsing to
-// Deny because subagents cannot ask. bypassPermissions mode skips only the
-// recoverable confirmation tier — the bypass-immune floor holds in every
-// mode.
+// matches docs/concepts/permission-model.md: deny_tools, circuit breaker,
+// confirmation tiers, allow_tools, mode default, with Prompt collapsing to
+// Deny because subagents cannot ask. bypassPermissions mode skips the
+// confirmation tiers — only the root/home-removal circuit breaker holds in
+// every mode.
 //
 // One communication carve-out sits between deny and allow_tools: for a
 // mode-gated worker (no explicit allow_tools list) SendMessage is permitted in
@@ -538,21 +538,24 @@ func subagentPermissionFunc(mode PermissionMode, allowRules, denyRules ToolList)
 		if denyRules.Matches(name, input) {
 			return false, fmt.Sprintf("tool %s is blocked by deny_tools", name)
 		}
-		// Bypass-immune floor: an unrecoverable call (real destruction, a
-		// sensitive path, data exfiltration) is denied in every mode, bypass
-		// included — subagents cannot ask, so the floor is a hard deny.
-		if reason := setting.UnrecoverableReason(name, input); reason != "" {
+		// Circuit breaker: a recursive removal of the filesystem root or the
+		// home directory is denied in every mode, bypass included — subagents
+		// cannot ask, so the breaker is a hard deny.
+		if reason := setting.CircuitBreakerReason(name, input); reason != "" {
 			return false, fmt.Sprintf("tool %s blocked: %s", name, reason)
 		}
-		// Bypass mode skips the recoverable confirmation tier: after deny_tools
-		// and the floor above, permit every executable worker tool. Keep the
+		// Bypass mode skips both confirmation tiers: after deny_tools and the
+		// breaker above, permit every executable worker tool. Keep the
 		// parent-only restriction below so a worker still cannot spawn agents
 		// or manipulate main-only state.
 		if opMode == setting.ModeBypassPermissions && !tool.IsParentOnlyTool(name) {
 			return true, ""
 		}
-		// Outside bypass, the recoverable tier (work-discarding git) is also a
-		// hard deny, so a greedy allow_tools pattern cannot smuggle it through.
+		// Outside bypass, both confirmation tiers are hard denies, so a greedy
+		// allow_tools pattern cannot smuggle destruction through.
+		if reason := setting.UnrecoverableReason(name, input); reason != "" {
+			return false, fmt.Sprintf("tool %s blocked: %s", name, reason)
+		}
 		if reason := setting.ConfirmationReason(name, input); reason != "" {
 			return false, fmt.Sprintf("tool %s blocked: %s", name, reason)
 		}

--- a/internal/subagent/executor.go
+++ b/internal/subagent/executor.go
@@ -553,10 +553,7 @@ func subagentPermissionFunc(mode PermissionMode, allowRules, denyRules ToolList)
 		}
 		// Outside bypass, both confirmation tiers are hard denies, so a greedy
 		// allow_tools pattern cannot smuggle destruction through.
-		if reason := setting.UnrecoverableReason(name, input); reason != "" {
-			return false, fmt.Sprintf("tool %s blocked: %s", name, reason)
-		}
-		if reason := setting.ConfirmationReason(name, input); reason != "" {
+		if reason, _ := setting.ConfirmationTier(name, input); reason != "" {
 			return false, fmt.Sprintf("tool %s blocked: %s", name, reason)
 		}
 		// Parent-only tools never reach a worker, even via allow_tools —

--- a/internal/subagent/executor.go
+++ b/internal/subagent/executor.go
@@ -516,11 +516,11 @@ func (e *Executor) skillsDirectoryFor(config *AgentConfig) string {
 }
 
 // subagentPermissionFunc returns the subagent permission gate. The pipeline
-// matches docs/concepts/permission-model.md: deny_tools, confirmation floor,
-// allow_tools, mode default, with Prompt collapsing to Deny because subagents
-// cannot ask. In bypassPermissions mode, the mode policy permits every
-// non-parent-only call after deny_tools, including otherwise
-// confirmation-required calls.
+// matches docs/concepts/permission-model.md: deny_tools, bypass-immune floor,
+// confirmation tier, allow_tools, mode default, with Prompt collapsing to
+// Deny because subagents cannot ask. bypassPermissions mode skips only the
+// recoverable confirmation tier — the bypass-immune floor holds in every
+// mode.
 //
 // One communication carve-out sits between deny and allow_tools: for a
 // mode-gated worker (no explicit allow_tools list) SendMessage is permitted in
@@ -538,16 +538,21 @@ func subagentPermissionFunc(mode PermissionMode, allowRules, denyRules ToolList)
 		if denyRules.Matches(name, input) {
 			return false, fmt.Sprintf("tool %s is blocked by deny_tools", name)
 		}
-		// Bypass mode means no permission confirmation: after honoring explicit
-		// deny_tools, permit every executable worker tool. Keep the parent-only
-		// restriction below so a worker still cannot spawn agents or manipulate
-		// main-only state.
+		// Bypass-immune floor: an unrecoverable call (real destruction, a
+		// sensitive path, data exfiltration) is denied in every mode, bypass
+		// included — subagents cannot ask, so the floor is a hard deny.
+		if reason := setting.UnrecoverableReason(name, input); reason != "" {
+			return false, fmt.Sprintf("tool %s blocked: %s", name, reason)
+		}
+		// Bypass mode skips the recoverable confirmation tier: after deny_tools
+		// and the floor above, permit every executable worker tool. Keep the
+		// parent-only restriction below so a worker still cannot spawn agents
+		// or manipulate main-only state.
 		if opMode == setting.ModeBypassPermissions && !tool.IsParentOnlyTool(name) {
 			return true, ""
 		}
-		// Outside bypass, the confirmation floor is a hard deny: subagents
-		// cannot ask, so a destructive or sensitive call is refused even when a
-		// greedy allow_tools pattern would otherwise match it.
+		// Outside bypass, the recoverable tier (work-discarding git) is also a
+		// hard deny, so a greedy allow_tools pattern cannot smuggle it through.
 		if reason := setting.ConfirmationReason(name, input); reason != "" {
 			return false, fmt.Sprintf("tool %s blocked: %s", name, reason)
 		}

--- a/internal/subagent/executor_test.go
+++ b/internal/subagent/executor_test.go
@@ -532,10 +532,15 @@ func TestBypassModeAllowsEverything(t *testing.T) {
 	if !allow {
 		t.Fatal("bypass mode should allow Bash")
 	}
-	// Bypass permits confirmation-required commands too.
-	allow, reason := check(context.Background(), "Bash", map[string]any{"command": "rm -rf /tmp/example"})
+	// Bypass skips the recoverable confirmation tier (work-discarding git)…
+	allow, reason := check(context.Background(), "Bash", map[string]any{"command": "git push --force origin main"})
 	if !allow {
-		t.Fatalf("bypass mode should allow destructive Bash: %s", reason)
+		t.Fatalf("bypass mode should allow work-discarding git: %s", reason)
+	}
+	// …but the unrecoverable bypass-immune floor still holds.
+	allow, _ = check(context.Background(), "Bash", map[string]any{"command": "rm -rf /tmp/example"})
+	if allow {
+		t.Fatal("bypass mode must still deny unrecoverable destruction")
 	}
 	// Parent-only tools stay denied even in bypass mode — the agent model
 	// is flat, and the gate backs up the schema-level exclusion.

--- a/internal/subagent/executor_test.go
+++ b/internal/subagent/executor_test.go
@@ -532,7 +532,8 @@ func TestBypassModeAllowsEverything(t *testing.T) {
 	if !allow {
 		t.Fatal("bypass mode should allow Bash")
 	}
-	// Bypass skips both confirmation tiers…
+	// Bypass skips both confirmation tiers. The circuit-breaker counterpart
+	// (rm -rf ~ still denied) is pinned in TestPermissionScenarios.
 	allow, reason := check(context.Background(), "Bash", map[string]any{"command": "git push --force origin main"})
 	if !allow {
 		t.Fatalf("bypass mode should allow work-discarding git: %s", reason)
@@ -540,11 +541,6 @@ func TestBypassModeAllowsEverything(t *testing.T) {
 	allow, reason = check(context.Background(), "Bash", map[string]any{"command": "rm -rf /tmp/example"})
 	if !allow {
 		t.Fatalf("bypass mode should allow destructive bash on a subpath: %s", reason)
-	}
-	// …but the root/home-removal circuit breaker still holds.
-	allow, _ = check(context.Background(), "Bash", map[string]any{"command": "rm -rf ~"})
-	if allow {
-		t.Fatal("bypass mode must still deny a home-directory removal")
 	}
 	// Parent-only tools stay denied even in bypass mode — the agent model
 	// is flat, and the gate backs up the schema-level exclusion.

--- a/internal/subagent/executor_test.go
+++ b/internal/subagent/executor_test.go
@@ -532,15 +532,19 @@ func TestBypassModeAllowsEverything(t *testing.T) {
 	if !allow {
 		t.Fatal("bypass mode should allow Bash")
 	}
-	// Bypass skips the recoverable confirmation tier (work-discarding git)…
+	// Bypass skips both confirmation tiers…
 	allow, reason := check(context.Background(), "Bash", map[string]any{"command": "git push --force origin main"})
 	if !allow {
 		t.Fatalf("bypass mode should allow work-discarding git: %s", reason)
 	}
-	// …but the unrecoverable bypass-immune floor still holds.
-	allow, _ = check(context.Background(), "Bash", map[string]any{"command": "rm -rf /tmp/example"})
+	allow, reason = check(context.Background(), "Bash", map[string]any{"command": "rm -rf /tmp/example"})
+	if !allow {
+		t.Fatalf("bypass mode should allow destructive bash on a subpath: %s", reason)
+	}
+	// …but the root/home-removal circuit breaker still holds.
+	allow, _ = check(context.Background(), "Bash", map[string]any{"command": "rm -rf ~"})
 	if allow {
-		t.Fatal("bypass mode must still deny unrecoverable destruction")
+		t.Fatal("bypass mode must still deny a home-directory removal")
 	}
 	// Parent-only tools stay denied even in bypass mode — the agent model
 	// is flat, and the gate backs up the schema-level exclusion.

--- a/internal/subagent/scenarios_test.go
+++ b/internal/subagent/scenarios_test.go
@@ -64,18 +64,24 @@ func TestPermissionScenarios(t *testing.T) {
 			want: false, wantMatch: "blocked by deny_tools",
 		},
 
-		// ── 3. bypass skips the recoverable tier; the unrecoverable floor holds ──
+		// ── 3. bypass skips confirmation tiers; the circuit breaker holds ──
 		{
-			name: "rm -rf in compound bash — bypass-immune floor still blocks",
+			name: "rm -rf on a subpath in compound bash — bypass allows",
 			mode: PermissionBypass, allow: allowGitDiff,
 			tool: "Bash", input: map[string]any{"command": "git diff && rm -rf /tmp/dummy"},
-			want: false, wantMatch: "blocked",
+			want: true,
 		},
 		{
 			name: "git push --force — bypass allows without confirmation",
 			mode: PermissionBypass, allow: ToolList{{Name: "Bash"}},
 			tool: "Bash", input: map[string]any{"command": "git push --force origin main"},
 			want: true,
+		},
+		{
+			name: "rm -rf ~ — circuit breaker blocks even in bypass",
+			mode: PermissionBypass, allow: ToolList{{Name: "Bash"}},
+			tool: "Bash", input: map[string]any{"command": "rm -rf ~"},
+			want: false, wantMatch: "blocked",
 		},
 		{
 			name: "git push --force — non-bypass hits the confirmation tier",

--- a/internal/subagent/scenarios_test.go
+++ b/internal/subagent/scenarios_test.go
@@ -64,12 +64,12 @@ func TestPermissionScenarios(t *testing.T) {
 			want: false, wantMatch: "blocked by deny_tools",
 		},
 
-		// ── 3. bypass permits destructive commands after deny_tools ──
+		// ── 3. bypass skips the recoverable tier; the unrecoverable floor holds ──
 		{
-			name: "rm -rf in compound bash — bypass allows without confirmation",
+			name: "rm -rf in compound bash — bypass-immune floor still blocks",
 			mode: PermissionBypass, allow: allowGitDiff,
 			tool: "Bash", input: map[string]any{"command": "git diff && rm -rf /tmp/dummy"},
-			want: true,
+			want: false, wantMatch: "blocked",
 		},
 		{
 			name: "git push --force — bypass allows without confirmation",
@@ -78,9 +78,9 @@ func TestPermissionScenarios(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "rm -rf in compound bash — non-bypass hits the confirmation floor",
-			mode: PermissionDefault, allow: allowGitDiff,
-			tool: "Bash", input: map[string]any{"command": "git diff && rm -rf /tmp/dummy"},
+			name: "git push --force — non-bypass hits the confirmation tier",
+			mode: PermissionDefault, allow: ToolList{{Name: "Bash"}},
+			tool: "Bash", input: map[string]any{"command": "git push --force origin main"},
 			want: false, wantMatch: "blocked",
 		},
 

--- a/internal/subagent/types.go
+++ b/internal/subagent/types.go
@@ -30,7 +30,7 @@ const (
 	// Used for research and read-only investigation.
 	PermissionExplore PermissionMode = "explore"
 
-	// PermissionBypass: everything Allow after deny_tools and the bypass-immune floor
+	// PermissionBypass: everything Allow after deny_tools and the root/home-removal circuit breaker
 	// (sensitive paths, destructive bash) which still gate the call.
 	PermissionBypass PermissionMode = "bypassPermissions"
 

--- a/internal/subagent/types.go
+++ b/internal/subagent/types.go
@@ -30,7 +30,7 @@ const (
 	// Used for research and read-only investigation.
 	PermissionExplore PermissionMode = "explore"
 
-	// PermissionBypass: everything Allow after deny_tools (parent-only tools still blocked)
+	// PermissionBypass: everything Allow after deny_tools and the bypass-immune floor
 	// (sensitive paths, destructive bash) which still gate the call.
 	PermissionBypass PermissionMode = "bypassPermissions"
 

--- a/internal/subagent/types.go
+++ b/internal/subagent/types.go
@@ -30,8 +30,8 @@ const (
 	// Used for research and read-only investigation.
 	PermissionExplore PermissionMode = "explore"
 
-	// PermissionBypass: everything Allow after deny_tools and the root/home-removal circuit breaker
-	// (sensitive paths, destructive bash) which still gate the call.
+	// PermissionBypass: everything Allow after deny_tools and the
+	// root/home-removal circuit breaker, which still gate the call.
 	PermissionBypass PermissionMode = "bypassPermissions"
 
 	// PermissionDontAsk: reads auto, everything else silently Deny.


### PR DESCRIPTION
Follow-up to #391 (which merged before its correction commit): bypass mode now sits between the two earlier designs, modeled on Claude Code's bypassPermissions minus the sandbox.

Pipeline:
1. deny rules
2. **circuit breaker** — the one check no mode may skip: a recursive removal of the filesystem root or home directory (`rm -rf /`, `rm -rf ~`, `sudo` prefixes, `$()`/backtick substitution forms; AST-based with a token-scan fallback on parse failure)
3. bypassPermissions → allow everything else — subpath `rm -rf`, `sudo`, sensitive paths, suspicious bash, and all git operations run without confirmation
4. confirmation tiers (non-bypass modes only): unrecoverable (destructive bash, sensitive paths, exfiltration — never judge-reviewable) and recoverable (work-discarding git — AutoPilot judge may weigh it), then session/ask/allow/mode as before

Outside bypass nothing loosens, and the subagent gate mirrors the same order with hard denies. Docs updated.