### PR TITLE
fix(tui): nest Bash results under commands 

### DIFF
--- a/internal/app/conv/diff_render.go
+++ b/internal/app/conv/diff_render.go
@@ -22,11 +22,17 @@ import (
 // maxVisible caps the number of rendered rows (0 means no cap). The second
 // return value is how many diff rows were hidden by that cap.
 func RenderFileDiff(lines []perm.DiffLine, width, maxVisible int) (string, int) {
+	return renderFileDiffIndented(lines, width, maxVisible, "     ")
+}
+
+// renderFileDiffIndented renders a diff under a caller-provided transcript
+// indent. Approval previews retain RenderFileDiff's five-column layout, while
+// nested Edit and Write results align their rows with their result trailer.
+func renderFileDiffIndented(lines []perm.DiffLine, width, maxVisible int, indent string) (string, int) {
 	if len(lines) == 0 {
 		return "", 0
 	}
 
-	const indent = "     "
 	rowWidth := max(width-lipgloss.Width(indent), 20)
 	gutterWidth := diffGutterWidth(lines)
 	emphasis := computeDiffEmphasis(lines)
@@ -231,6 +237,7 @@ type storedDiffKey struct {
 	diff       string
 	width      int
 	maxVisible int
+	indent     string
 	darkMode   bool
 }
 
@@ -250,14 +257,18 @@ var (
 // immutable. Only live-region results hit the cache, so it stays tiny; it
 // is dropped wholesale when it outgrows that working set.
 func RenderStoredFileDiff(unifiedDiff string, width, maxVisible int) (string, int) {
-	key := storedDiffKey{diff: unifiedDiff, width: width, maxVisible: maxVisible, darkMode: kit.IsDarkBackground()}
+	return renderStoredFileDiffIndented(unifiedDiff, width, maxVisible, "     ")
+}
+
+func renderStoredFileDiffIndented(unifiedDiff string, width, maxVisible int, indent string) (string, int) {
+	key := storedDiffKey{diff: unifiedDiff, width: width, maxVisible: maxVisible, indent: indent, darkMode: kit.IsDarkBackground()}
 	storedDiffMu.Lock()
 	cached, ok := storedDiffCache[key]
 	storedDiffMu.Unlock()
 	if ok {
 		return cached.block, cached.hidden
 	}
-	block, hidden := RenderFileDiff(perm.ParseUnifiedDiff(unifiedDiff), width, maxVisible)
+	block, hidden := renderFileDiffIndented(perm.ParseUnifiedDiff(unifiedDiff), width, maxVisible, indent)
 	storedDiffMu.Lock()
 	if len(storedDiffCache) >= 32 {
 		clear(storedDiffCache)

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -587,11 +587,7 @@ func RenderToolCalls(params ToolCallsParams) string {
 				row = renderBashToolCall(tc.Input, params.Width, icon)
 			} else {
 				args := extractToolArgs(tc.Input)
-				label := fmt.Sprintf("%s(%s)", tc.Name, args)
-				if tc.Name == tool.ToolRead {
-					label = formatReadToolLabel(tc.Input, args)
-				}
-				row = renderToolLineWithIcon(label, params.Width, icon) + "\n"
+				row = renderToolLineWithIcon(fmt.Sprintf("%s(%s)", tc.Name, args), params.Width, icon) + "\n"
 			}
 			sb.WriteString(appendRowDetail(row, runningRowDetail(tc, params)))
 		}

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -517,6 +517,9 @@ type ToolResultData struct {
 	ToolInput   string
 	Width       int
 	Details     any
+	// Nested indicates this result is rendering immediately below its tool call.
+	// Bash uses that context to show a terminal state without repeating its name.
+	Nested bool
 	// Decision is the auto-review decision for this call (nil if it was not
 	// judged), drawn as a colored line between the call and its result.
 	Decision *core.ReviewDecision
@@ -593,6 +596,7 @@ func RenderToolCalls(params ToolCallsParams) string {
 			resultData.ToolInput = tc.Input
 			resultData.Interactive = params.Interactive
 			resultData.Width = params.Width
+			resultData.Nested = true
 			// Decision sits between the call and its result, mirroring the
 			// order things happened: judged → ran → produced this output.
 			sb.WriteString(renderDecision(resultData.Decision))

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -518,7 +518,7 @@ type ToolResultData struct {
 	Width       int
 	Details     any
 	// Nested indicates this result is rendering immediately below its tool call.
-	// Bash uses that context to show a terminal state without repeating its name.
+	// Nested results show a terminal state without repeating the tool name.
 	Nested bool
 	// Decision is the auto-review decision for this call (nil if it was not
 	// judged), drawn as a colored line between the call and its result.

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -587,7 +587,11 @@ func RenderToolCalls(params ToolCallsParams) string {
 				row = renderBashToolCall(tc.Input, params.Width, icon)
 			} else {
 				args := extractToolArgs(tc.Input)
-				row = renderToolLineWithIcon(fmt.Sprintf("%s(%s)", tc.Name, args), params.Width, icon) + "\n"
+				label := fmt.Sprintf("%s(%s)", tc.Name, args)
+				if tc.Name == tool.ToolRead {
+					label = formatReadToolLabel(tc.Input, args)
+				}
+				row = renderToolLineWithIcon(label, params.Width, icon) + "\n"
 			}
 			sb.WriteString(appendRowDetail(row, runningRowDetail(tc, params)))
 		}

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -864,7 +864,7 @@ func TestRenderToolCallsNestsBashResultUnderCommand(t *testing.T) {
 	if strings.Count(rendered, "Bash") != 1 {
 		t.Fatalf("Bash should be named only in its call header, got %q", rendered)
 	}
-	if !strings.Contains(rendered, "Bash\n  $  git status\n  ┊\n  └ 2 lines\n  on main\n  nothing to commit\n") {
+	if !strings.Contains(rendered, "Bash\n  $  git status\n  ┊ on main\n  ┊ nothing to commit\n  └ 2 lines\n") {
 		t.Fatalf("Bash result should be a dotted, nested line summary followed by expanded output, got %q", rendered)
 	}
 }
@@ -882,7 +882,7 @@ func TestRenderToolCallsNestsBashFailureUnderCommand(t *testing.T) {
 	if strings.Count(rendered, "Bash") != 1 {
 		t.Fatalf("Bash should be named only in its call header, got %q", rendered)
 	}
-	if !strings.Contains(rendered, "  └ failed · 2 lines\n  exit status 1\n  stderr detail\n") {
+	if !strings.Contains(rendered, "  ┊ exit status 1\n  ┊ stderr detail\n  └ failed · 2 lines\n") {
 		t.Fatalf("Bash failure should report its line count and expanded detail, got %q", rendered)
 	}
 }
@@ -921,7 +921,7 @@ func TestRenderToolCallsNestsEditResultUnderPath(t *testing.T) {
 	if strings.Count(rendered, "Edit") != 1 {
 		t.Fatalf("Edit should be named only in its call header, got %q", rendered)
 	}
-	if !strings.Contains(rendered, "  1 - old") || !strings.Contains(rendered, "  1 + new") {
+	if !strings.Contains(rendered, "  ┊    1 - old") || !strings.Contains(rendered, "  ┊    1 + new") {
 		t.Fatalf("Edit diff rows should align with the nested result trailer, got %q", rendered)
 	}
 	if !strings.Contains(rendered, "1 - old") || !strings.Contains(rendered, "1 + new") {
@@ -951,7 +951,7 @@ func TestRenderToolCallsNestsWriteResultUnderPath(t *testing.T) {
 	if strings.Count(rendered, "Write") != 1 {
 		t.Fatalf("Write should be named only in its call header, got %q", rendered)
 	}
-	if !strings.Contains(rendered, "  1 + package app") {
+	if !strings.Contains(rendered, "  ┊    1 + package app") {
 		t.Fatalf("Write diff rows should align with the nested result trailer, got %q", rendered)
 	}
 	if !strings.Contains(rendered, "+ package app") {
@@ -993,7 +993,7 @@ func TestRenderToolCallsNestsFileChangeFailureUnderPath(t *testing.T) {
 	if strings.Count(rendered, "Edit") != 1 {
 		t.Fatalf("Edit should be named only in its call header, got %q", rendered)
 	}
-	if !strings.Contains(rendered, "    - old") || !strings.Contains(rendered, "  └ failed\n") || !strings.Contains(rendered, "    oldText was not found") {
+	if !strings.Contains(rendered, "  ┊ - old") || !strings.Contains(rendered, "  └ failed\n") || !strings.Contains(rendered, "  ┊ oldText was not found") {
 		t.Fatalf("Edit failure should show requested input, terminal failure, and diagnostic, got %q", rendered)
 	}
 }
@@ -1030,7 +1030,7 @@ func TestRenderToolCallsExpandsReadResultAlignedWithSummary(t *testing.T) {
 		Width: 100,
 	}))
 
-	if !strings.Contains(rendered, "     510    type ToolResultData struct {\n     511        ToolName string\n  └ 2 lines\n") {
+	if !strings.Contains(rendered, "  ┊    510    type ToolResultData struct {\n  ┊    511        ToolName string\n  └ 2 lines\n") {
 		t.Fatalf("expanded Read rows should align with the nested result summary, got %q", rendered)
 	}
 }
@@ -1078,7 +1078,7 @@ func TestRenderToolCallsNestsReadFailure(t *testing.T) {
 		ResultMap: map[string]ToolResultData{call.ID: {ToolName: "Read", Content: "Error: file not found: missing", IsError: true}},
 		Width:     100,
 	}))
-	if !strings.Contains(rendered, "    file not found: missing\n  └ failed\n") {
+	if !strings.Contains(rendered, "  ┊ file not found: missing\n  └ failed\n") {
 		t.Fatalf("Read failure should end in nested failed state, got %q", rendered)
 	}
 }

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -886,7 +886,7 @@ func TestRenderToolCallsNestsBashFailureUnderCommand(t *testing.T) {
 	}
 }
 
-func TestRenderToolCallsShowsEditResult(t *testing.T) {
+func TestRenderToolCallsNestsEditResultUnderPath(t *testing.T) {
 	call := core.ToolCall{
 		ID:    "edit-1",
 		Name:  "Edit",
@@ -895,15 +895,85 @@ func TestRenderToolCallsShowsEditResult(t *testing.T) {
 	rendered := stripANSI(RenderToolCalls(ToolCallsParams{
 		ToolCalls: []core.ToolCall{call},
 		ResultMap: map[string]ToolResultData{
-			call.ID: {ToolName: "Edit", Content: "Edited internal/app/view.go"},
+			call.ID: {ToolName: "Edit", Content: "Edited internal/app/view.go", Details: toolresult.FileChangeDetails{
+				Path: "internal/app/view.go", EditCount: 1, AddedLines: 1, RemovedLines: 1,
+				UnifiedDiff: "@@ -1 +1 @@\n-old\n+new",
+			}},
 		},
 		Width: 100,
 	}))
-	if !strings.Contains(rendered, "Edit(internal/app/view.go)") {
-		t.Fatalf("completed Edit call should remain visible, got %q", rendered)
+
+	if strings.Count(rendered, "Edit") != 1 {
+		t.Fatalf("Edit should be named only in its call header, got %q", rendered)
 	}
-	if !strings.Contains(rendered, "Edit →") {
-		t.Fatalf("Edit result should be visible, got %q", rendered)
+	if !strings.Contains(rendered, "Edit(internal/app/view.go)\n  └ 1 replacements · +1 -1\n") {
+		t.Fatalf("Edit result should nest its summary under the path, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "1 - old") || !strings.Contains(rendered, "1 + new") {
+		t.Fatalf("Edit result should retain its rendered diff, got %q", rendered)
+	}
+	if strings.Contains(rendered, "Edited internal/app/view.go") {
+		t.Fatalf("Edit result should not duplicate its call path, got %q", rendered)
+	}
+}
+
+func TestRenderToolCallsNestsWriteResultUnderPath(t *testing.T) {
+	call := core.ToolCall{ID: "write-1", Name: "Write", Input: `{"path":"internal/app/new.go","content":"package app"}`}
+	rendered := stripANSI(RenderToolCalls(ToolCallsParams{
+		ToolCalls: []core.ToolCall{call},
+		ResultMap: map[string]ToolResultData{
+			call.ID: {ToolName: "Write", Content: "Wrote internal/app/new.go", Details: toolresult.FileChangeDetails{
+				Path: "internal/app/new.go", IsNewFile: true, AddedLines: 1,
+				UnifiedDiff: "@@ -0,0 +1 @@\n+package app",
+			}},
+		},
+		Width: 100,
+	}))
+
+	if strings.Count(rendered, "Write") != 1 {
+		t.Fatalf("Write should be named only in its call header, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "Write(internal/app/new.go)\n  └ new file · 1 lines\n") {
+		t.Fatalf("Write result should nest its summary under the path, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "+ package app") {
+		t.Fatalf("Write result should retain its rendered diff, got %q", rendered)
+	}
+}
+
+func TestRenderToolCallsNestsFileChangeResultWithoutDetails(t *testing.T) {
+	call := core.ToolCall{ID: "edit-1", Name: "Edit", Input: `{"path":"internal/app/view.go","edits":[]}`}
+	rendered := stripANSI(RenderToolCalls(ToolCallsParams{
+		ToolCalls: []core.ToolCall{call},
+		ResultMap: map[string]ToolResultData{
+			call.ID: {ToolName: "Edit", Content: "Edited internal/app/view.go (1 replacement(s), +1 -1)"},
+		},
+		Width: 100,
+	}))
+
+	if strings.Count(rendered, "Edit") != 1 {
+		t.Fatalf("Edit should be named only in its call header, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "Edit(internal/app/view.go)\n  └ 1 replacement(s), +1 -1\n") {
+		t.Fatalf("Edit fallback result should retain its summary, got %q", rendered)
+	}
+}
+
+func TestRenderToolCallsNestsFileChangeFailureUnderPath(t *testing.T) {
+	call := core.ToolCall{ID: "edit-1", Name: "Edit", Input: `{"path":"internal/app/view.go","edits":[]}`}
+	rendered := stripANSI(RenderToolCalls(ToolCallsParams{
+		ToolCalls: []core.ToolCall{call},
+		ResultMap: map[string]ToolResultData{
+			call.ID: {ToolName: "Edit", Content: "Error: oldText was not found\nmatching lines:\n     1\tactual", IsError: true},
+		},
+		Width: 100,
+	}))
+
+	if strings.Count(rendered, "Edit") != 1 {
+		t.Fatalf("Edit should be named only in its call header, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "  └ failed: oldText was not found\n      matching lines:\n           1    actual\n") {
+		t.Fatalf("Edit failure and details should nest under its path, got %q", rendered)
 	}
 }
 

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -124,14 +124,14 @@ func Test_extractToolArgsPreservesFullCommand(t *testing.T) {
 
 func Test_renderBashToolCallSingleLineUsesCommandBlock(t *testing.T) {
 	out := stripANSI(renderBashToolCall(`{"command":"git status"}`, 100, "●"))
-	if strings.Contains(out, "Bash(git status)") || !strings.Contains(out, "Bash\n  $  git status\n") {
+	if strings.Contains(out, "Bash(git status)") || !strings.Contains(out, "Bash\n  $ git status\n") {
 		t.Fatalf("single-line command should render in a Bash block, got %q", out)
 	}
 }
 
 func Test_renderBashToolCallEmptyCommandUsesCommandBlock(t *testing.T) {
 	out := stripANSI(renderBashToolCall(`{}`, 100, "●"))
-	if strings.Contains(out, "Bash(") || !strings.Contains(out, "Bash\n  $  (no command)\n") {
+	if strings.Contains(out, "Bash(") || !strings.Contains(out, "Bash\n  $ (no command)\n") {
 		t.Fatalf("empty command should retain the Bash command block, got %q", out)
 	}
 }
@@ -173,7 +173,11 @@ func Test_renderBashToolCallShowsShellPrompt(t *testing.T) {
 	if !strings.HasPrefix(rows[0], bashPrompt) {
 		t.Fatalf("first command row should carry the %q prompt: %q", bashPrompt, rows[0])
 	}
-	// Continuations hang under the command text: a blank indent the width of the
+	// The command text starts immediately after the single space following "$".
+	if got := strings.TrimPrefix(rows[0], bashPrompt); !strings.HasPrefix(got, "git log") {
+		t.Fatalf("command should follow the prompt without extra spacing: %q", rows[0])
+	}
+
 	// prompt, so command text lines up down one column and the prompt never repeats.
 	contIndent := strings.Repeat(" ", lipgloss.Width(bashPrompt))
 	for i, row := range rows[1:] {
@@ -182,14 +186,10 @@ func Test_renderBashToolCallShowsShellPrompt(t *testing.T) {
 		}
 	}
 
-	// The "$" sits in the "⎿" result column, so the two markers line up down the left.
-	resultPrefix := "  ⎿  "
-	if strings.IndexByte(bashPrompt, '$') != strings.Index(resultPrefix, "⎿") {
-		t.Fatalf("prompt $ column must equal the result ⎿ column")
-	}
-	// The command after "$" starts where the result's Bash label starts.
-	if lipgloss.Width(bashPrompt) != lipgloss.Width(resultPrefix) {
-		t.Fatalf("command indent width = %d, want result label indent %d", lipgloss.Width(bashPrompt), lipgloss.Width(resultPrefix))
+	// The prompt and nested result markers occupy the same column.
+	resultPrefix := "  └ "
+	if strings.IndexByte(bashPrompt, '$') != strings.Index(resultPrefix, "└") {
+		t.Fatalf("prompt $ column must equal the result └ column")
 	}
 }
 
@@ -422,7 +422,7 @@ func TestRenderToolCallsShowsRunningStateForPendingBash(t *testing.T) {
 	}
 
 	rendered := stripANSI(RenderToolCalls(params))
-	if !strings.Contains(rendered, "⋯ Bash\n  $  find /Users/myan -name test\n") {
+	if !strings.Contains(rendered, "⋯ Bash\n  $ find /Users/myan -name test\n") {
 		t.Fatalf("RenderToolCalls() = %q, want spinner on the Bash header", rendered)
 	}
 	if strings.Contains(rendered, "running...") {
@@ -443,7 +443,7 @@ func TestRenderToolCallsShowsElapsedTimerOnRunningBash(t *testing.T) {
 	}
 
 	rendered := stripANSI(RenderToolCalls(params))
-	if !strings.Contains(rendered, "⋯ Bash · 12s\n  $  npm test\n") {
+	if !strings.Contains(rendered, "⋯ Bash · 12s\n  $ npm test\n") {
 		t.Fatalf("RenderToolCalls() = %q, want spinner and timer on the Bash header", rendered)
 	}
 	if !strings.Contains(rendered, "· 12s") {
@@ -826,7 +826,7 @@ func TestRenderToolResultInlineShowsEditSummary(t *testing.T) {
 		UnifiedDiff:  "@@ -1 +1 @@\n-old\n+new",
 	}
 	result := stripANSI(RenderToolResultInline(ToolResultData{ToolName: "Edit", Details: details}, nil))
-	if !strings.Contains(result, "2 replacements · +3 -1") {
+	if !strings.Contains(result, "+3 -1") {
 		t.Fatalf("successful Edit summary = %q", result)
 	}
 	// The diff now shows by default, in gutter-and-marker form.
@@ -864,7 +864,7 @@ func TestRenderToolCallsNestsBashResultUnderCommand(t *testing.T) {
 	if strings.Count(rendered, "Bash") != 1 {
 		t.Fatalf("Bash should be named only in its call header, got %q", rendered)
 	}
-	if !strings.Contains(rendered, "Bash\n  $  git status\n  ┊ on main\n  ┊ nothing to commit\n  └ 2 lines\n") {
+	if !strings.Contains(rendered, "Bash\n  $ git status\n  ┊ on main\n  ┊ nothing to commit\n  └ 2 lines\n") {
 		t.Fatalf("Bash result should be a dotted, nested line summary followed by expanded output, got %q", rendered)
 	}
 }
@@ -927,7 +927,7 @@ func TestRenderToolCallsNestsEditResultUnderPath(t *testing.T) {
 	if !strings.Contains(rendered, "1 - old") || !strings.Contains(rendered, "1 + new") {
 		t.Fatalf("Edit result should retain its rendered diff, got %q", rendered)
 	}
-	if !strings.Contains(rendered, "  └ 1 replacements · +1 -1\n") || strings.Index(rendered, "  └ 1 replacements · +1 -1") < strings.Index(rendered, "1 + new") {
+	if !strings.Contains(rendered, "  └ +1 -1\n") || strings.Index(rendered, "  └ +1 -1") < strings.Index(rendered, "1 + new") {
 		t.Fatalf("Edit summary should follow the actual diff, got %q", rendered)
 	}
 	if strings.Contains(rendered, "Edited internal/app/view.go") {
@@ -957,7 +957,7 @@ func TestRenderToolCallsNestsWriteResultUnderPath(t *testing.T) {
 	if !strings.Contains(rendered, "+ package app") {
 		t.Fatalf("Write result should retain its rendered diff, got %q", rendered)
 	}
-	if !strings.Contains(rendered, "  └ new file · 1 lines\n") || strings.Index(rendered, "  └ new file · 1 lines") < strings.Index(rendered, "+ package app") {
+	if !strings.Contains(rendered, "  └ +1\n") || strings.Index(rendered, "  └ +1") < strings.Index(rendered, "+ package app") {
 		t.Fatalf("Write summary should follow its diff, got %q", rendered)
 	}
 }

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -842,8 +842,47 @@ func TestRenderToolResultInlineShowsEditSummary(t *testing.T) {
 	}
 
 	bashErrResult := stripANSI(RenderToolResultInline(ToolResultData{ToolName: "Bash", Content: "command failed", IsError: true}, nil))
-	if !strings.Contains(bashErrResult, "\n     command failed\n") {
-		t.Fatalf("Bash error reason should align with Bash, got %q", bashErrResult)
+	if !strings.Contains(bashErrResult, "Bash → failed") {
+		t.Fatalf("standalone Bash error should retain its tool label, got %q", bashErrResult)
+	}
+}
+
+func TestRenderToolCallsNestsBashResultUnderCommand(t *testing.T) {
+	call := core.ToolCall{ID: "bash-1", Name: "Bash", Input: `{"command":"git status"}`}
+	rendered := stripANSI(RenderToolCalls(ToolCallsParams{
+		ToolCalls: []core.ToolCall{call},
+		ResultMap: map[string]ToolResultData{
+			call.ID: {ToolName: "Bash", Content: "on main\nnothing to commit", Expanded: true},
+		},
+		Width: 100,
+	}))
+
+	if strings.Count(rendered, "Bash") != 1 {
+		t.Fatalf("Bash should be named only in its call header, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "Bash(git status)\n  └ completed\n") {
+		t.Fatalf("Bash result should be a nested completed state, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "      on main\n      nothing to commit\n") {
+		t.Fatalf("expanded Bash output should remain nested under its command, got %q", rendered)
+	}
+}
+
+func TestRenderToolCallsNestsBashFailureUnderCommand(t *testing.T) {
+	call := core.ToolCall{ID: "bash-1", Name: "Bash", Input: `{"command":"false"}`}
+	rendered := stripANSI(RenderToolCalls(ToolCallsParams{
+		ToolCalls: []core.ToolCall{call},
+		ResultMap: map[string]ToolResultData{
+			call.ID: {ToolName: "Bash", Content: "exit status 1\nstderr detail", IsError: true},
+		},
+		Width: 100,
+	}))
+
+	if strings.Count(rendered, "Bash") != 1 {
+		t.Fatalf("Bash should be named only in its call header, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "  └ failed: exit status 1\n      stderr detail\n") {
+		t.Fatalf("Bash failure and detail should be nested under its command, got %q", rendered)
 	}
 }
 

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -146,6 +146,12 @@ func Test_renderBashToolCallMultiLineShowsEveryLine(t *testing.T) {
 			t.Fatalf("multi-line command should show %q in place, got %q", want, out)
 		}
 	}
+	plain := stripANSI(out)
+	// Later physical command lines use the result connector, while the first
+	// line retains the shell prompt.
+	if !strings.Contains(plain, "  $ for f in a b; do\n  ┊   echo \"$f\"\n  ┊ done\n") {
+		t.Fatalf("multi-line command should connect its continuation lines, got %q", plain)
+	}
 	// The description stays on the header in normal text, separated by a dash.
 	if !strings.Contains(stripANSI(out), "Bash - loop over files") {
 		t.Fatalf("multi-line command should show its description on the header, got %q", out)
@@ -181,7 +187,7 @@ func Test_renderBashToolCallShowsShellPrompt(t *testing.T) {
 	// prompt, so command text lines up down one column and the prompt never repeats.
 	contIndent := strings.Repeat(" ", lipgloss.Width(bashPrompt))
 	for i, row := range rows[1:] {
-		if !strings.HasPrefix(row, contIndent) || strings.HasPrefix(row, bashPrompt) {
+		if !strings.HasPrefix(row, contIndent) || strings.HasPrefix(row, bashPrompt) || strings.HasPrefix(row, "  ┊ ") {
 			t.Fatalf("continuation row %d should hang under the command text, not repeat the prompt: %q", i+1, row)
 		}
 	}

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -887,6 +887,20 @@ func TestRenderToolCallsNestsBashFailureUnderCommand(t *testing.T) {
 	}
 }
 
+func TestRenderToolCallsKeepsBashConnectorWhenOutputIsCollapsed(t *testing.T) {
+	call := core.ToolCall{ID: "bash-1", Name: "Bash", Input: `{"command":"git status"}`}
+	rendered := stripANSI(RenderToolCalls(ToolCallsParams{
+		ToolCalls: []core.ToolCall{call},
+		ResultMap: map[string]ToolResultData{
+			call.ID: {ToolName: "Bash", Content: "on main\nnothing to commit"},
+		},
+		Width: 100,
+	}))
+	if !strings.Contains(rendered, "  $ git status\n  ┊\n  └ 2 lines\n") {
+		t.Fatalf("collapsed Bash output should retain its connector, got %q", rendered)
+	}
+}
+
 func TestRenderToolCallsDoesNotAddBashBodyForEmptyOutput(t *testing.T) {
 	call := core.ToolCall{ID: "bash-1", Name: "Bash", Input: `{"command":"true"}`}
 	rendered := stripANSI(RenderToolCalls(ToolCallsParams{

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -864,7 +864,7 @@ func TestRenderToolCallsNestsBashResultUnderCommand(t *testing.T) {
 	if strings.Count(rendered, "Bash") != 1 {
 		t.Fatalf("Bash should be named only in its call header, got %q", rendered)
 	}
-	if !strings.Contains(rendered, "Bash\n  $  git status\n  ┊\n  └ 2 lines\n    on main\n    nothing to commit\n") {
+	if !strings.Contains(rendered, "Bash\n  $  git status\n  ┊\n  └ 2 lines\n  on main\n  nothing to commit\n") {
 		t.Fatalf("Bash result should be a dotted, nested line summary followed by expanded output, got %q", rendered)
 	}
 }
@@ -882,8 +882,22 @@ func TestRenderToolCallsNestsBashFailureUnderCommand(t *testing.T) {
 	if strings.Count(rendered, "Bash") != 1 {
 		t.Fatalf("Bash should be named only in its call header, got %q", rendered)
 	}
-	if !strings.Contains(rendered, "  └ failed · 2 lines\n    exit status 1\n    stderr detail\n") {
+	if !strings.Contains(rendered, "  └ failed · 2 lines\n  exit status 1\n  stderr detail\n") {
 		t.Fatalf("Bash failure should report its line count and expanded detail, got %q", rendered)
+	}
+}
+
+func TestRenderToolCallsDoesNotAddBashBodyForEmptyOutput(t *testing.T) {
+	call := core.ToolCall{ID: "bash-1", Name: "Bash", Input: `{"command":"true"}`}
+	rendered := stripANSI(RenderToolCalls(ToolCallsParams{
+		ToolCalls: []core.ToolCall{call},
+		ResultMap: map[string]ToolResultData{
+			call.ID: {ToolName: "Bash", Expanded: true},
+		},
+		Width: 100,
+	}))
+	if strings.Contains(rendered, "└ no output\n  \n") {
+		t.Fatalf("empty Bash output should not add a blank body row, got %q", rendered)
 	}
 }
 
@@ -906,6 +920,9 @@ func TestRenderToolCallsNestsEditResultUnderPath(t *testing.T) {
 
 	if strings.Count(rendered, "Edit") != 1 {
 		t.Fatalf("Edit should be named only in its call header, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "  1 - old") || !strings.Contains(rendered, "  1 + new") {
+		t.Fatalf("Edit diff rows should align with the nested result trailer, got %q", rendered)
 	}
 	if !strings.Contains(rendered, "1 - old") || !strings.Contains(rendered, "1 + new") {
 		t.Fatalf("Edit result should retain its rendered diff, got %q", rendered)
@@ -933,6 +950,9 @@ func TestRenderToolCallsNestsWriteResultUnderPath(t *testing.T) {
 
 	if strings.Count(rendered, "Write") != 1 {
 		t.Fatalf("Write should be named only in its call header, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "  1 + package app") {
+		t.Fatalf("Write diff rows should align with the nested result trailer, got %q", rendered)
 	}
 	if !strings.Contains(rendered, "+ package app") {
 		t.Fatalf("Write result should retain its rendered diff, got %q", rendered)
@@ -978,12 +998,13 @@ func TestRenderToolCallsNestsFileChangeFailureUnderPath(t *testing.T) {
 	}
 }
 
-func TestRenderToolCallsNestsReadContentBeforeTerminalSummary(t *testing.T) {
+func TestRenderToolCallsCollapsesReadResultByDefault(t *testing.T) {
 	call := core.ToolCall{ID: "read-1", Name: "Read", Input: `{"file_path":"internal/app/conv/message.go","offset":510,"limit":2}`}
+	content := "   510\ttype ToolResultData struct {\n   511\t\tToolName string"
 	rendered := stripANSI(RenderToolCalls(ToolCallsParams{
 		ToolCalls: []core.ToolCall{call},
 		ResultMap: map[string]ToolResultData{
-			call.ID: {ToolName: "Read", Content: "   510\ttype ToolResultData struct {\n   511\t\tToolName string"},
+			call.ID: {ToolName: "Read", Content: content},
 		},
 		Width: 100,
 	}))
@@ -991,11 +1012,26 @@ func TestRenderToolCallsNestsReadContentBeforeTerminalSummary(t *testing.T) {
 	if !strings.Contains(rendered, "Read(internal/app/conv/message.go) · lines 510–511") {
 		t.Fatalf("Read call should annotate its requested range, got %q", rendered)
 	}
-	if !strings.Contains(rendered, "510    type ToolResultData struct {") || !strings.Contains(rendered, "511        ToolName string") {
-		t.Fatalf("Read result should retain its numbered content, got %q", rendered)
+	if strings.Contains(rendered, "type ToolResultData") {
+		t.Fatalf("collapsed Read should not render file content, got %q", rendered)
 	}
-	if !strings.Contains(rendered, "  └ 2 lines\n") || strings.Index(rendered, "  └ 2 lines") < strings.Index(rendered, "511    ") {
-		t.Fatalf("Read summary should follow its content, got %q", rendered)
+	if !strings.Contains(rendered, "  └ 2 lines\n") {
+		t.Fatalf("collapsed Read should show a compact line summary, got %q", rendered)
+	}
+}
+
+func TestRenderToolCallsExpandsReadResultAlignedWithSummary(t *testing.T) {
+	call := core.ToolCall{ID: "read-1", Name: "Read", Input: `{"file_path":"internal/app/conv/message.go","offset":510,"limit":2}`}
+	rendered := stripANSI(RenderToolCalls(ToolCallsParams{
+		ToolCalls: []core.ToolCall{call},
+		ResultMap: map[string]ToolResultData{
+			call.ID: {ToolName: "Read", Content: "   510\ttype ToolResultData struct {\n   511\t\tToolName string", Expanded: true},
+		},
+		Width: 100,
+	}))
+
+	if !strings.Contains(rendered, "     510    type ToolResultData struct {\n     511        ToolName string\n  └ 2 lines\n") {
+		t.Fatalf("expanded Read rows should align with the nested result summary, got %q", rendered)
 	}
 }
 

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -187,15 +187,34 @@ func Test_renderBashToolCallShowsShellPrompt(t *testing.T) {
 	// prompt, so command text lines up down one column and the prompt never repeats.
 	contIndent := strings.Repeat(" ", lipgloss.Width(bashPrompt))
 	for i, row := range rows[1:] {
-		if !strings.HasPrefix(row, contIndent) || strings.HasPrefix(row, bashPrompt) || strings.HasPrefix(row, "  ┊ ") {
+		if !strings.HasPrefix(row, contIndent) || strings.HasPrefix(row, bashPrompt) || strings.HasPrefix(row, nestedBodyPrefix) {
 			t.Fatalf("continuation row %d should hang under the command text, not repeat the prompt: %q", i+1, row)
 		}
 	}
 
 	// The prompt and nested result markers occupy the same column.
-	resultPrefix := "  └ "
-	if strings.IndexByte(bashPrompt, '$') != strings.Index(resultPrefix, "└") {
+	if strings.IndexByte(bashPrompt, '$') != strings.Index(nestedTrailerPrefix, "└") {
 		t.Fatalf("prompt $ column must equal the result └ column")
+	}
+}
+
+func Test_renderBashToolCallAvoidsConnectorOnlyRows(t *testing.T) {
+	for _, input := range []string{
+		`{"command":"first\n"}`,
+		`{"command":"first\n\nthird"}`,
+		`{"command":"first\n   \nthird"}`,
+		`{"command":"\nfirst"}`,
+	} {
+		out := stripANSI(renderBashToolCall(input, 100, "●"))
+		if strings.Contains(out, strings.TrimSuffix(nestedBodyPrefix, " ")+"\n") {
+			t.Fatalf("blank command lines should not create connector-only rows, got %q", out)
+		}
+		if !strings.Contains(out, bashPrompt+"first\n") {
+			t.Fatalf("first visible command line should retain the shell prompt, got %q", out)
+		}
+	}
+	if out := stripANSI(renderBashToolCall(`{"command":"   "}`, 100, "●")); !strings.Contains(out, bashPrompt+"(no command)\n") {
+		t.Fatalf("whitespace-only command should use the empty-command fallback, got %q", out)
 	}
 }
 
@@ -620,6 +639,30 @@ func TestRenderToolCallsShowsCompletedIconForResultEvenWhenPending(t *testing.T)
 	if strings.Contains(rendered, "⋯ WebFetch") {
 		t.Fatalf("RenderToolCalls() = %q, should not show spinner for completed result", rendered)
 	}
+	if strings.Count(rendered, "WebFetch") != 1 || !strings.Contains(rendered, "  └ 4 B\n") {
+		t.Fatalf("nested WebFetch should not repeat its tool name, got %q", rendered)
+	}
+}
+
+func TestRenderToolCallsNestsGenericFailureWithoutRepeatingToolName(t *testing.T) {
+	call := core.ToolCall{ID: "tc-1", Name: "WebSearch", Input: `{"query":"test"}`}
+	rendered := stripANSI(RenderToolCalls(ToolCallsParams{
+		ToolCalls: []core.ToolCall{call},
+		ResultMap: map[string]ToolResultData{
+			call.ID: {ToolName: "WebSearch", Content: "Error: request failed\n   \nretry later\n\n", IsError: true},
+		},
+		Width: 100,
+	}))
+
+	if strings.Count(rendered, "WebSearch") != 1 {
+		t.Fatalf("WebSearch should be named only in its call header, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "  ┊ request failed\n    \n  ┊ retry later\n  └ failed\n") {
+		t.Fatalf("generic failure should use the nested result layout without connector-only rows, got %q", rendered)
+	}
+	if strings.Contains(rendered, "  ┊ \n") {
+		t.Fatalf("blank output lines should not render connector-only rows, got %q", rendered)
+	}
 }
 
 func TestRenderToolCallsShowsGapForPendingAgent(t *testing.T) {
@@ -977,7 +1020,7 @@ func TestRenderToolCallsNestsWriteResultUnderPath(t *testing.T) {
 	if !strings.Contains(rendered, "+ package app") {
 		t.Fatalf("Write result should retain its rendered diff, got %q", rendered)
 	}
-	if !strings.Contains(rendered, "  └ +1\n") || strings.Index(rendered, "  └ +1") < strings.Index(rendered, "+ package app") {
+	if !strings.Contains(rendered, "  └ +1 -0\n") || strings.Index(rendered, "  └ +1 -0") < strings.Index(rendered, "+ package app") {
 		t.Fatalf("Write summary should follow its diff, got %q", rendered)
 	}
 }
@@ -997,6 +1040,30 @@ func TestRenderToolCallsNestsFileChangeResultWithoutDetails(t *testing.T) {
 	}
 	if !strings.Contains(rendered, "Edit(internal/app/view.go)\n  └ 1 replacement(s), +1 -1\n") {
 		t.Fatalf("Edit fallback result should retain its summary, got %q", rendered)
+	}
+}
+
+func TestRenderToolCallsExtractsFallbackAfterParenthesizedPath(t *testing.T) {
+	call := core.ToolCall{ID: "edit-1", Name: "Edit", Input: `{"path":"dir/foo(bar).go","edits":[]}`}
+	rendered := stripANSI(RenderToolCalls(ToolCallsParams{
+		ToolCalls: []core.ToolCall{call},
+		ResultMap: map[string]ToolResultData{
+			call.ID: {ToolName: "Edit", Content: "Edited dir/foo(bar).go (1 replacement(s), +1 -1)"},
+		},
+		Width: 100,
+	}))
+
+	if !strings.Contains(rendered, "  └ 1 replacement(s), +1 -1\n") {
+		t.Fatalf("Edit fallback should use the trailing summary, got %q", rendered)
+	}
+	if strings.Contains(rendered, "  └ bar\n") {
+		t.Fatalf("Edit fallback should not mistake path parentheses for its summary, got %q", rendered)
+	}
+	if got := extractTrailingParenContent("Edited dir/foo.go (1 replacement(s), +1 -1); current", "completed"); got != "1 replacement(s), +1 -1" {
+		t.Fatalf("extractTrailingParenContent() = %q, want the recognized summary", got)
+	}
+	if got := extractTrailingParenContent("Wrote dir/foo(bar).go", "completed"); got != "completed" {
+		t.Fatalf("extractTrailingParenContent() = %q, want fallback for parenthesized path", got)
 	}
 }
 
@@ -1062,8 +1129,37 @@ func TestFormatReadResultSummaryCountsNumberedRows(t *testing.T) {
 	}
 }
 
+func TestFormatReadResultSummaryDescribesAdvisoryOutput(t *testing.T) {
+	tests := map[string]string{
+		"Binary file detected: fixture.bin":                                "binary file",
+		"image file: fixture.png (1.2 KB). Read cannot display images yet": "image file",
+	}
+	for content, want := range tests {
+		if got := formatReadResultSummary(content); got != want {
+			t.Fatalf("formatReadResultSummary(%q) = %q, want %q", content, got, want)
+		}
+	}
+}
+
+func TestFormatReadResultSummaryUsesSingularLine(t *testing.T) {
+	if got := formatReadResultSummary("     1\tpackage app"); got != "1 line" {
+		t.Fatalf("formatReadResultSummary() = %q, want %q", got, "1 line")
+	}
+}
+
+func TestRenderFileChangeInputPreviewUsesFailedLegacyEdit(t *testing.T) {
+	input := `{"edits":[{"oldText":"first old","newText":"first new"},{"oldText":"second old","newText":"second new"}]}`
+	preview := stripANSI(renderFileChangeInputPreview(input, "Error: edits[1]: oldText was not found", 80))
+	if !strings.Contains(preview, "- second old") || !strings.Contains(preview, "+ second new") {
+		t.Fatalf("preview should show the failed edit, got %q", preview)
+	}
+	if strings.Contains(preview, "first old") || strings.Contains(preview, "first new") {
+		t.Fatalf("preview should not show an unrelated edit, got %q", preview)
+	}
+}
+
 func TestRenderFileChangeInputPreviewWrapsLongContent(t *testing.T) {
-	preview := stripANSI(renderFileChangeInputPreview(`{"content":"`+strings.Repeat("x", 100)+`"}`, 40))
+	preview := stripANSI(renderFileChangeInputPreview(`{"content":"`+strings.Repeat("x", 100)+`"}`, "", 40))
 	for line := range strings.SplitSeq(strings.TrimSuffix(preview, "\n"), "\n") {
 		if width := lipgloss.Width(line); width > 40 {
 			t.Fatalf("preview line width = %d, want at most 40: %q", width, line)
@@ -1072,7 +1168,7 @@ func TestRenderFileChangeInputPreviewWrapsLongContent(t *testing.T) {
 }
 
 func TestRenderFileChangeInputPreviewHonorsNarrowWidth(t *testing.T) {
-	preview := stripANSI(renderFileChangeInputPreview(`{"content":"long"}`, 6))
+	preview := stripANSI(renderFileChangeInputPreview(`{"content":"long"}`, "", 6))
 	if preview != "" {
 		t.Fatalf("narrow preview = %q, want no overflowing preview", preview)
 	}

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -122,13 +122,17 @@ func Test_extractToolArgsPreservesFullCommand(t *testing.T) {
 	}
 }
 
-func Test_renderBashToolCallSingleLineStaysCompact(t *testing.T) {
-	out := renderBashToolCall(`{"command":"git status"}`, 100, "●")
-	if !strings.Contains(out, "Bash(git status)") {
-		t.Fatalf("single-line command should render compact, got %q", out)
+func Test_renderBashToolCallSingleLineUsesCommandBlock(t *testing.T) {
+	out := stripANSI(renderBashToolCall(`{"command":"git status"}`, 100, "●"))
+	if strings.Contains(out, "Bash(git status)") || !strings.Contains(out, "Bash\n  $  git status\n") {
+		t.Fatalf("single-line command should render in a Bash block, got %q", out)
 	}
-	if strings.Contains(out, "│") {
-		t.Fatalf("single-line command should not render a command block, got %q", out)
+}
+
+func Test_renderBashToolCallEmptyCommandUsesCommandBlock(t *testing.T) {
+	out := stripANSI(renderBashToolCall(`{}`, 100, "●"))
+	if strings.Contains(out, "Bash(") || !strings.Contains(out, "Bash\n  $  (no command)\n") {
+		t.Fatalf("empty command should retain the Bash command block, got %q", out)
 	}
 }
 
@@ -418,8 +422,8 @@ func TestRenderToolCallsShowsRunningStateForPendingBash(t *testing.T) {
 	}
 
 	rendered := stripANSI(RenderToolCalls(params))
-	if !strings.Contains(rendered, "⋯ Bash(find /Users/myan -name test)") {
-		t.Fatalf("RenderToolCalls() = %q, want spinner on the main tool line", rendered)
+	if !strings.Contains(rendered, "⋯ Bash\n  $  find /Users/myan -name test\n") {
+		t.Fatalf("RenderToolCalls() = %q, want spinner on the Bash header", rendered)
 	}
 	if strings.Contains(rendered, "running...") {
 		t.Fatalf("RenderToolCalls() = %q, should not add extra running text", rendered)
@@ -439,8 +443,8 @@ func TestRenderToolCallsShowsElapsedTimerOnRunningBash(t *testing.T) {
 	}
 
 	rendered := stripANSI(RenderToolCalls(params))
-	if !strings.Contains(rendered, "⋯ Bash(npm test)") {
-		t.Fatalf("RenderToolCalls() = %q, want spinner on the tool line", rendered)
+	if !strings.Contains(rendered, "⋯ Bash · 12s\n  $  npm test\n") {
+		t.Fatalf("RenderToolCalls() = %q, want spinner and timer on the Bash header", rendered)
 	}
 	if !strings.Contains(rendered, "· 12s") {
 		t.Fatalf("RenderToolCalls() = %q, want an elapsed timer on the running row", rendered)
@@ -860,11 +864,8 @@ func TestRenderToolCallsNestsBashResultUnderCommand(t *testing.T) {
 	if strings.Count(rendered, "Bash") != 1 {
 		t.Fatalf("Bash should be named only in its call header, got %q", rendered)
 	}
-	if !strings.Contains(rendered, "Bash(git status)\n  └ completed\n") {
-		t.Fatalf("Bash result should be a nested completed state, got %q", rendered)
-	}
-	if !strings.Contains(rendered, "      on main\n      nothing to commit\n") {
-		t.Fatalf("expanded Bash output should remain nested under its command, got %q", rendered)
+	if !strings.Contains(rendered, "Bash\n  $  git status\n  ┊\n  └ 2 lines\n    on main\n    nothing to commit\n") {
+		t.Fatalf("Bash result should be a dotted, nested line summary followed by expanded output, got %q", rendered)
 	}
 }
 
@@ -881,8 +882,8 @@ func TestRenderToolCallsNestsBashFailureUnderCommand(t *testing.T) {
 	if strings.Count(rendered, "Bash") != 1 {
 		t.Fatalf("Bash should be named only in its call header, got %q", rendered)
 	}
-	if !strings.Contains(rendered, "  └ failed: exit status 1\n      stderr detail\n") {
-		t.Fatalf("Bash failure and detail should be nested under its command, got %q", rendered)
+	if !strings.Contains(rendered, "  └ failed · 2 lines\n    exit status 1\n    stderr detail\n") {
+		t.Fatalf("Bash failure should report its line count and expanded detail, got %q", rendered)
 	}
 }
 
@@ -906,11 +907,11 @@ func TestRenderToolCallsNestsEditResultUnderPath(t *testing.T) {
 	if strings.Count(rendered, "Edit") != 1 {
 		t.Fatalf("Edit should be named only in its call header, got %q", rendered)
 	}
-	if !strings.Contains(rendered, "Edit(internal/app/view.go)\n  └ 1 replacements · +1 -1\n") {
-		t.Fatalf("Edit result should nest its summary under the path, got %q", rendered)
-	}
 	if !strings.Contains(rendered, "1 - old") || !strings.Contains(rendered, "1 + new") {
 		t.Fatalf("Edit result should retain its rendered diff, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "  └ 1 replacements · +1 -1\n") || strings.Index(rendered, "  └ 1 replacements · +1 -1") < strings.Index(rendered, "1 + new") {
+		t.Fatalf("Edit summary should follow the actual diff, got %q", rendered)
 	}
 	if strings.Contains(rendered, "Edited internal/app/view.go") {
 		t.Fatalf("Edit result should not duplicate its call path, got %q", rendered)
@@ -933,11 +934,11 @@ func TestRenderToolCallsNestsWriteResultUnderPath(t *testing.T) {
 	if strings.Count(rendered, "Write") != 1 {
 		t.Fatalf("Write should be named only in its call header, got %q", rendered)
 	}
-	if !strings.Contains(rendered, "Write(internal/app/new.go)\n  └ new file · 1 lines\n") {
-		t.Fatalf("Write result should nest its summary under the path, got %q", rendered)
-	}
 	if !strings.Contains(rendered, "+ package app") {
 		t.Fatalf("Write result should retain its rendered diff, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "  └ new file · 1 lines\n") || strings.Index(rendered, "  └ new file · 1 lines") < strings.Index(rendered, "+ package app") {
+		t.Fatalf("Write summary should follow its diff, got %q", rendered)
 	}
 }
 
@@ -960,7 +961,7 @@ func TestRenderToolCallsNestsFileChangeResultWithoutDetails(t *testing.T) {
 }
 
 func TestRenderToolCallsNestsFileChangeFailureUnderPath(t *testing.T) {
-	call := core.ToolCall{ID: "edit-1", Name: "Edit", Input: `{"path":"internal/app/view.go","edits":[]}`}
+	call := core.ToolCall{ID: "edit-1", Name: "Edit", Input: `{"path":"internal/app/view.go","edits":[{"oldText":"old","newText":"new"}]}`}
 	rendered := stripANSI(RenderToolCalls(ToolCallsParams{
 		ToolCalls: []core.ToolCall{call},
 		ResultMap: map[string]ToolResultData{
@@ -972,8 +973,77 @@ func TestRenderToolCallsNestsFileChangeFailureUnderPath(t *testing.T) {
 	if strings.Count(rendered, "Edit") != 1 {
 		t.Fatalf("Edit should be named only in its call header, got %q", rendered)
 	}
-	if !strings.Contains(rendered, "  └ failed: oldText was not found\n      matching lines:\n           1    actual\n") {
-		t.Fatalf("Edit failure and details should nest under its path, got %q", rendered)
+	if !strings.Contains(rendered, "    - old") || !strings.Contains(rendered, "  └ failed\n") || !strings.Contains(rendered, "    oldText was not found") {
+		t.Fatalf("Edit failure should show requested input, terminal failure, and diagnostic, got %q", rendered)
+	}
+}
+
+func TestRenderToolCallsNestsReadContentBeforeTerminalSummary(t *testing.T) {
+	call := core.ToolCall{ID: "read-1", Name: "Read", Input: `{"file_path":"internal/app/conv/message.go","offset":510,"limit":2}`}
+	rendered := stripANSI(RenderToolCalls(ToolCallsParams{
+		ToolCalls: []core.ToolCall{call},
+		ResultMap: map[string]ToolResultData{
+			call.ID: {ToolName: "Read", Content: "   510\ttype ToolResultData struct {\n   511\t\tToolName string"},
+		},
+		Width: 100,
+	}))
+
+	if !strings.Contains(rendered, "Read(internal/app/conv/message.go) · lines 510–511") {
+		t.Fatalf("Read call should annotate its requested range, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "510    type ToolResultData struct {") || !strings.Contains(rendered, "511        ToolName string") {
+		t.Fatalf("Read result should retain its numbered content, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "  └ 2 lines\n") || strings.Index(rendered, "  └ 2 lines") < strings.Index(rendered, "511    ") {
+		t.Fatalf("Read summary should follow its content, got %q", rendered)
+	}
+}
+
+func TestFormatReadResultSummaryCountsNumberedRows(t *testing.T) {
+	content := "     1\tpackage app\n     2\t\n(output truncated at line 2; continue with offset=3)"
+	if got := formatReadResultSummary(content); got != "2 lines" {
+		t.Fatalf("formatReadResultSummary() = %q, want %q", got, "2 lines")
+	}
+}
+
+func TestRenderFileChangeInputPreviewWrapsLongContent(t *testing.T) {
+	preview := stripANSI(renderFileChangeInputPreview(`{"content":"`+strings.Repeat("x", 100)+`"}`, 40))
+	for line := range strings.SplitSeq(strings.TrimSuffix(preview, "\n"), "\n") {
+		if width := lipgloss.Width(line); width > 40 {
+			t.Fatalf("preview line width = %d, want at most 40: %q", width, line)
+		}
+	}
+}
+
+func TestRenderFileChangeInputPreviewHonorsNarrowWidth(t *testing.T) {
+	preview := stripANSI(renderFileChangeInputPreview(`{"content":"long"}`, 6))
+	if preview != "" {
+		t.Fatalf("narrow preview = %q, want no overflowing preview", preview)
+	}
+}
+
+func TestFormatReadToolLabelSkipsInvalidRange(t *testing.T) {
+	for _, input := range []string{
+		`{"file_path":"file.go","limit":0}`,
+		`{"file_path":"file.go","limit":-1}`,
+		`{"file_path":"file.go","offset":-1}`,
+		`{"file_path":"file.go","offset":-1,"limit":10}`,
+	} {
+		if got := formatReadToolLabel(input, "file.go"); got != "Read(file.go)" {
+			t.Fatalf("formatReadToolLabel(%s) = %q, want no range label", input, got)
+		}
+	}
+}
+
+func TestRenderToolCallsNestsReadFailure(t *testing.T) {
+	call := core.ToolCall{ID: "read-1", Name: "Read", Input: `{"file_path":"missing"}`}
+	rendered := stripANSI(RenderToolCalls(ToolCallsParams{
+		ToolCalls: []core.ToolCall{call},
+		ResultMap: map[string]ToolResultData{call.ID: {ToolName: "Read", Content: "Error: file not found: missing", IsError: true}},
+		Width:     100,
+	}))
+	if !strings.Contains(rendered, "    file not found: missing\n  └ failed\n") {
+		t.Fatalf("Read failure should end in nested failed state, got %q", rendered)
 	}
 }
 

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -162,7 +162,7 @@ func Test_renderBashToolCallShowsShellPrompt(t *testing.T) {
 	// text without repeating it. No gutter bar, no background fill.
 	long := `{"command":"git log --oneline --graph --all --decorate --abbrev-commit --since='2 weeks ago' | head -50"}`
 	raw := renderBashToolCall(long, 70, "●")
-	if strings.ContainsAny(raw, "│┊") || strings.Contains(raw, "48;2;") {
+	if strings.ContainsAny(raw, "│") || strings.Contains(raw, "48;2;") {
 		t.Fatalf("command block should have no bar and no background, got %q", raw)
 	}
 
@@ -896,7 +896,7 @@ func TestRenderToolCallsKeepsBashConnectorWhenOutputIsCollapsed(t *testing.T) {
 		},
 		Width: 100,
 	}))
-	if !strings.Contains(rendered, "  $ git status\n  ┊\n  └ 2 lines\n") {
+	if !strings.Contains(rendered, "  $ git status\n  └ 2 lines\n") {
 		t.Fatalf("collapsed Bash output should retain its connector, got %q", rendered)
 	}
 }
@@ -1023,8 +1023,8 @@ func TestRenderToolCallsCollapsesReadResultByDefault(t *testing.T) {
 		Width: 100,
 	}))
 
-	if !strings.Contains(rendered, "Read(internal/app/conv/message.go) · lines 510–511") {
-		t.Fatalf("Read call should annotate its requested range, got %q", rendered)
+	if !strings.Contains(rendered, "Read(internal/app/conv/message.go)") || strings.Contains(rendered, "· lines") {
+		t.Fatalf("Read call should show only its path, got %q", rendered)
 	}
 	if strings.Contains(rendered, "type ToolResultData") {
 		t.Fatalf("collapsed Read should not render file content, got %q", rendered)
@@ -1069,19 +1069,6 @@ func TestRenderFileChangeInputPreviewHonorsNarrowWidth(t *testing.T) {
 	preview := stripANSI(renderFileChangeInputPreview(`{"content":"long"}`, 6))
 	if preview != "" {
 		t.Fatalf("narrow preview = %q, want no overflowing preview", preview)
-	}
-}
-
-func TestFormatReadToolLabelSkipsInvalidRange(t *testing.T) {
-	for _, input := range []string{
-		`{"file_path":"file.go","limit":0}`,
-		`{"file_path":"file.go","limit":-1}`,
-		`{"file_path":"file.go","offset":-1}`,
-		`{"file_path":"file.go","offset":-1,"limit":10}`,
-	} {
-		if got := formatReadToolLabel(input, "file.go"); got != "Read(file.go)" {
-			t.Fatalf("formatReadToolLabel(%s) = %q, want no range label", input, got)
-		}
 	}
 }
 

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -124,7 +124,7 @@ func renderNestedReadResultInline(data ToolResultData) string {
 	if data.IsError {
 		var sb strings.Builder
 		for line := range strings.SplitSeq(strings.TrimPrefix(data.Content, "Error: "), "\n") {
-			sb.WriteString(toolResultExpandedStyle.Render(line) + "\n")
+			sb.WriteString(renderNestedToolBodyLine(line))
 		}
 		sb.WriteString(errorStyle.Render("  └ failed") + "\n")
 		return sb.String()
@@ -134,18 +134,18 @@ func renderNestedReadResultInline(data ToolResultData) string {
 	var sb strings.Builder
 	if data.Expanded && content != "" {
 		for line := range strings.SplitSeq(content, "\n") {
-			sb.WriteString(renderNestedReadBodyLine(line))
+			sb.WriteString(renderNestedToolBodyLine(line))
 		}
 	}
 	sb.WriteString(toolResultStyle.Render("  └ "+formatReadResultSummary(content)) + "\n")
 	return sb.String()
 }
 
-// renderNestedReadBodyLine keeps expanded Read results one level below their
-// call, avoiding the generic expanded-result padding that made Read rows appear
-// four columns farther right than their terminal summary.
-func renderNestedReadBodyLine(line string) string {
-	return toolResultStyle.Render("  "+line) + "\n"
+// renderNestedToolBodyLine keeps body content under the same visual connector
+// that ends at the adjacent terminal summary. The connector only appears for
+// visible content, so collapsed results stay compact.
+func renderNestedToolBodyLine(line string) string {
+	return toolResultStyle.Render("  ┊ "+line) + "\n"
 }
 
 func formatReadResultSummary(content string) string {
@@ -181,22 +181,19 @@ func renderBashToolResultInline(data ToolResultData) string {
 	}
 
 	var sb strings.Builder
-	// This short, intentionally discontinuous connector visually ties the
-	// command prompt to its result without turning the whole block into a rail.
-	sb.WriteString(toolResultStyle.Render("  ┊") + "\n")
-	sb.WriteString(style.Render("  └ "+summary) + "\n")
 	if (data.Expanded || data.IsError) && content != "" {
 		for line := range strings.SplitSeq(content, "\n") {
-			sb.WriteString(renderNestedBashBodyLine(line))
+			sb.WriteString(renderNestedToolBodyLine(line))
 		}
 	}
+	sb.WriteString(style.Render("  └ "+summary) + "\n")
 	return sb.String()
 }
 
 // renderNestedBashBodyLine aligns expanded command output with the shell
 // prompt, connector, and terminal summary in a nested Bash block.
 func renderNestedBashBodyLine(line string) string {
-	return toolResultStyle.Render("  "+line) + "\n"
+	return renderNestedToolBodyLine(line)
 }
 
 func renderNestedFileChangeResultInline(data ToolResultData) string {
@@ -209,17 +206,17 @@ func renderNestedFileChangeResultInline(data ToolResultData) string {
 	if data.IsError {
 		sb.WriteString(renderFileChangeInputPreview(data.ToolInput, width))
 		for line := range strings.SplitSeq(strings.TrimPrefix(data.Content, "Error: "), "\n") {
-			sb.WriteString(toolResultExpandedStyle.Render(line) + "\n")
+			sb.WriteString(renderNestedToolBodyLine(line))
 		}
 		sb.WriteString(errorStyle.Render("  └ failed") + "\n")
 		return sb.String()
 	}
 
 	if details, ok := data.Details.(toolresult.FileChangeDetails); ok {
-		block, _ := renderStoredFileDiffIndented(details.UnifiedDiff, width, 0, "  ")
+		block, _ := renderStoredFileDiffIndented(details.UnifiedDiff, width, 0, "  ┊ ")
 		sb.WriteString(block)
 		if details.TruncatedDiffLines > 0 {
-			sb.WriteString(truncatedStyle.Render(fmt.Sprintf("  … diff truncated (%d more lines)", details.TruncatedDiffLines)) + "\n")
+			sb.WriteString(truncatedStyle.Render(fmt.Sprintf("  ┊ … diff truncated (%d more lines)", details.TruncatedDiffLines)) + "\n")
 		}
 		sb.WriteString(toolResultStyle.Render("  └ "+fileChangeSummary(details)) + "\n")
 		return sb.String()
@@ -280,7 +277,7 @@ func renderFileChangeInputPreview(input string, width int) string {
 		}
 		for line := range strings.SplitSeq(preview.text, "\n") {
 			for _, segment := range strings.Split(xansi.Wrap(line, previewWidth-lipgloss.Width(preview.marker)-1, " "), "\n") {
-				sb.WriteString(toolResultExpandedStyle.Render(preview.marker+" "+segment) + "\n")
+				sb.WriteString(toolResultStyle.Render("  ┊ "+preview.marker+" "+segment) + "\n")
 			}
 		}
 	}

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -289,14 +289,17 @@ func nestedFileChangeFallbackState(data ToolResultData) (state, content string) 
 }
 
 func fileChangeSummary(details toolresult.FileChangeDetails) string {
-	switch {
-	case details.IsNewFile:
-		return fmt.Sprintf("new file · %d lines", details.AddedLines)
-	case details.EditCount > 0:
-		return fmt.Sprintf("%d replacements · +%d -%d", details.EditCount, details.AddedLines, details.RemovedLines)
-	default:
-		return fmt.Sprintf("rewrote · +%d -%d", details.AddedLines, details.RemovedLines)
+	parts := make([]string, 0, 2)
+	if details.AddedLines > 0 {
+		parts = append(parts, fmt.Sprintf("+%d", details.AddedLines))
 	}
+	if details.RemovedLines > 0 {
+		parts = append(parts, fmt.Sprintf("-%d", details.RemovedLines))
+	}
+	if len(parts) == 0 {
+		return "no changes"
+	}
+	return strings.Join(parts, " ")
 }
 
 func renderFileChangeResultInline(data ToolResultData) string {
@@ -1033,7 +1036,7 @@ func renderToolLineWithIcon(label string, width int, iconText string) string {
 // command body lines up in one column with the "$" as a hanging prompt to its
 // left. The "$" aligns with the "⎿" result marker below, while the command text
 // aligns with the result's tool label (for example, "Bash").
-const bashPrompt = "  $  "
+const bashPrompt = "  $ "
 
 // renderBashToolCall renders a Bash tool call so its command is always readable
 // in full. A short single-line command keeps the compact Bash(cmd) label; a

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -109,87 +109,173 @@ func RenderToolResultInline(data ToolResultData, mdRenderer *MDRenderer) string 
 			return renderNestedFileChangeResultInline(data)
 		}
 		return renderFileChangeResultInline(data)
+	case tool.ToolRead:
+		if data.Nested {
+			return renderNestedReadResultInline(data)
+		}
+		return renderGenericToolResultInline(data)
 	case tool.ToolAskUserQuestion:
 		return renderAskUserResultInline(data)
 	}
 	return renderGenericToolResultInline(data)
 }
 
-func renderBashToolResultInline(data ToolResultData) string {
-	state := "completed"
-	content := data.Content
+func renderNestedReadResultInline(data ToolResultData) string {
 	if data.IsError {
-		lines := strings.Split(content, "\n")
-		state = "failed"
-		if len(lines) > 0 && lines[0] != "" {
-			state += ": " + lines[0]
-			content = strings.Join(lines[1:], "\n")
+		var sb strings.Builder
+		for line := range strings.SplitSeq(strings.TrimPrefix(data.Content, "Error: "), "\n") {
+			sb.WriteString(toolResultExpandedStyle.Render(line) + "\n")
 		}
+		sb.WriteString(errorStyle.Render("  └ failed") + "\n")
+		return sb.String()
 	}
 
+	var sb strings.Builder
+	content := strings.TrimSuffix(data.Content, "\n")
+	if content != "" {
+		for line := range strings.SplitSeq(content, "\n") {
+			sb.WriteString(toolResultExpandedStyle.Render(line) + "\n")
+		}
+	}
+	sb.WriteString(toolResultStyle.Render("  └ "+formatReadResultSummary(content)) + "\n")
+	return sb.String()
+}
+
+func formatReadResultSummary(content string) string {
+	count := 0
+	for line := range strings.SplitSeq(content, "\n") {
+		prefix, _, ok := strings.Cut(line, "\t")
+		if !ok {
+			continue
+		}
+		if _, err := strconv.Atoi(strings.TrimSpace(prefix)); err == nil {
+			count++
+		}
+	}
+	if count > 0 {
+		return fmt.Sprintf("%d lines", count)
+	}
+	if strings.HasPrefix(content, "file exists but is empty:") {
+		return "empty file"
+	}
+	if strings.HasPrefix(content, "no lines at offset ") {
+		return "no lines"
+	}
+	return "no output"
+}
+
+func renderBashToolResultInline(data ToolResultData) string {
+	content := strings.TrimSuffix(data.Content, "\n")
+	summary := formatLineCount(content)
 	style := toolResultStyle
 	if data.IsError {
+		summary = "failed · " + summary
 		style = errorStyle
 	}
 
 	var sb strings.Builder
-	sb.WriteString(style.Render("  └ "+state) + "\n")
+	// This short, intentionally discontinuous connector visually ties the
+	// command prompt to its result without turning the whole block into a rail.
+	sb.WriteString(toolResultStyle.Render("  ┊") + "\n")
+	sb.WriteString(style.Render("  └ "+summary) + "\n")
 	if (data.Expanded || data.IsError) && content != "" {
 		for line := range strings.SplitSeq(content, "\n") {
-			sb.WriteString(toolResultExpandedStyle.Render("  "+line) + "\n")
+			sb.WriteString(toolResultExpandedStyle.Render(line) + "\n")
 		}
 	}
 	return sb.String()
 }
 
 func renderNestedFileChangeResultInline(data ToolResultData) string {
-	content := data.Content
-	state := "completed"
-	style := toolResultStyle
-
-	if data.IsError {
-		style = errorStyle
-		lines := strings.Split(strings.TrimPrefix(content, "Error: "), "\n")
-		state = "failed"
-		if len(lines) > 0 && lines[0] != "" {
-			state += ": " + lines[0]
-			content = strings.Join(lines[1:], "\n")
-		}
-	} else if details, ok := data.Details.(toolresult.FileChangeDetails); ok {
-		state = fileChangeSummary(details)
-		content = ""
-	} else {
-		state, content = nestedFileChangeFallbackState(data)
+	width := data.Width
+	if width <= 0 {
+		width = 80
 	}
 
 	var sb strings.Builder
-	sb.WriteString(style.Render("  └ "+state) + "\n")
-	if (data.Expanded || data.IsError) && content != "" {
-		for line := range strings.SplitSeq(content, "\n") {
-			sb.WriteString(toolResultExpandedStyle.Render("  "+line) + "\n")
+	if data.IsError {
+		sb.WriteString(renderFileChangeInputPreview(data.ToolInput, width))
+		for line := range strings.SplitSeq(strings.TrimPrefix(data.Content, "Error: "), "\n") {
+			sb.WriteString(toolResultExpandedStyle.Render(line) + "\n")
 		}
+		sb.WriteString(errorStyle.Render("  └ failed") + "\n")
+		return sb.String()
 	}
 
-	if !data.IsError {
-		details, ok := data.Details.(toolresult.FileChangeDetails)
-		if !ok {
-			return sb.String()
-		}
-		width := data.Width
-		if width <= 0 {
-			width = 80
-		}
+	if details, ok := data.Details.(toolresult.FileChangeDetails); ok {
 		block, _ := RenderStoredFileDiff(details.UnifiedDiff, width, 0)
 		sb.WriteString(block)
 		if details.TruncatedDiffLines > 0 {
 			sb.WriteString(truncatedStyle.Render(fmt.Sprintf("     … diff truncated (%d more lines)", details.TruncatedDiffLines)) + "\n")
+		}
+		sb.WriteString(toolResultStyle.Render("  └ "+fileChangeSummary(details)) + "\n")
+		return sb.String()
+	}
+
+	state, content := nestedFileChangeFallbackState(data)
+	if content != "" {
+		for line := range strings.SplitSeq(content, "\n") {
+			sb.WriteString(toolResultExpandedStyle.Render(line) + "\n")
+		}
+	}
+	sb.WriteString(toolResultStyle.Render("  └ "+state) + "\n")
+	return sb.String()
+}
+
+// renderFileChangeInputPreview shows the requested change when the edit did
+// not apply. It uses tool input rather than diagnostics so the user can compare
+// the intended replacement with the actual-file diagnostic below.
+func renderFileChangeInputPreview(input string, width int) string {
+	var params struct {
+		OldString string `json:"old_string"`
+		NewString string `json:"new_string"`
+		OldText   string `json:"oldText"`
+		NewText   string `json:"newText"`
+		Edits     []struct {
+			OldString string `json:"old_string"`
+			NewString string `json:"new_string"`
+			OldText   string `json:"oldText"`
+			NewText   string `json:"newText"`
+		} `json:"edits"`
+		Content string `json:"content"`
+	}
+	if json.Unmarshal([]byte(input), &params) != nil {
+		return ""
+	}
+	old, new := params.OldString, params.NewString
+	if old == "" && new == "" {
+		old, new = params.OldText, params.NewText
+	}
+	if old == "" && new == "" && len(params.Edits) > 0 {
+		edit := params.Edits[0]
+		old, new = edit.OldString, edit.NewString
+		if old == "" && new == "" {
+			old, new = edit.OldText, edit.NewText
+		}
+	}
+	if new == "" && params.Content != "" {
+		new = params.Content
+	}
+	previewWidth := width - 4
+	if previewWidth <= lipgloss.Width("+ ") {
+		return ""
+	}
+	var sb strings.Builder
+	for _, preview := range []struct{ marker, text string }{{"-", old}, {"+", new}} {
+		if preview.text == "" {
+			continue
+		}
+		for line := range strings.SplitSeq(preview.text, "\n") {
+			for _, segment := range strings.Split(xansi.Wrap(line, previewWidth-lipgloss.Width(preview.marker)-1, " "), "\n") {
+				sb.WriteString(toolResultExpandedStyle.Render(preview.marker+" "+segment) + "\n")
+			}
 		}
 	}
 	return sb.String()
 }
 
 func nestedFileChangeFallbackState(data ToolResultData) (state, content string) {
-	return extractParenContent(data.Content, "completed"), data.Content
+	return extractParenContent(data.Content, "completed"), ""
 }
 
 func fileChangeSummary(details toolresult.FileChangeDetails) string {
@@ -861,6 +947,26 @@ func extractToolArgs(input string) string {
 	return ""
 }
 
+// formatReadToolLabel adds a compact requested range only when the caller chose
+// one explicitly; the common full-file Read remains just Read(path).
+func formatReadToolLabel(input, path string) string {
+	var params struct {
+		Offset int `json:"offset"`
+		Limit  int `json:"limit"`
+	}
+	if json.Unmarshal([]byte(input), &params) != nil || params.Offset < 0 || params.Limit < 0 || (params.Offset == 0 && params.Limit == 0) {
+		return fmt.Sprintf("%s(%s)", tool.ToolRead, path)
+	}
+	start := params.Offset
+	if start <= 0 {
+		start = 1
+	}
+	if params.Limit > 0 {
+		return fmt.Sprintf("%s(%s) · lines %d–%d", tool.ToolRead, path, start, start+params.Limit-1)
+	}
+	return fmt.Sprintf("%s(%s) · lines %d–", tool.ToolRead, path, start)
+}
+
 func formatToolResultSize(toolName, content string) string {
 	switch toolName {
 	case "WebFetch":
@@ -928,17 +1034,10 @@ const bashPrompt = "  $  "
 func renderBashToolCall(input string, width int, icon string) string {
 	command, description := extractBashCommand(input)
 	if command == "" {
-		return renderToolLineWithIcon(fmt.Sprintf("%s(%s)", tool.ToolBash, extractToolArgs(input)), width, icon) + "\n"
+		command = "(no command)"
 	}
 
 	budget := maxToolLabelWidth(width)
-
-	// A short single-line command fits on the compact label untouched.
-	if !strings.Contains(command, "\n") {
-		if label := fmt.Sprintf("%s(%s)", tool.ToolBash, command); lipgloss.Width(label) <= budget {
-			return renderToolLineWithIcon(label, width, icon) + "\n"
-		}
-	}
 
 	var sb strings.Builder
 

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -181,7 +181,14 @@ func renderBashToolResultInline(data ToolResultData) string {
 	}
 
 	var sb strings.Builder
-	if (data.Expanded || data.IsError) && content != "" {
+	// Keep Bash's connector visible while its output is collapsed. When output
+	// is visible, its first row carries the connector so no blank row splits the
+	// command from the result block.
+	showBody := (data.Expanded || data.IsError) && content != ""
+	if !showBody {
+		sb.WriteString(toolResultStyle.Render("  ┊") + "\n")
+	}
+	if showBody {
 		for line := range strings.SplitSeq(content, "\n") {
 			sb.WriteString(renderNestedToolBodyLine(line))
 		}

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -105,6 +105,9 @@ func RenderToolResultInline(data ToolResultData, mdRenderer *MDRenderer) string 
 	case tool.ToolAgent, tool.ToolSendMessage:
 		return renderTaskResultInline(data, mdRenderer)
 	case tool.ToolEdit, tool.ToolWrite:
+		if data.Nested {
+			return renderNestedFileChangeResultInline(data)
+		}
 		return renderFileChangeResultInline(data)
 	case tool.ToolAskUserQuestion:
 		return renderAskUserResultInline(data)
@@ -130,13 +133,74 @@ func renderBashToolResultInline(data ToolResultData) string {
 	}
 
 	var sb strings.Builder
-	sb.WriteString(style.Render("  └ " + state) + "\n")
+	sb.WriteString(style.Render("  └ "+state) + "\n")
 	if (data.Expanded || data.IsError) && content != "" {
 		for line := range strings.SplitSeq(content, "\n") {
-			sb.WriteString(toolResultExpandedStyle.Render("  " + line) + "\n")
+			sb.WriteString(toolResultExpandedStyle.Render("  "+line) + "\n")
 		}
 	}
 	return sb.String()
+}
+
+func renderNestedFileChangeResultInline(data ToolResultData) string {
+	content := data.Content
+	state := "completed"
+	style := toolResultStyle
+
+	if data.IsError {
+		style = errorStyle
+		lines := strings.Split(strings.TrimPrefix(content, "Error: "), "\n")
+		state = "failed"
+		if len(lines) > 0 && lines[0] != "" {
+			state += ": " + lines[0]
+			content = strings.Join(lines[1:], "\n")
+		}
+	} else if details, ok := data.Details.(toolresult.FileChangeDetails); ok {
+		state = fileChangeSummary(details)
+		content = ""
+	} else {
+		state, content = nestedFileChangeFallbackState(data)
+	}
+
+	var sb strings.Builder
+	sb.WriteString(style.Render("  └ "+state) + "\n")
+	if (data.Expanded || data.IsError) && content != "" {
+		for line := range strings.SplitSeq(content, "\n") {
+			sb.WriteString(toolResultExpandedStyle.Render("  "+line) + "\n")
+		}
+	}
+
+	if !data.IsError {
+		details, ok := data.Details.(toolresult.FileChangeDetails)
+		if !ok {
+			return sb.String()
+		}
+		width := data.Width
+		if width <= 0 {
+			width = 80
+		}
+		block, _ := RenderStoredFileDiff(details.UnifiedDiff, width, 0)
+		sb.WriteString(block)
+		if details.TruncatedDiffLines > 0 {
+			sb.WriteString(truncatedStyle.Render(fmt.Sprintf("     … diff truncated (%d more lines)", details.TruncatedDiffLines)) + "\n")
+		}
+	}
+	return sb.String()
+}
+
+func nestedFileChangeFallbackState(data ToolResultData) (state, content string) {
+	return extractParenContent(data.Content, "completed"), data.Content
+}
+
+func fileChangeSummary(details toolresult.FileChangeDetails) string {
+	switch {
+	case details.IsNewFile:
+		return fmt.Sprintf("new file · %d lines", details.AddedLines)
+	case details.EditCount > 0:
+		return fmt.Sprintf("%d replacements · +%d -%d", details.EditCount, details.AddedLines, details.RemovedLines)
+	default:
+		return fmt.Sprintf("rewrote · +%d -%d", details.AddedLines, details.RemovedLines)
+	}
 }
 
 func renderFileChangeResultInline(data ToolResultData) string {
@@ -151,15 +215,7 @@ func renderFileChangeResultInline(data ToolResultData) string {
 		return renderGenericToolResultInline(data)
 	}
 
-	var summary string
-	switch {
-	case details.IsNewFile:
-		summary = fmt.Sprintf("new file · %d lines", details.AddedLines)
-	case details.EditCount > 0:
-		summary = fmt.Sprintf("%d replacements · +%d -%d", details.EditCount, details.AddedLines, details.RemovedLines)
-	default:
-		summary = fmt.Sprintf("rewrote · +%d -%d", details.AddedLines, details.RemovedLines)
-	}
+	summary := fileChangeSummary(details)
 
 	var sb strings.Builder
 	sb.WriteString(toolResultStyle.Render(fmt.Sprintf("  %s  %s → %s", toolResultIcon(false), data.ToolName, summary)) + "\n")
@@ -817,15 +873,24 @@ func formatToolResultSize(toolName, content string) string {
 }
 
 func extractParenContent(s, fallback string) string {
-	start := strings.Index(s, "(")
+	start := strings.IndexByte(s, '(')
 	if start == -1 {
 		return fallback
 	}
-	end := strings.Index(s[start:], ")")
-	if end == -1 {
-		return fallback
+
+	depth := 0
+	for i := start; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return s[start+1 : i]
+			}
+		}
 	}
-	return s[start+1 : start+end]
+	return fallback
 }
 
 func formatLineCount(content string) string {

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -1038,18 +1038,22 @@ func renderBashToolCall(input string, width int, icon string) string {
 	}
 	sb.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, iconCell, header) + "\n")
 
-	// Soft-wrap the whole command to the width left of the prompt, so long lines
-	// flow onto more rows instead of being clipped. xansi.Wrap treats embedded
-	// newlines as hard breaks and breaks any run with no break point, so
-	// multi-line commands and unbroken tokens alike stay within the width — one
-	// wrap covers every line. The first row carries the "$" prompt; every later
-	// row hangs under the command text on an indent the width of that prompt.
+	// Soft-wrap every command line to the available width. The first row carries
+	// the shell prompt; later physical command lines use the same connector as
+	// result output, while soft-wrapped continuations hang under their text.
 	promptWidth := lipgloss.Width(bashPrompt)
 	contIndent := strings.Repeat(" ", promptWidth)
-	segments := strings.Split(xansi.Wrap(command, budget-promptWidth, " "), "\n")
-	sb.WriteString(toolResultStyle.Render(bashPrompt+segments[0]) + "\n")
-	for _, segment := range segments[1:] {
-		sb.WriteString(contIndent + toolResultStyle.Render(segment) + "\n")
+	commandLines := strings.Split(command, "\n")
+	for i, commandLine := range commandLines {
+		segments := strings.Split(xansi.Wrap(commandLine, budget-promptWidth, " "), "\n")
+		if i == 0 {
+			sb.WriteString(toolResultStyle.Render(bashPrompt+segments[0]) + "\n")
+		} else {
+			sb.WriteString(toolResultStyle.Render("  ┊ "+segments[0]) + "\n")
+		}
+		for _, segment := range segments[1:] {
+			sb.WriteString(contIndent + toolResultStyle.Render(segment) + "\n")
+		}
 	}
 	return sb.String()
 }

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -181,13 +181,7 @@ func renderBashToolResultInline(data ToolResultData) string {
 	}
 
 	var sb strings.Builder
-	// Keep Bash's connector visible while its output is collapsed. When output
-	// is visible, its first row carries the connector so no blank row splits the
-	// command from the result block.
 	showBody := (data.Expanded || data.IsError) && content != ""
-	if !showBody {
-		sb.WriteString(toolResultStyle.Render("  ┊") + "\n")
-	}
 	if showBody {
 		for line := range strings.SplitSeq(content, "\n") {
 			sb.WriteString(renderNestedToolBodyLine(line))
@@ -195,12 +189,6 @@ func renderBashToolResultInline(data ToolResultData) string {
 	}
 	sb.WriteString(style.Render("  └ "+summary) + "\n")
 	return sb.String()
-}
-
-// renderNestedBashBodyLine aligns expanded command output with the shell
-// prompt, connector, and terminal summary in a nested Bash block.
-func renderNestedBashBodyLine(line string) string {
-	return renderNestedToolBodyLine(line)
 }
 
 func renderNestedFileChangeResultInline(data ToolResultData) string {
@@ -965,26 +953,6 @@ func extractToolArgs(input string) string {
 		}
 	}
 	return ""
-}
-
-// formatReadToolLabel adds a compact requested range only when the caller chose
-// one explicitly; the common full-file Read remains just Read(path).
-func formatReadToolLabel(input, path string) string {
-	var params struct {
-		Offset int `json:"offset"`
-		Limit  int `json:"limit"`
-	}
-	if json.Unmarshal([]byte(input), &params) != nil || params.Offset < 0 || params.Limit < 0 || (params.Offset == 0 && params.Limit == 0) {
-		return fmt.Sprintf("%s(%s)", tool.ToolRead, path)
-	}
-	start := params.Offset
-	if start <= 0 {
-		start = 1
-	}
-	if params.Limit > 0 {
-		return fmt.Sprintf("%s(%s) · lines %d–%d", tool.ToolRead, path, start, start+params.Limit-1)
-	}
-	return fmt.Sprintf("%s(%s) · lines %d–", tool.ToolRead, path, start)
 }
 
 func formatToolResultSize(toolName, content string) string {

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -95,6 +95,11 @@ func RenderToolResultInline(data ToolResultData, mdRenderer *MDRenderer) string 
 	}
 
 	switch toolName {
+	case tool.ToolBash:
+		if data.Nested {
+			return renderBashToolResultInline(data)
+		}
+		return renderGenericToolResultInline(data)
 	case tool.ToolSkill:
 		return renderSkillResultInline(data)
 	case tool.ToolAgent, tool.ToolSendMessage:
@@ -105,6 +110,33 @@ func RenderToolResultInline(data ToolResultData, mdRenderer *MDRenderer) string 
 		return renderAskUserResultInline(data)
 	}
 	return renderGenericToolResultInline(data)
+}
+
+func renderBashToolResultInline(data ToolResultData) string {
+	state := "completed"
+	content := data.Content
+	if data.IsError {
+		lines := strings.Split(content, "\n")
+		state = "failed"
+		if len(lines) > 0 && lines[0] != "" {
+			state += ": " + lines[0]
+			content = strings.Join(lines[1:], "\n")
+		}
+	}
+
+	style := toolResultStyle
+	if data.IsError {
+		style = errorStyle
+	}
+
+	var sb strings.Builder
+	sb.WriteString(style.Render("  └ " + state) + "\n")
+	if (data.Expanded || data.IsError) && content != "" {
+		for line := range strings.SplitSeq(content, "\n") {
+			sb.WriteString(toolResultExpandedStyle.Render("  " + line) + "\n")
+		}
+	}
+	return sb.String()
 }
 
 func renderFileChangeResultInline(data ToolResultData) string {

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -94,6 +94,17 @@ func RenderToolResultInline(data ToolResultData, mdRenderer *MDRenderer) string 
 		toolName = "Tool"
 	}
 
+	// File-change failures retain their requested-change preview, and Bash
+	// failures retain their line-count summary. Every other nested failure can
+	// use the shared layout without repeating the call's tool name.
+	if data.Nested && data.IsError {
+		switch toolName {
+		case tool.ToolBash, tool.ToolEdit, tool.ToolWrite:
+		default:
+			return renderNestedFailure(data.Content)
+		}
+	}
+
 	switch toolName {
 	case tool.ToolBash:
 		if data.Nested {
@@ -117,35 +128,81 @@ func RenderToolResultInline(data ToolResultData, mdRenderer *MDRenderer) string 
 	case tool.ToolAskUserQuestion:
 		return renderAskUserResultInline(data)
 	}
+	if data.Nested {
+		return renderNestedGenericToolResultInline(data)
+	}
 	return renderGenericToolResultInline(data)
 }
 
+const (
+	// Nested markers share a display column across command, body, and trailer rows.
+	nestedBodyPrefix    = "  ┊ "
+	nestedTrailerPrefix = "  └ "
+	bashPrompt          = "  $ "
+)
+
 func renderNestedReadResultInline(data ToolResultData) string {
 	if data.IsError {
-		var sb strings.Builder
-		for line := range strings.SplitSeq(strings.TrimPrefix(data.Content, "Error: "), "\n") {
-			sb.WriteString(renderNestedToolBodyLine(line))
-		}
-		sb.WriteString(errorStyle.Render("  └ failed") + "\n")
-		return sb.String()
+		return renderNestedFailure(data.Content)
 	}
 
 	content := strings.TrimSuffix(data.Content, "\n")
 	var sb strings.Builder
-	if data.Expanded && content != "" {
-		for line := range strings.SplitSeq(content, "\n") {
-			sb.WriteString(renderNestedToolBodyLine(line))
-		}
+	if data.Expanded {
+		sb.WriteString(renderNestedToolBody(content))
 	}
-	sb.WriteString(toolResultStyle.Render("  └ "+formatReadResultSummary(content)) + "\n")
+	sb.WriteString(renderNestedToolTrailer(formatReadResultSummary(content), toolResultStyle))
 	return sb.String()
 }
 
-// renderNestedToolBodyLine keeps body content under the same visual connector
-// that ends at the adjacent terminal summary. The connector only appears for
-// visible content, so collapsed results stay compact.
+// renderNestedToolBody keeps visible content under the same connector that
+// ends at the adjacent terminal summary. Empty content adds no decorative row.
+func renderNestedToolBody(content string) string {
+	content = strings.TrimRight(content, "\n")
+	if content == "" {
+		return ""
+	}
+
+	var sb strings.Builder
+	for line := range strings.SplitSeq(content, "\n") {
+		if strings.TrimSpace(line) == "" {
+			sb.WriteString(strings.Repeat(" ", lipgloss.Width(nestedBodyPrefix)) + "\n")
+			continue
+		}
+		sb.WriteString(renderNestedToolBodyLine(line))
+	}
+	return sb.String()
+}
+
 func renderNestedToolBodyLine(line string) string {
-	return toolResultStyle.Render("  ┊ "+line) + "\n"
+	return toolResultStyle.Render(nestedBodyPrefix+line) + "\n"
+}
+
+func renderNestedToolTrailer(summary string, style lipgloss.Style) string {
+	return style.Render(nestedTrailerPrefix+summary) + "\n"
+}
+
+func renderNestedFailure(content string) string {
+	content = strings.TrimPrefix(content, "Error: ")
+	return renderNestedToolBody(content) + renderNestedToolTrailer("failed", errorStyle)
+}
+
+func renderNestedGenericToolResultInline(data ToolResultData) string {
+	if data.IsError {
+		return renderNestedFailure(data.Content)
+	}
+
+	content := strings.TrimSuffix(data.Content, "\n")
+	var sb strings.Builder
+	if data.Expanded {
+		sb.WriteString(renderNestedToolBody(content))
+	}
+	toolName := data.ToolName
+	if toolName == "" {
+		toolName = "Tool"
+	}
+	sb.WriteString(renderNestedToolTrailer(formatToolResultSize(toolName, content), toolResultStyle))
+	return sb.String()
 }
 
 func formatReadResultSummary(content string) string {
@@ -160,7 +217,7 @@ func formatReadResultSummary(content string) string {
 		}
 	}
 	if count > 0 {
-		return fmt.Sprintf("%d lines", count)
+		return formatLineCountValue(count)
 	}
 	if strings.HasPrefix(content, "file exists but is empty:") {
 		return "empty file"
@@ -168,7 +225,13 @@ func formatReadResultSummary(content string) string {
 	if strings.HasPrefix(content, "no lines at offset ") {
 		return "no lines"
 	}
-	return "no output"
+	if strings.HasPrefix(content, "Binary file detected:") {
+		return "binary file"
+	}
+	if strings.HasPrefix(content, "image file:") {
+		return "image file"
+	}
+	return formatLineCount(content)
 }
 
 func renderBashToolResultInline(data ToolResultData) string {
@@ -183,11 +246,9 @@ func renderBashToolResultInline(data ToolResultData) string {
 	var sb strings.Builder
 	showBody := (data.Expanded || data.IsError) && content != ""
 	if showBody {
-		for line := range strings.SplitSeq(content, "\n") {
-			sb.WriteString(renderNestedToolBodyLine(line))
-		}
+		sb.WriteString(renderNestedToolBody(content))
 	}
-	sb.WriteString(style.Render("  └ "+summary) + "\n")
+	sb.WriteString(renderNestedToolTrailer(summary, style))
 	return sb.String()
 }
 
@@ -199,38 +260,29 @@ func renderNestedFileChangeResultInline(data ToolResultData) string {
 
 	var sb strings.Builder
 	if data.IsError {
-		sb.WriteString(renderFileChangeInputPreview(data.ToolInput, width))
-		for line := range strings.SplitSeq(strings.TrimPrefix(data.Content, "Error: "), "\n") {
-			sb.WriteString(renderNestedToolBodyLine(line))
-		}
-		sb.WriteString(errorStyle.Render("  └ failed") + "\n")
+		sb.WriteString(renderFileChangeInputPreview(data.ToolInput, data.Content, width))
+		sb.WriteString(renderNestedFailure(data.Content))
 		return sb.String()
 	}
 
 	if details, ok := data.Details.(toolresult.FileChangeDetails); ok {
-		block, _ := renderStoredFileDiffIndented(details.UnifiedDiff, width, 0, "  ┊ ")
+		block, _ := renderStoredFileDiffIndented(details.UnifiedDiff, width, 0, nestedBodyPrefix)
 		sb.WriteString(block)
 		if details.TruncatedDiffLines > 0 {
-			sb.WriteString(truncatedStyle.Render(fmt.Sprintf("  ┊ … diff truncated (%d more lines)", details.TruncatedDiffLines)) + "\n")
+			sb.WriteString(truncatedStyle.Render(fmt.Sprintf(nestedBodyPrefix+"… diff truncated (%d more lines)", details.TruncatedDiffLines)) + "\n")
 		}
-		sb.WriteString(toolResultStyle.Render("  └ "+fileChangeSummary(details)) + "\n")
+		sb.WriteString(renderNestedToolTrailer(fileChangeSummary(details), toolResultStyle))
 		return sb.String()
 	}
 
-	state, content := nestedFileChangeFallbackState(data)
-	if content != "" {
-		for line := range strings.SplitSeq(content, "\n") {
-			sb.WriteString(toolResultExpandedStyle.Render(line) + "\n")
-		}
-	}
-	sb.WriteString(toolResultStyle.Render("  └ "+state) + "\n")
+	sb.WriteString(renderNestedToolTrailer(extractTrailingParenContent(data.Content, "completed"), toolResultStyle))
 	return sb.String()
 }
 
 // renderFileChangeInputPreview shows the requested change when the edit did
 // not apply. It uses tool input rather than diagnostics so the user can compare
 // the intended replacement with the actual-file diagnostic below.
-func renderFileChangeInputPreview(input string, width int) string {
+func renderFileChangeInputPreview(input, diagnostic string, width int) string {
 	var params struct {
 		OldString string `json:"old_string"`
 		NewString string `json:"new_string"`
@@ -252,7 +304,11 @@ func renderFileChangeInputPreview(input string, width int) string {
 		old, new = params.OldText, params.NewText
 	}
 	if old == "" && new == "" && len(params.Edits) > 0 {
-		edit := params.Edits[0]
+		index := editIndexFromDiagnostic(diagnostic)
+		if index < 0 || index >= len(params.Edits) {
+			index = 0
+		}
+		edit := params.Edits[index]
 		old, new = edit.OldString, edit.NewString
 		if old == "" && new == "" {
 			old, new = edit.OldText, edit.NewText
@@ -261,7 +317,7 @@ func renderFileChangeInputPreview(input string, width int) string {
 	if new == "" && params.Content != "" {
 		new = params.Content
 	}
-	previewWidth := width - 4
+	previewWidth := width - lipgloss.Width(nestedBodyPrefix)
 	if previewWidth <= lipgloss.Width("+ ") {
 		return ""
 	}
@@ -271,30 +327,59 @@ func renderFileChangeInputPreview(input string, width int) string {
 			continue
 		}
 		for line := range strings.SplitSeq(preview.text, "\n") {
-			for _, segment := range strings.Split(xansi.Wrap(line, previewWidth-lipgloss.Width(preview.marker)-1, " "), "\n") {
-				sb.WriteString(toolResultStyle.Render("  ┊ "+preview.marker+" "+segment) + "\n")
+			for segment := range strings.SplitSeq(xansi.Wrap(line, previewWidth-lipgloss.Width(preview.marker)-1, " "), "\n") {
+				sb.WriteString(toolResultStyle.Render(nestedBodyPrefix+preview.marker+" "+segment) + "\n")
 			}
 		}
 	}
 	return sb.String()
 }
 
-func nestedFileChangeFallbackState(data ToolResultData) (state, content string) {
-	return extractParenContent(data.Content, "completed"), ""
+func editIndexFromDiagnostic(diagnostic string) int {
+	const prefix = "edits["
+	start := strings.Index(diagnostic, prefix)
+	if start < 0 {
+		return -1
+	}
+	start += len(prefix)
+	end := strings.IndexByte(diagnostic[start:], ']')
+	if end < 0 {
+		return -1
+	}
+	index, err := strconv.Atoi(diagnostic[start : start+end])
+	if err != nil {
+		return -1
+	}
+	return index
+}
+
+func extractTrailingParenContent(s, fallback string) string {
+	end := strings.LastIndexByte(s, ')')
+	if end < 0 {
+		return fallback
+	}
+
+	depth := 0
+	for i := end; i >= 0; i-- {
+		switch s[i] {
+		case ')':
+			depth++
+		case '(':
+			depth--
+			if depth == 0 {
+				candidate := s[i+1 : end]
+				if strings.Contains(candidate, " lines") || strings.Contains(candidate, "replacement(s)") {
+					return candidate
+				}
+				return fallback
+			}
+		}
+	}
+	return fallback
 }
 
 func fileChangeSummary(details toolresult.FileChangeDetails) string {
-	parts := make([]string, 0, 2)
-	if details.AddedLines > 0 {
-		parts = append(parts, fmt.Sprintf("+%d", details.AddedLines))
-	}
-	if details.RemovedLines > 0 {
-		parts = append(parts, fmt.Sprintf("-%d", details.RemovedLines))
-	}
-	if len(parts) == 0 {
-		return "no changes"
-	}
-	return strings.Join(parts, " ")
+	return fmt.Sprintf("+%d -%d", details.AddedLines, details.RemovedLines)
 }
 
 func renderFileChangeResultInline(data ToolResultData) string {
@@ -992,7 +1077,13 @@ func formatLineCount(content string) string {
 	if trimmed == "" {
 		return "no output"
 	}
-	lineCount := strings.Count(trimmed, "\n") + 1
+	return formatLineCountValue(strings.Count(trimmed, "\n") + 1)
+}
+
+func formatLineCountValue(lineCount int) string {
+	if lineCount == 1 {
+		return "1 line"
+	}
 	return fmt.Sprintf("%d lines", lineCount)
 }
 
@@ -1005,23 +1096,14 @@ func renderToolLineWithIcon(label string, width int, iconText string) string {
 	return lipgloss.JoinHorizontal(lipgloss.Top, icon, toolCallStyle.Render(truncateToolLabel(label, width)))
 }
 
-// bashPrompt marks the first command row with a shell "$" so the block reads as
-// a terminal command. Every later row (a wrap or a continued command line) hangs
-// under the command text by an indent the width of the prompt, so the whole
-// command body lines up in one column with the "$" as a hanging prompt to its
-// left. The "$" aligns with the "⎿" result marker below, while the command text
-// aligns with the result's tool label (for example, "Bash").
-const bashPrompt = "  $ "
-
 // renderBashToolCall renders a Bash tool call so its command is always readable
-// in full. A short single-line command keeps the compact Bash(cmd) label; a
-// multi-line command — or a single line too long for that label — renders as a
-// dimmed block below a "● Bash" header, led by a shell "$" prompt, with the
-// optional description as a caption. Command lines soft-wrap to the width rather
-// than truncate, so the full command is always visible, never clipped.
+// in full. It renders a dimmed command block below a "● Bash" header, led by a
+// shell "$" prompt, with the optional description as a caption. Command lines
+// soft-wrap to the width rather than truncate, so the full command is always
+// visible, never clipped.
 func renderBashToolCall(input string, width int, icon string) string {
 	command, description := extractBashCommand(input)
-	if command == "" {
+	if strings.TrimSpace(command) == "" {
 		command = "(no command)"
 	}
 
@@ -1031,27 +1113,47 @@ func renderBashToolCall(input string, width int, icon string) string {
 
 	// Header line: ● Bash - description. The description may be shortened
 	// (it's metadata); the command below never is.
-	iconCell := toolCallStyle.Width(2).Render(icon)
-	header := toolCallStyle.Render(tool.ToolBash)
+	header := tool.ToolBash
 	if description != "" {
-		header += " - " + kit.TruncateText(description, budget)
+		header += " - " + description
 	}
-	sb.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, iconCell, header) + "\n")
+	sb.WriteString(renderToolLineWithIcon(header, width, icon) + "\n")
 
 	// Soft-wrap every command line to the available width. The first row carries
 	// the shell prompt; later physical command lines use the same connector as
 	// result output, while soft-wrapped continuations hang under their text.
 	promptWidth := lipgloss.Width(bashPrompt)
 	contIndent := strings.Repeat(" ", promptWidth)
-	commandLines := strings.Split(command, "\n")
-	for i, commandLine := range commandLines {
-		segments := strings.Split(xansi.Wrap(commandLine, budget-promptWidth, " "), "\n")
-		if i == 0 {
-			sb.WriteString(toolResultStyle.Render(bashPrompt+segments[0]) + "\n")
-		} else {
-			sb.WriteString(toolResultStyle.Render("  ┊ "+segments[0]) + "\n")
+	wrapWidth := budget - promptWidth
+	seenCommand := false
+	for commandLine := range strings.SplitSeq(command, "\n") {
+		// Preserve intentional blank lines between command rows as hanging rows,
+		// but skip leading whitespace so the first visible command retains "$".
+		if strings.TrimSpace(commandLine) == "" {
+			if seenCommand {
+				sb.WriteString(contIndent + "\n")
+			}
+			continue
 		}
-		for _, segment := range segments[1:] {
+
+		prefix := bashPrompt
+		if seenCommand {
+			prefix = nestedBodyPrefix
+		}
+		seenCommand = true
+
+		if lipgloss.Width(commandLine) <= wrapWidth {
+			sb.WriteString(toolResultStyle.Render(prefix+commandLine) + "\n")
+			continue
+		}
+
+		first := true
+		for segment := range strings.SplitSeq(xansi.Wrap(commandLine, wrapWidth, " "), "\n") {
+			if first {
+				sb.WriteString(toolResultStyle.Render(prefix+segment) + "\n")
+				first = false
+				continue
+			}
 			sb.WriteString(contIndent + toolResultStyle.Render(segment) + "\n")
 		}
 	}

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -130,15 +130,22 @@ func renderNestedReadResultInline(data ToolResultData) string {
 		return sb.String()
 	}
 
-	var sb strings.Builder
 	content := strings.TrimSuffix(data.Content, "\n")
-	if content != "" {
+	var sb strings.Builder
+	if data.Expanded && content != "" {
 		for line := range strings.SplitSeq(content, "\n") {
-			sb.WriteString(toolResultExpandedStyle.Render(line) + "\n")
+			sb.WriteString(renderNestedReadBodyLine(line))
 		}
 	}
 	sb.WriteString(toolResultStyle.Render("  └ "+formatReadResultSummary(content)) + "\n")
 	return sb.String()
+}
+
+// renderNestedReadBodyLine keeps expanded Read results one level below their
+// call, avoiding the generic expanded-result padding that made Read rows appear
+// four columns farther right than their terminal summary.
+func renderNestedReadBodyLine(line string) string {
+	return toolResultStyle.Render("  "+line) + "\n"
 }
 
 func formatReadResultSummary(content string) string {
@@ -180,10 +187,16 @@ func renderBashToolResultInline(data ToolResultData) string {
 	sb.WriteString(style.Render("  └ "+summary) + "\n")
 	if (data.Expanded || data.IsError) && content != "" {
 		for line := range strings.SplitSeq(content, "\n") {
-			sb.WriteString(toolResultExpandedStyle.Render(line) + "\n")
+			sb.WriteString(renderNestedBashBodyLine(line))
 		}
 	}
 	return sb.String()
+}
+
+// renderNestedBashBodyLine aligns expanded command output with the shell
+// prompt, connector, and terminal summary in a nested Bash block.
+func renderNestedBashBodyLine(line string) string {
+	return toolResultStyle.Render("  "+line) + "\n"
 }
 
 func renderNestedFileChangeResultInline(data ToolResultData) string {
@@ -203,10 +216,10 @@ func renderNestedFileChangeResultInline(data ToolResultData) string {
 	}
 
 	if details, ok := data.Details.(toolresult.FileChangeDetails); ok {
-		block, _ := RenderStoredFileDiff(details.UnifiedDiff, width, 0)
+		block, _ := renderStoredFileDiffIndented(details.UnifiedDiff, width, 0, "  ")
 		sb.WriteString(block)
 		if details.TruncatedDiffLines > 0 {
-			sb.WriteString(truncatedStyle.Render(fmt.Sprintf("     … diff truncated (%d more lines)", details.TruncatedDiffLines)) + "\n")
+			sb.WriteString(truncatedStyle.Render(fmt.Sprintf("  … diff truncated (%d more lines)", details.TruncatedDiffLines)) + "\n")
 		}
 		sb.WriteString(toolResultStyle.Render("  └ "+fileChangeSummary(details)) + "\n")
 		return sb.String()


### PR DESCRIPTION
Render Bash completion and error states beneath their command instead of repeating a misaligned Bash result label.

- preserve Bash as a single call header
- nest expanded output and error detail under the command