### PR TITLE
feat(command): ship /simplify as a builtin prompt command

### DIFF
--- a/docs/packages/2-feature/command.md
+++ b/docs/packages/2-feature/command.md
@@ -6,9 +6,11 @@ layer: feature
 # command
 
 Registry for slash commands: built-in handlers (`/help`, `/model`,
-`/identity`, …), dynamic provider-supplied entries, and user-defined
-markdown commands under `commands/` directories. Resolves names, fuzzy
-prefixes, and plugin-scoped command paths.
+`/identity`, …), dynamic provider-supplied entries, builtin prompt
+commands embedded in the binary (`/simplify`), and user-defined markdown
+commands under `commands/` directories. Resolves names, fuzzy prefixes,
+and plugin-scoped command paths; a user or project command shadows a
+builtin prompt command of the same name.
 
 ## Purpose
 

--- a/internal/command/builtin.go
+++ b/internal/command/builtin.go
@@ -1,10 +1,32 @@
 package command
 
-import "fmt"
+import (
+	_ "embed"
+	"fmt"
+)
 
 // WrapInvocation envelopes a workflow body in the <custom-command> tag expected
 // by the skill-invocation pipeline. Centralizing the envelope keeps
 // user-defined custom commands consistent.
 func WrapInvocation(name, body string) string {
 	return fmt.Sprintf("<custom-command name=%q>\n%s\n</custom-command>", name, body)
+}
+
+//go:embed prompts/simplify.md
+var simplifyPrompt string
+
+// builtinPromptCommands are slash commands that ship with San as embedded
+// markdown workflows rather than Go handlers. They dispatch through the same
+// <custom-command> pipeline as user-defined commands, and a user or project
+// command with the same name takes precedence — customizing a shipped
+// workflow is just dropping a file into .san/commands/.
+func builtinPromptCommands() []CustomCommand {
+	return []CustomCommand{
+		{
+			Name:        "simplify",
+			Description: "Review the changed code with 4 parallel cleanup agents (reuse, simplification, efficiency, altitude), then apply the fixes",
+			Body:        simplifyPrompt,
+			Scope:       scopeBuiltin,
+		},
+	}
 }

--- a/internal/command/builtin_test.go
+++ b/internal/command/builtin_test.go
@@ -1,0 +1,64 @@
+package command
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSimplifyShipsAsBuiltinPromptCommand(t *testing.T) {
+	reg := &Registry{cwd: t.TempDir()}
+
+	pc, ok := reg.IsCustomCommand("simplify")
+	if !ok {
+		t.Fatal("/simplify should resolve as a builtin prompt command")
+	}
+	if pc.Scope != scopeBuiltin || pc.FilePath != "" {
+		t.Fatalf("builtin command metadata = %+v", pc)
+	}
+	if pc.Description == "" {
+		t.Fatal("builtin command needs a description for the /help listing")
+	}
+	instructions := pc.GetInstructions()
+	for _, want := range []string{"Phase 0", "Reuse", "Simplification", "Efficiency", "Altitude", "Agent tool"} {
+		if !strings.Contains(instructions, want) {
+			t.Fatalf("simplify workflow should mention %q, got %d bytes", want, len(instructions))
+		}
+	}
+
+	// The builtin also surfaces in the aggregate listing for autocomplete.
+	found := false
+	for _, info := range reg.List() {
+		if info.Name == "simplify" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("/simplify should appear in the command listing")
+	}
+}
+
+func TestDiskCommandShadowsBuiltinPromptCommand(t *testing.T) {
+	root := t.TempDir()
+	cmdsDir := filepath.Join(root, ".san", "commands")
+	if err := os.MkdirAll(cmdsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	custom := "---\nname: simplify\ndescription: my own pass\n---\nDo it my way.\n"
+	if err := os.WriteFile(filepath.Join(cmdsDir, "simplify.md"), []byte(custom), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := &Registry{cwd: root}
+	pc, ok := reg.IsCustomCommand("simplify")
+	if !ok {
+		t.Fatal("/simplify should still resolve")
+	}
+	if pc.FilePath == "" || pc.Scope == scopeBuiltin {
+		t.Fatalf("a project command must shadow the builtin, got %+v", pc)
+	}
+	if got := pc.GetInstructions(); !strings.Contains(got, "Do it my way.") {
+		t.Fatalf("instructions should come from the project file, got %q", got)
+	}
+}

--- a/internal/command/prompts/simplify.md
+++ b/internal/command/prompts/simplify.md
@@ -1,0 +1,65 @@
+`/simplify → 4 cleanup agents in parallel → apply the fixes`
+
+You are improving the quality of the changed code, not hunting for bugs.
+Review it for reuse, simplification, efficiency, and altitude issues, then fix
+what you find. Do not look for correctness bugs — that is a code review's job,
+not this command's.
+
+## Phase 0 — Gather the diff
+
+Run `git diff @{upstream}...HEAD` (or `git diff main...HEAD` / `git diff
+HEAD~1` if there is no upstream) to get the unified diff under review. If
+there are uncommitted changes, or the range diff is empty, also run `git diff
+HEAD` and include the working-tree changes in scope — the review often runs
+before the commit. If a PR number, branch name, or file path was passed as an
+argument, review that target instead. Treat this diff as the review scope.
+
+## Phase 1 — Review (4 cleanup agents in parallel)
+
+Launch **4 independent review agents** via the Agent tool, all in a single
+message so they run concurrently. Tell each agent how to reproduce the diff
+(the exact git command and directory) and give it ONE of the four angles
+below. Each returns its findings with `file`, `line`, a one-line `summary`,
+and the concrete cost (what is duplicated, wasted, or harder to maintain).
+Tell agents to verify each finding against the current file before reporting.
+
+### Reuse
+
+Flag new code that re-implements something the codebase already has — search
+shared/utility modules and files adjacent to the change, and name the
+existing helper to call instead.
+
+### Simplification
+
+Flag unnecessary complexity the diff adds: redundant or derivable state,
+copy-paste with slight variation, deep nesting, dead code left behind (a
+helper whose last caller the diff removed), parameters nobody uses. Name the
+simpler form that does the same job.
+
+### Efficiency
+
+Flag wasted work the diff introduces: redundant computation or repeated I/O,
+work re-done per call that could be computed once, independent operations run
+sequentially, blocking work added to startup or hot paths. Also flag
+long-lived objects built from closures or captured environments — they keep
+the entire enclosing scope alive for the object's lifetime; prefer a struct
+that copies only the fields it needs. Name the cheaper alternative, and be
+honest about whether the cost actually sits on a hot path.
+
+### Altitude
+
+Check that each change is implemented at the right depth, not as a fragile
+bandaid. Special cases layered on shared infrastructure are a sign the fix
+isn't deep enough — prefer generalizing the underlying mechanism over adding
+special cases. Also flag knowledge duplicated across layers that will drift,
+and string-matching against message content where a typed value belongs.
+
+## Phase 2 — Apply the fixes
+
+Wait for all four agents to complete, dedup findings that point at the same
+line or mechanism, and fix each remaining one directly. Skip any finding
+whose fix would change intended behavior, require changes well outside the
+reviewed diff, or that you judge to be a false positive — note the skip
+rather than arguing with it. Run the project's tests and linter after the
+fixes. Finish with a brief summary of what was fixed and what was skipped
+(or confirm the code was already clean).

--- a/internal/command/registry.go
+++ b/internal/command/registry.go
@@ -85,6 +85,7 @@ const (
 	scopeUserPlugin                        // ~/.san/plugins/*/commands/
 	scopeProjectPlugin                     // .san/plugins/*/commands/
 	scopeProject                           // .san/commands/
+	scopeBuiltin                           // embedded in the binary (internal/command/prompts/)
 )
 
 // CustomCommand represents a user-defined slash command from
@@ -96,6 +97,7 @@ type CustomCommand struct {
 	Description string `yaml:"description"`
 	Namespace   string `yaml:"namespace"`
 	FilePath    string
+	Body        string // embedded workflow body for builtin commands (FilePath is empty)
 	Scope       commandScope
 }
 
@@ -107,10 +109,11 @@ func (cc *CustomCommand) FullName() string {
 	return cc.Name
 }
 
-// GetInstructions reads the markdown body (excluding frontmatter) from disk.
+// GetInstructions reads the markdown body (excluding frontmatter) from disk,
+// or returns the embedded body for a builtin command.
 func (cc *CustomCommand) GetInstructions() string {
 	if cc.FilePath == "" {
-		return ""
+		return cc.Body
 	}
 	_, body, _ := markdown.ParseFrontmatterFile(cc.FilePath)
 	return body
@@ -274,8 +277,24 @@ func (s *Registry) loadAllCustomCommands() []CustomCommand {
 	if s.cachedCustomCommands != nil {
 		return s.cachedCustomCommands
 	}
-	s.cachedCustomCommands = s.loadCustomCommandsFromDisk()
+	s.cachedCustomCommands = appendBuiltinPromptCommands(s.loadCustomCommandsFromDisk())
 	return s.cachedCustomCommands
+}
+
+// appendBuiltinPromptCommands adds the workflows shipped inside the binary,
+// unless a disk command already claims the name — user, project, and plugin
+// commands override builtins.
+func appendBuiltinPromptCommands(cmds []CustomCommand) []CustomCommand {
+	taken := make(map[string]struct{}, len(cmds))
+	for _, c := range cmds {
+		taken[c.Name] = struct{}{}
+	}
+	for _, b := range builtinPromptCommands() {
+		if _, shadowed := taken[b.Name]; !shadowed {
+			cmds = append(cmds, b)
+		}
+	}
+	return cmds
 }
 
 // loadCustomCommandsFromDisk loads custom commands from all sources in priority order:

--- a/internal/command/registry_test.go
+++ b/internal/command/registry_test.go
@@ -265,15 +265,22 @@ func TestProjectCommandOverridesUser(t *testing.T) {
 	t.Setenv("HOME", homeDir)
 	t.Cleanup(func() { os.Setenv("HOME", origHome) })
 
-	cmds := svc.loadAllCustomCommands()
-	if len(cmds) != 1 {
-		t.Fatalf("expected 1 command (project overrides user), got %d: %+v", len(cmds), cmds)
+	// The list also carries builtin prompt commands, so assert on the deploy
+	// entries specifically: exactly one, and the project copy wins.
+	var deploys []CustomCommand
+	for _, c := range svc.loadAllCustomCommands() {
+		if c.Name == "deploy" {
+			deploys = append(deploys, c)
+		}
 	}
-	if cmds[0].Description != "Project deploy" {
-		t.Errorf("description = %q, want %q (project should override user)", cmds[0].Description, "Project deploy")
+	if len(deploys) != 1 {
+		t.Fatalf("expected 1 deploy command (project overrides user), got %d: %+v", len(deploys), deploys)
 	}
-	if cmds[0].Scope != scopeProject {
-		t.Errorf("scope = %d, want %d (scopeProject)", cmds[0].Scope, scopeProject)
+	if deploys[0].Description != "Project deploy" {
+		t.Errorf("description = %q, want %q (project should override user)", deploys[0].Description, "Project deploy")
+	}
+	if deploys[0].Scope != scopeProject {
+		t.Errorf("scope = %d, want %d (scopeProject)", deploys[0].Scope, scopeProject)
 	}
 }
 


### PR DESCRIPTION
## What

`/simplify` reviews the branch's changed code with **four cleanup agents launched in parallel** — one angle each — then dedups their findings and applies the fixes directly:

- **Reuse** — new code that re-implements an existing helper; names the helper to call instead.
- **Simplification** — redundant/derivable state, copy-paste variation, deep nesting, dead code; names the simpler form.
- **Efficiency** — redundant computation, repeated I/O, sequential independent work, scope-capturing closures; names the cheaper alternative and whether the cost is actually on a hot path.
- **Altitude** — fixes made at the wrong depth: special cases layered on shared infrastructure, knowledge duplicated across layers, string-matching where a typed value belongs.

It is explicitly a quality pass, not a bug hunt (that's a code review's job). The workflow gathers the diff (`@{upstream}...HEAD`, falling back to `main...HEAD` / `HEAD~1`, plus working-tree changes when present), fans out the four agents in one message, requires each finding to be verified against the current file, and finishes by running tests/linter and summarizing what was fixed and what was skipped.

## How

The vehicle is a new registry concept: a **builtin prompt command** — an embedded markdown workflow (`internal/command/prompts/simplify.md`, `go:embed`) that dispatches through the same `<custom-command>` pipeline as user-defined commands. No Go handler; it appears in `/help` and autocomplete like any other command.

- `CustomCommand` gains a `Body` field (used when `FilePath` is empty) and a `scopeBuiltin` scope.
- `loadAllCustomCommands` appends builtins **after** disk commands, deduped by name — a user or project command with the same name shadows the builtin, so customizing the shipped workflow is just dropping a file into `.san/commands/`.
- The pre-existing project-overrides-user test now asserts on its own command instead of the aggregate count, so future builtins don't perturb it.

## Testing

- `/simplify` resolves as a builtin (scope, empty FilePath, description present), its workflow body carries all four angles, and it appears in the aggregate listing.
- A project-level `simplify.md` shadows the builtin and serves its own instructions.
- `go test ./...` and `make lint` (vet + layercheck) pass; no new packages.