### PR TITLE
fix(agent): split stop control from spawn

### DIFF
--- a/docs/guides/writing-a-subagent.md
+++ b/docs/guides/writing-a-subagent.md
@@ -128,7 +128,7 @@ A background subagent registers with the broker while running:
   on its next step. Delivery is best-effort.
 - **Report to main**: `SendMessage(to="main", message)` sends an interim note.
   The final answer returns automatically on completion.
-- **Stop**: `Agent` with `signal: "stop"` and the task id cancels the run. Start a new subagent to continue.
+- **Stop**: `AgentStop` with the task id cancels the run. This optional tool is disabled by default; enable it with `/tool` when the model should manage running workers. Start a new subagent to continue.
 
 ## Trying It
 

--- a/docs/packages/2-feature/task.md
+++ b/docs/packages/2-feature/task.md
@@ -14,12 +14,13 @@ their output asynchronously.
 When the agent invokes `Bash` with `run_in_background: true` or spawns a
 subagent via `Agent`, the work is registered as a `BackgroundTask` here.
 The TUI's task panel reads from this registry; completion notifications
-flow back to the agent automatically, and the Agent tool's stop signal
-cancels a running task.
+flow back to the agent automatically. `AgentStop` cancels a running agent
+task; on Unix, a background Bash command reports its own process-group ID so
+Bash can terminate it directly.
 
 ## Contract
 
-Background task manager. Tracks bash and subagent tasks for the TUI panel and the Agent tool's stop signal. The package exposes `*Tracker` directly — no Service interface.
+Background task manager. Tracks bash and subagent tasks for the TUI panel and `AgentStop`. The package exposes `*Tracker` directly — no Service interface.
 
 ```go
 package task

--- a/internal/proc/proc_unix.go
+++ b/internal/proc/proc_unix.go
@@ -37,6 +37,18 @@ func DetachSession(cmd *exec.Cmd) {
 	cmd.SysProcAttr.Setsid = true
 }
 
+// GroupLeaderPID returns the process-group ID a caller can signal (as -pgid)
+// to reach cmd and its ordinary descendants. It is meaningful once cmd was
+// configured with SetProcessGroup or DetachSession — both make the child a
+// group leader, so the PGID equals its PID. ok is false when the command has
+// not started, or on platforms without a signalable process group.
+func GroupLeaderPID(cmd *exec.Cmd) (pid int, ok bool) {
+	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
+		return 0, false
+	}
+	return cmd.Process.Pid, true
+}
+
 // TerminateGroup sends sig to the process group led by cmd. A missing process
 // (ESRCH) is treated as success because the caller's intent — "stop this
 // process" — is already satisfied.

--- a/internal/proc/proc_windows.go
+++ b/internal/proc/proc_windows.go
@@ -19,6 +19,11 @@ func SetProcessGroup(cmd *exec.Cmd) {}
 // this package.
 func DetachSession(cmd *exec.Cmd) {}
 
+// GroupLeaderPID reports that Windows offers no signalable process group —
+// the package does not yet use Job Objects — so callers must fall back to
+// single-process controls.
+func GroupLeaderPID(cmd *exec.Cmd) (pid int, ok bool) { return 0, false }
+
 // TerminateGroup terminates cmd's direct child process. Windows has no
 // signal-based group termination, so sig is ignored and we call Process.Kill,
 // which maps to TerminateProcess. Because we use the handle the standard

--- a/internal/setting/loader.go
+++ b/internal/setting/loader.go
@@ -403,6 +403,9 @@ var defaultDisabledTools = map[string]bool{
 	// their own), so it ships off; the tool's own schema documents it when a
 	// user re-enables it from the /tool panel.
 	"SendMessage": true,
+	// Stopping a background agent is uncommon and destructive. It remains
+	// available through /tool when a user wants the model to manage workers.
+	"AgentStop": true,
 }
 
 // IsDefaultDisabledTool reports whether the tool ships disabled. The /tool

--- a/internal/setting/loader_test.go
+++ b/internal/setting/loader_test.go
@@ -34,8 +34,10 @@ func TestWithDefaultDisabledToolsOverlay(t *testing.T) {
 		t.Fatal("explicit enable must override the task-tracker default")
 	}
 
-	// SendMessage (inter-agent steering) also ships disabled by default.
-	if !WithDefaultDisabledTools(nil)["SendMessage"] {
-		t.Fatal("SendMessage should be disabled by default")
+	// Inter-agent controls ship disabled by default.
+	for _, name := range []string{"SendMessage", "AgentStop"} {
+		if !WithDefaultDisabledTools(nil)[name] {
+			t.Fatalf("%s should be disabled by default", name)
+		}
 	}
 }

--- a/internal/task/bash_task.go
+++ b/internal/task/bash_task.go
@@ -3,6 +3,7 @@ package task
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os/exec"
 	"sync"
 	"sync/atomic"
@@ -116,17 +117,14 @@ func (t *BashTask) GetOutput() string {
 // counterpart to AgentTask.Complete and classifying the same three outcomes.
 //
 // A stopped run reaches cmd.Wait as an ordinary signal death ("signal:
-// terminated"), never as context.Canceled, so unlike the agent case the error
-// alone cannot tell a deliberate stop from a genuine failure. Stop records
-// that it asked, and that flag is the only thing that distinguishes them: a
-// run killed by its own timeout sets nothing and stays a failure. Without this
-// a user-requested TaskStop was recorded as failed, and the main agent could
-// retry work the user had just cancelled — the outcome StatusStopped exists to
-// prevent.
+// terminated"), never as context.Canceled. A manager-initiated stop records
+// that intent before signalling; the Bash tool also reports a process-group
+// command that can send SIGTERM directly. Treat that graceful external
+// termination as stopped too. A timeout uses SIGKILL and remains a failure.
 func (t *BashTask) Complete(exitCode int, err error) {
 	status, errMsg := StatusCompleted, ""
 	switch {
-	case t.stopRequested.Load():
+	case t.stopRequested.Load() || wasGracefullyTerminated(err):
 		status, errMsg = StatusStopped, "stopped before completion"
 	case err != nil:
 		status, errMsg = StatusFailed, err.Error()
@@ -134,6 +132,20 @@ func (t *BashTask) Complete(exitCode int, err error) {
 		status = StatusFailed
 	}
 	t.finalize(status, exitCode, errMsg)
+}
+
+// wasGracefullyTerminated reports whether the child died of SIGTERM — the
+// graceful stop delivered by the process-group command Bash hands out. It is
+// deliberately narrow: timeout and forced-stop paths use SIGKILL, and a
+// non-zero exit is Exited, not Signaled, so both remain failures. (On Windows
+// WaitStatus.Signaled is always false, so this never matches there.)
+func wasGracefullyTerminated(err error) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	ws, ok := exitErr.Sys().(syscall.WaitStatus)
+	return ok && ws.Signaled() && ws.Signal() == syscall.SIGTERM
 }
 
 // signalExitCode renders a death by signal the way a shell does, so a reader

--- a/internal/task/bash_task_test.go
+++ b/internal/task/bash_task_test.go
@@ -239,14 +239,32 @@ func TestBashTask_ImplementsBackgroundTask(t *testing.T) {
 }
 
 // A stopped child dies of the signal Stop sent it, so cmd.Wait reports
-// "signal: terminated" — indistinguishable from a crash by the error alone.
-// Recording that as failed told the main agent the work had broken rather than
-// been called off, inviting a retry of what the user had just cancelled.
+// "signal: terminated". Recording that as failed would tell the main agent
+// the work had broken rather than been called off, inviting an unwanted retry.
 func TestBashTaskStopIsNotAFailure(t *testing.T) {
 	task := newRunningBashTask(t, "stop-id", "sleep 100", "Long task")
 
 	_ = task.Stop()
 	task.Complete(signalExitCode(syscall.SIGTERM), errors.New("signal: terminated"))
+
+	if info := task.GetStatus(); info.Status != StatusStopped {
+		t.Errorf("expected status '%s', got '%s'", StatusStopped, info.Status)
+	}
+}
+
+// Bash exposes the task's process-group ID, so the model can send this same
+// SIGTERM directly from a later Bash invocation. The real *exec.ExitError
+// from that death must classify as stopped, same as a Manager.Kill call.
+func TestBashTaskDirectGracefulTerminationIsNotAFailure(t *testing.T) {
+	task := newRunningBashTask(t, "direct-stop-id", "sleep 100", "Long task")
+
+	cmd := exec.Command("sh", "-c", "kill -TERM $$")
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("helper was expected to die of SIGTERM")
+	}
+
+	task.Complete(signalExitCode(syscall.SIGTERM), err)
 
 	if info := task.GetStatus(); info.Status != StatusStopped {
 		t.Errorf("expected status '%s', got '%s'", StatusStopped, info.Status)

--- a/internal/task/types.go
+++ b/internal/task/types.go
@@ -32,9 +32,8 @@ const (
 // An implementation owes one thing the compiler cannot check: a Stop-induced
 // exit must stay distinguishable from a failure, so that a task the user
 // called off is not reported as broken work to retry. How is left open,
-// because the two existing types genuinely differ — a bash child dies of an
-// opaque signal and so must record the intent up front, while an agent
-// goroutine returns context.Canceled, which says it already.
+// because the two existing types genuinely differ — a bash child reports its
+// graceful SIGTERM, while an agent goroutine returns context.Canceled.
 type BackgroundTask interface {
 	// GetID returns the unique task identifier
 	GetID() string

--- a/internal/tool/agent/agent.go
+++ b/internal/tool/agent/agent.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/genai-io/san/internal/task"
 	"github.com/genai-io/san/internal/tool"
 	"github.com/genai-io/san/internal/tool/perm"
 	"github.com/genai-io/san/internal/tool/toolresult"
@@ -40,21 +39,6 @@ func (t *AgentTool) SetExecutor(executor tool.AgentExecutor) {
 
 // PreparePermission prepares a permission request with agent metadata
 func (t *AgentTool) PreparePermission(ctx context.Context, params map[string]any, cwd string) (*perm.PermissionRequest, error) {
-	if signal := tool.GetString(params, "signal"); signal != "" {
-		if signal != "stop" {
-			return nil, fmt.Errorf("unknown signal: %s", signal)
-		}
-		taskID := tool.GetString(params, "task_id")
-		if taskID == "" {
-			return nil, fmt.Errorf("task_id is required when signal is \"stop\"")
-		}
-		return &perm.PermissionRequest{
-			ID:          tool.GenerateRequestID(),
-			ToolName:    t.Name(),
-			Description: fmt.Sprintf("Stop background task %s", taskID),
-		}, nil
-	}
-
 	agentType := tool.GetString(params, "subagent_type")
 	if agentType == "" {
 		agentType = "general-purpose"
@@ -143,13 +127,6 @@ func (t *AgentTool) Execute(ctx context.Context, params map[string]any, cwd stri
 // is what keeps the model flat — main spawns workers, workers do not.
 func (t *AgentTool) execute(ctx context.Context, params map[string]any, cwd string) toolresult.ToolResult {
 	start := time.Now()
-
-	if signal := tool.GetString(params, "signal"); signal != "" {
-		if signal != "stop" {
-			return toolresult.NewErrorResult(t.Name(), fmt.Sprintf("unknown signal: %s", signal))
-		}
-		return t.stopTask(params, start)
-	}
 
 	agentType := tool.GetString(params, "subagent_type")
 	if agentType == "" {
@@ -263,59 +240,6 @@ func (t *AgentTool) execute(ctx context.Context, params map[string]any, cwd stri
 			Icon:     t.Icon(),
 			Subtitle: fmt.Sprintf("%s: done (%d steps)", agentType, result.StepCount),
 			Duration: duration,
-		},
-	}
-}
-
-// stopTask cancels a running background task (agent worker or background
-// command). The prompt, when given, is recorded as the cancellation reason.
-func (t *AgentTool) stopTask(params map[string]any, start time.Time) toolresult.ToolResult {
-	taskID := tool.GetString(params, "task_id")
-	if taskID == "" {
-		return toolresult.NewErrorResult(t.Name(), "task_id is required when signal is \"stop\"")
-	}
-
-	bgTask, found := task.Default().Get(taskID)
-	if !found {
-		return toolresult.NewErrorResult(t.Name(), fmt.Sprintf("task not found: %s", taskID))
-	}
-	if !bgTask.IsRunning() {
-		info := bgTask.GetStatus()
-		return toolresult.NewErrorResult(t.Name(), fmt.Sprintf("task already completed with status: %s", info.Status))
-	}
-
-	info := bgTask.GetStatus()
-	if err := task.Default().Kill(taskID); err != nil {
-		return toolresult.NewErrorResult(t.Name(), fmt.Sprintf("failed to stop task: %v", err))
-	}
-	finalInfo := bgTask.GetStatus()
-
-	var output string
-	switch info.Type {
-	case task.TaskTypeBash:
-		output = fmt.Sprintf("Task stopped successfully.\nTask ID: %s\nType: bash\nPID: %d\nStatus: %s",
-			taskID, info.PID, finalInfo.Status)
-	case task.TaskTypeAgent:
-		output = fmt.Sprintf("Task stopped successfully.\nTask ID: %s\nType: agent\nAgent: %s\nSteps: %d\nStatus: %s",
-			taskID, info.AgentName, info.StepCount, finalInfo.Status)
-	default:
-		output = fmt.Sprintf("Task stopped successfully.\nTask ID: %s\nStatus: %s", taskID, finalInfo.Status)
-	}
-	if reason := tool.GetString(params, "prompt"); reason != "" {
-		output += "\nReason: " + reason
-	}
-	if finalInfo.Output != "" {
-		output += fmt.Sprintf("\n\nOutput before stop:\n%s", finalInfo.Output)
-	}
-
-	return toolresult.ToolResult{
-		Success: true,
-		Output:  output,
-		Metadata: toolresult.ResultMetadata{
-			Title:    t.Name(),
-			Icon:     t.Icon(),
-			Subtitle: fmt.Sprintf("Stopped: %s", taskID),
-			Duration: time.Since(start),
 		},
 	}
 }

--- a/internal/tool/agent/agent_stop.go
+++ b/internal/tool/agent/agent_stop.go
@@ -1,0 +1,93 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/genai-io/san/internal/task"
+	"github.com/genai-io/san/internal/tool"
+	"github.com/genai-io/san/internal/tool/perm"
+	"github.com/genai-io/san/internal/tool/toolresult"
+)
+
+// AgentStopTool stops a running background subagent. Bash tasks deliberately
+// stay outside this control surface: Bash reports its process-group ID, so the
+// model can stop that command with Bash itself.
+type AgentStopTool struct{}
+
+var _ tool.PermissionAwareTool = (*AgentStopTool)(nil)
+
+func NewAgentStopTool() *AgentStopTool { return &AgentStopTool{} }
+
+func (t *AgentStopTool) Name() string        { return tool.ToolAgentStop }
+func (t *AgentStopTool) Description() string { return "Stop a running background agent" }
+func (t *AgentStopTool) Icon() string        { return tool.IconAgent }
+
+func (t *AgentStopTool) RequiresPermission() bool { return true }
+
+func (t *AgentStopTool) PreparePermission(ctx context.Context, params map[string]any, cwd string) (*perm.PermissionRequest, error) {
+	taskID, err := tool.RequireString(params, "task_id")
+	if err != nil {
+		return nil, err
+	}
+	return &perm.PermissionRequest{
+		ID:          tool.GenerateRequestID(),
+		ToolName:    t.Name(),
+		Description: fmt.Sprintf("Stop background agent %s", taskID),
+	}, nil
+}
+
+func (t *AgentStopTool) ExecuteApproved(ctx context.Context, params map[string]any, cwd string) toolresult.ToolResult {
+	return t.execute(params)
+}
+
+func (t *AgentStopTool) Execute(ctx context.Context, params map[string]any, cwd string) toolresult.ToolResult {
+	return t.execute(params)
+}
+
+func (t *AgentStopTool) execute(params map[string]any) toolresult.ToolResult {
+	start := time.Now()
+	taskID, err := tool.RequireString(params, "task_id")
+	if err != nil {
+		return toolresult.NewErrorResult(t.Name(), err.Error())
+	}
+
+	bgTask, found := task.Default().Get(taskID)
+	if !found {
+		return toolresult.NewErrorResult(t.Name(), fmt.Sprintf("agent task not found: %s", taskID))
+	}
+	if bgTask.GetType() != task.TaskTypeAgent {
+		return toolresult.NewErrorResult(t.Name(), fmt.Sprintf("task %s is a background Bash command; stop its process group with Bash instead", taskID))
+	}
+	// Kill validates liveness itself; a pre-check here would only be a second,
+	// racier copy of its "already completed" rejection.
+	if err := task.Default().Kill(taskID); err != nil {
+		return toolresult.NewErrorResult(t.Name(), fmt.Sprintf("failed to stop agent task: %v", err))
+	}
+
+	info := bgTask.GetStatus()
+	output := fmt.Sprintf("Agent stopped successfully.\nTask ID: %s\nAgent: %s\nSteps: %d\nStatus: %s",
+		taskID, info.AgentName, info.StepCount, info.Status)
+	if reason := tool.GetString(params, "reason"); reason != "" {
+		output += "\nReason: " + reason
+	}
+	if info.Output != "" {
+		output += fmt.Sprintf("\n\nOutput before stop:\n%s", info.Output)
+	}
+
+	return toolresult.ToolResult{
+		Success: true,
+		Output:  output,
+		Metadata: toolresult.ResultMetadata{
+			Title:    t.Name(),
+			Icon:     t.Icon(),
+			Subtitle: fmt.Sprintf("Stopped: %s", taskID),
+			Duration: time.Since(start),
+		},
+	}
+}
+
+func init() {
+	tool.Register(NewAgentStopTool())
+}

--- a/internal/tool/agent/schema.go
+++ b/internal/tool/agent/schema.go
@@ -46,7 +46,6 @@ func agentSchema(agentDirectory string) core.ToolSchema {
 	sb.WriteString("Brief the agent like a colleague who just walked in — it has not seen this conversation. Write a self-contained prompt: the goal and why, what you've ruled out, relevant paths and constraints; for lookups the exact command, for investigations the question. Never delegate understanding: \"based on your findings, fix the bug\" pushes synthesis onto the agent.\n\n")
 	sb.WriteString("Notes:\n")
 	sb.WriteString("- Launch independent agents concurrently — multiple Agent calls in one message. Run foreground when you need the result to continue; run_in_background only for genuinely independent work (you are notified on completion).\n")
-	sb.WriteString("- Cancel a running background task with signal \"stop\" and its task_id.\n")
 	sb.WriteString("- A result summary is what the agent meant to do, not what it did — verify the actual changes before reporting work done, and summarize results back to the user yourself.")
 
 	return core.ToolSchema{
@@ -92,17 +91,32 @@ var agentToolParameters = map[string]any{
 			"description": "Permission mode for spawned agent: explore = read-only, edit = can modify files, default = agent config's mode.",
 			"enum":        []string{"explore", "edit", "default"},
 		},
-		"task_id": map[string]any{
-			"type":        "string",
-			"description": "With signal \"stop\": the running background task to cancel.",
-		},
-		"signal": map[string]any{
-			"type":        "string",
-			"enum":        []string{"stop"},
-			"description": "Send a control signal instead of spawning: \"stop\" cancels the running background task named by task_id.",
-		},
 	},
 	"required": []string{"description", "prompt"},
+}
+
+// Schema returns the model-facing tool definition for AgentStop.
+func (t *AgentStopTool) Schema() core.ToolSchema {
+	return core.ToolSchema{
+		Name: t.Name(),
+		Description: `Stops a running background agent.
+
+Only use the exact task_id returned when that agent was started. This tool cannot stop background Bash commands; use the process-group command reported by Bash instead.`,
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"task_id": map[string]any{
+					"type":        "string",
+					"description": "The exact Task ID of the running background agent to stop.",
+				},
+				"reason": map[string]any{
+					"type":        "string",
+					"description": "Optional concise reason for stopping the agent.",
+				},
+			},
+			"required": []string{"task_id"},
+		},
+	}
 }
 
 // Schema returns the model-facing tool definition for SendMessage.

--- a/internal/tool/agent/schema_test.go
+++ b/internal/tool/agent/schema_test.go
@@ -42,3 +42,11 @@ func TestAgentToolSchemaMatchesEmptyDirectory(t *testing.T) {
 		t.Error("SchemaWithAgentDirectory(\"\") must equal the directory-less agentSchema")
 	}
 }
+
+func TestAgentStopSchemaRequiresOnlyTaskID(t *testing.T) {
+	params := (&AgentStopTool{}).Schema().Parameters.(map[string]any)
+	required := params["required"].([]string)
+	if len(required) != 1 || required[0] != "task_id" {
+		t.Fatalf("AgentStop required fields = %#v, want [task_id]", required)
+	}
+}

--- a/internal/tool/agent/stop_test.go
+++ b/internal/tool/agent/stop_test.go
@@ -2,13 +2,14 @@ package agent
 
 import (
 	"context"
+	"os/exec"
 	"strings"
 	"testing"
 
 	"github.com/genai-io/san/internal/task"
 )
 
-func TestAgentTool_StopSignalCancelsRunningTask(t *testing.T) {
+func TestAgentStopCancelsRunningAgent(t *testing.T) {
 	task.Initialize(task.Options{})
 	t.Cleanup(task.ResetDefaultTracker)
 
@@ -18,20 +19,22 @@ func TestAgentTool_StopSignalCancelsRunningTask(t *testing.T) {
 	agentTask := task.NewAgentTask("task-stop-1", "Explore Worker", "Long task", ctx, cancel)
 	task.Default().RegisterTask(agentTask)
 	defer task.Default().Remove("task-stop-1")
+	go func() {
+		<-ctx.Done()
+		agentTask.Complete(ctx.Err())
+	}()
 
-	toolInst := NewAgentTool()
+	toolInst := NewAgentStopTool()
 
 	result := toolInst.Execute(context.Background(), map[string]any{
-		"signal":      "stop",
-		"task_id":     "task-stop-1",
-		"prompt":      "No longer needed",
-		"description": "Stop worker",
+		"task_id": "task-stop-1",
+		"reason":  "No longer needed",
 	}, ".")
 
 	if !result.Success {
 		t.Fatalf("expected success, got error: %s", result.Error)
 	}
-	if !strings.Contains(result.Output, "Task stopped successfully.") {
+	if !strings.Contains(result.Output, "Agent stopped successfully.") {
 		t.Fatalf("unexpected output: %s", result.Output)
 	}
 	if !strings.Contains(result.Output, "Reason: No longer needed") {
@@ -42,7 +45,7 @@ func TestAgentTool_StopSignalCancelsRunningTask(t *testing.T) {
 	}
 }
 
-func TestAgentTool_StopSignalRejectsCompletedTask(t *testing.T) {
+func TestAgentStopRejectsCompletedAgent(t *testing.T) {
 	task.Initialize(task.Options{})
 	t.Cleanup(task.ResetDefaultTracker)
 
@@ -54,13 +57,10 @@ func TestAgentTool_StopSignalRejectsCompletedTask(t *testing.T) {
 	task.Default().RegisterTask(agentTask)
 	defer task.Default().Remove("task-stop-2")
 
-	toolInst := NewAgentTool()
+	toolInst := NewAgentStopTool()
 
 	result := toolInst.Execute(context.Background(), map[string]any{
-		"signal":      "stop",
-		"task_id":     "task-stop-2",
-		"prompt":      "Stop it",
-		"description": "Stop worker",
+		"task_id": "task-stop-2",
 	}, ".")
 
 	if result.Success {
@@ -71,19 +71,43 @@ func TestAgentTool_StopSignalRejectsCompletedTask(t *testing.T) {
 	}
 }
 
-func TestAgentTool_StopSignalRequiresTaskID(t *testing.T) {
-	toolInst := NewAgentTool()
+func TestAgentStopRequiresTaskID(t *testing.T) {
+	toolInst := NewAgentStopTool()
 
-	result := toolInst.Execute(context.Background(), map[string]any{
-		"signal":      "stop",
-		"prompt":      "Stop something",
-		"description": "Stop worker",
-	}, ".")
+	result := toolInst.Execute(context.Background(), map[string]any{}, ".")
 
 	if result.Success {
 		t.Fatal("expected failure without task_id")
 	}
 	if !strings.Contains(result.Error, "task_id is required") {
+		t.Fatalf("unexpected error: %s", result.Error)
+	}
+}
+
+func TestAgentStopRejectsBashTask(t *testing.T) {
+	task.Initialize(task.Options{})
+	t.Cleanup(task.ResetDefaultTracker)
+
+	cmd := exec.Command("bash", "-c", "sleep 60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start bash task: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	bashTask := task.Default().CreateBashTask(cmd, "sleep 60", "Long command", func() {})
+	defer task.Default().Remove(bashTask.GetID())
+
+	result := NewAgentStopTool().Execute(context.Background(), map[string]any{
+		"task_id": bashTask.GetID(),
+	}, ".")
+
+	if result.Success {
+		t.Fatal("expected bash task rejection")
+	}
+	if !strings.Contains(result.Error, "stop its process group with Bash") {
 		t.Fatalf("unexpected error: %s", result.Error)
 	}
 }

--- a/internal/tool/fs/bash.go
+++ b/internal/tool/fs/bash.go
@@ -369,17 +369,31 @@ func (t *BashTool) executeBackground(ctx context.Context, command, description, 
 		bgTask.Complete(exitCode, err)
 	}()
 
-	// Return immediately with task ID
+	// Report how to stop the detached command. Where the platform gives the
+	// child a signalable process group (see proc.GroupLeaderPID), a later Bash
+	// call can stop it and every ordinary descendant without a control tool.
+	output := fmt.Sprintf("Task started in background.\nTask ID: %s\nPID: %d\nCommand: %s\nOutputFile: %s",
+		bgTask.ID, bgTask.PID, command, bgTask.OutputFile)
+	backgroundMeta := map[string]any{
+		"taskId":      bgTask.ID,
+		"description": description,
+		"pid":         bgTask.PID,
+		"outputFile":  bgTask.OutputFile,
+		"toolName":    t.Name(),
+	}
+	if pgid, ok := proc.GroupLeaderPID(cmd); ok {
+		output += fmt.Sprintf("\nProcess group ID: %d\n\nTo stop it while it is still running, use Bash:\nkill -TERM -- -%d\nIf it does not exit after a short wait:\nkill -KILL -- -%d",
+			pgid, pgid, pgid)
+		backgroundMeta["processGroupId"] = pgid
+	} else {
+		output += "\n\nThis platform does not provide a reliable Bash process group. Use the system process controls for PID " + fmt.Sprint(bgTask.PID) + "."
+	}
+
 	return toolresult.ToolResult{
 		Success: true,
-		Output:  fmt.Sprintf("Task started in background.\nTask ID: %s\nPID: %d\nCommand: %s\nOutputFile: %s", bgTask.ID, bgTask.PID, command, bgTask.OutputFile),
+		Output:  output,
 		HookResponse: map[string]any{
-			"backgroundTask": map[string]any{
-				"taskId":      bgTask.ID,
-				"description": description,
-				"outputFile":  bgTask.OutputFile,
-				"toolName":    t.Name(),
-			},
+			"backgroundTask": backgroundMeta,
 		},
 		Metadata: toolresult.ResultMetadata{
 			Title:    t.Name(),

--- a/internal/tool/fs/bash_test.go
+++ b/internal/tool/fs/bash_test.go
@@ -2,9 +2,15 @@ package fs
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/genai-io/san/internal/task"
 )
 
 func TestBashToolTracksChangedDirectory(t *testing.T) {
@@ -36,5 +42,61 @@ func TestBashToolTracksChangedDirectory(t *testing.T) {
 	}
 	if gotResolved != wantResolved {
 		t.Fatalf("tracked cwd = %q (%q), want %q (%q)", got, gotResolved, subdir, wantResolved)
+	}
+}
+
+func TestBackgroundBashReportsProcessGroupStopCommands(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not provide Bash process-group control")
+	}
+	task.Initialize(task.Options{})
+	t.Cleanup(task.ResetDefaultTracker)
+	t.Cleanup(func() {
+		for _, bgTask := range task.Default().ListRunning() {
+			_ = task.Default().Kill(bgTask.GetID())
+		}
+	})
+
+	result := (&BashTool{}).ExecuteApproved(context.Background(), map[string]any{
+		"command":           "sleep 60",
+		"run_in_background": true,
+	}, t.TempDir())
+	if !result.Success {
+		t.Fatalf("background Bash failed: %s", result.Error)
+	}
+	for _, want := range []string{
+		"Process group ID:",
+		"kill -TERM -- -",
+		"kill -KILL -- -",
+	} {
+		if !strings.Contains(result.Output, want) {
+			t.Errorf("background result missing %q:\n%s", want, result.Output)
+		}
+	}
+
+	response, ok := result.HookResponse.(map[string]any)
+	if !ok {
+		t.Fatalf("hook response = %#v, want map", result.HookResponse)
+	}
+	background, ok := response["backgroundTask"].(map[string]any)
+	if !ok || background["processGroupId"] == nil {
+		t.Fatalf("background task metadata = %#v, want processGroupId", background)
+	}
+
+	bgTask, ok := task.Default().Get(background["taskId"].(string))
+	if !ok {
+		t.Fatalf("task %v not registered", background["taskId"])
+	}
+	stop := (&BashTool{}).ExecuteApproved(context.Background(), map[string]any{
+		"command": fmt.Sprintf("kill -TERM -- -%d", background["processGroupId"]),
+	}, t.TempDir())
+	if !stop.Success {
+		t.Fatalf("graceful process-group stop failed: %s", stop.Error)
+	}
+	if !bgTask.WaitForCompletion(time.Second) {
+		t.Fatal("background task did not stop after its reported Bash command")
+	}
+	if got := bgTask.GetStatus().Status; got != task.StatusStopped {
+		t.Fatalf("background task status = %s, want %s", got, task.StatusStopped)
 	}
 }

--- a/internal/tool/fs/schema.go
+++ b/internal/tool/fs/schema.go
@@ -112,7 +112,7 @@ func (t *BashTool) Schema() core.ToolSchema {
 - Search and discovery run through this tool (rg, find/fd, ls); pipe large output through head/wc. Provably read-only commands run without approval prompts.
 - For file contents use the dedicated tools: Read (not cat), Edit (not sed), Write (not echo/redirection).
 - No TTY and no stdin — anything awaiting interactive input hangs until timeout. Use non-interactive flags ("git commit -m", "npm init -y", "apt-get -y") or feed input via heredoc.
-- Optional timeout in ms (default 120000, max 600000). run_in_background detaches the command; you are notified when it finishes, and can cancel it via Agent with signal "stop" and its task ID.`,
+- Optional timeout in ms (default 120000, max 600000). On Unix, run_in_background detaches the command and its result includes the process-group ID plus exact Bash commands for graceful or forced termination.`,
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tool/schema.go
+++ b/internal/tool/schema.go
@@ -12,6 +12,7 @@ const (
 
 	ToolBash        = "Bash"
 	ToolAgent       = "Agent"
+	ToolAgentStop   = "AgentStop"
 	ToolSendMessage = "SendMessage"
 
 	ToolSkill           = "Skill"
@@ -26,7 +27,7 @@ const (
 
 // IsAgentToolName reports whether the tool name represents an agent-like worker tool.
 func IsAgentToolName(name string) bool {
-	return name == ToolAgent || name == ToolSendMessage
+	return name == ToolAgent || name == ToolAgentStop || name == ToolSendMessage
 }
 
 // SchemaOptions configures dynamic content embedded in tool schemas.
@@ -60,7 +61,7 @@ type SchemaOptions struct {
 var builtinToolOrder = []string{
 	ToolRead, ToolWebFetch, ToolWebSearch, ToolEdit, ToolWrite, ToolBash, ToolAskUserQuestion,
 	ToolSkill,
-	ToolAgent, ToolSendMessage,
+	ToolAgent, ToolAgentStop, ToolSendMessage,
 	ToolTaskCreate, ToolTaskGet, ToolTaskUpdate,
 	ToolCron,
 }

--- a/internal/tool/schema_registry_test.go
+++ b/internal/tool/schema_registry_test.go
@@ -31,7 +31,7 @@ func TestBuiltinToolsAllRegistered(t *testing.T) {
 	for _, name := range []string{
 		tool.ToolRead, tool.ToolWebFetch, tool.ToolWebSearch,
 		tool.ToolEdit, tool.ToolWrite, tool.ToolBash, tool.ToolAskUserQuestion,
-		tool.ToolSkill, tool.ToolAgent, tool.ToolSendMessage,
+		tool.ToolSkill, tool.ToolAgent, tool.ToolAgentStop, tool.ToolSendMessage,
 		tool.ToolTaskCreate, tool.ToolTaskGet, tool.ToolTaskUpdate,
 		tool.ToolCron,
 	} {

--- a/internal/tool/set.go
+++ b/internal/tool/set.go
@@ -20,6 +20,7 @@ import (
 // that outlives the worker and belongs to the session owner.
 var parentOnlyTools = map[string]bool{
 	ToolAgent:      true,
+	ToolAgentStop:  true,
 	ToolTaskCreate: true,
 	ToolTaskUpdate: true,
 	ToolTaskGet:    true,


### PR DESCRIPTION
## Summary

- split background-agent cancellation out of `Agent` into an optional `AgentStop` tool
- disable `AgentStop` by default so spawning agents never sees a stop-only enum field
- let background Bash work report a Unix process-group ID and tested `kill` commands for graceful or forced shutdown

## Root cause

`Agent` combined spawning with cancellation through an optional `signal: "stop"` field. Models could emit that singleton enum while trying to spawn a worker, sending a placeholder task ID to the stop path and producing `task not found` instead of starting the worker.

## Behavior

`AgentStop` accepts only a running agent task ID and rejects Bash tasks. It is parent-only and disabled by default; enable it with `/tool` when agent-managed cancellation is needed. Bash remains responsible for stopping its own background commands. On Unix the reported `kill -TERM -- -<pgid>` command stops the process group and records the task as `stopped`.

## Validation

`GOCACHE=/private/tmp/san-go-build-cache go test ./...`
