### PR TITLE
fix(tui): keep Bash output connectors continuous

### DIFF
--- a/internal/app/conv/bash_render_demo_test.go
+++ b/internal/app/conv/bash_render_demo_test.go
@@ -2,15 +2,20 @@ package conv
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/genai-io/san/internal/core"
 )
 
 // TestBashRenderDemo prints how Bash tool calls render, for eyeballing.
-// Run:  go test ./internal/app/conv/ -run TestBashRenderDemo -v
+// Run:  SAN_BASH_RENDER_DEMO=1 go test ./internal/app/conv/ -run TestBashRenderDemo -v
 // Tweak the `width` and add your own cases to `samples`.
 func TestBashRenderDemo(t *testing.T) {
+	if os.Getenv("SAN_BASH_RENDER_DEMO") == "" {
+		t.Skip("set SAN_BASH_RENDER_DEMO=1 to print the Bash rendering demo")
+	}
+
 	const width = 70 // terminal width; block wraps at ~80% of this
 
 	samples := []struct {

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -184,11 +184,11 @@ func Test_renderBashToolCallShowsShellPrompt(t *testing.T) {
 		t.Fatalf("command should follow the prompt without extra spacing: %q", rows[0])
 	}
 
-	// prompt, so command text lines up down one column and the prompt never repeats.
-	contIndent := strings.Repeat(" ", lipgloss.Width(bashPrompt))
+	// Wrapped rows use the connector so the command block stays connected to its
+	// result summary. The prompt appears only on the first row.
 	for i, row := range rows[1:] {
-		if !strings.HasPrefix(row, contIndent) || strings.HasPrefix(row, bashPrompt) || strings.HasPrefix(row, nestedBodyPrefix) {
-			t.Fatalf("continuation row %d should hang under the command text, not repeat the prompt: %q", i+1, row)
+		if !strings.HasPrefix(row, nestedBodyPrefix) || strings.HasPrefix(row, bashPrompt) {
+			t.Fatalf("continuation row %d should retain the connector without repeating the prompt: %q", i+1, row)
 		}
 	}
 
@@ -198,20 +198,22 @@ func Test_renderBashToolCallShowsShellPrompt(t *testing.T) {
 	}
 }
 
-func Test_renderBashToolCallAvoidsConnectorOnlyRows(t *testing.T) {
+func Test_renderBashToolCallKeepsConnectorsContinuousAcrossBlankLines(t *testing.T) {
 	for _, input := range []string{
-		`{"command":"first\n"}`,
 		`{"command":"first\n\nthird"}`,
 		`{"command":"first\n   \nthird"}`,
-		`{"command":"\nfirst"}`,
 	} {
 		out := stripANSI(renderBashToolCall(input, 100, "●"))
-		if strings.Contains(out, strings.TrimSuffix(nestedBodyPrefix, " ")+"\n") {
-			t.Fatalf("blank command lines should not create connector-only rows, got %q", out)
+		if !strings.Contains(out, bashPrompt+"first\n"+nestedBodyPrefix+"\n"+nestedBodyPrefix+"third\n") {
+			t.Fatalf("blank command lines should retain the connector, got %q", out)
 		}
-		if !strings.Contains(out, bashPrompt+"first\n") {
-			t.Fatalf("first visible command line should retain the shell prompt, got %q", out)
-		}
+	}
+
+	if out := stripANSI(renderBashToolCall(`{"command":"first\n"}`, 100, "●")); !strings.Contains(out, bashPrompt+"first\n"+nestedBodyPrefix+"\n") {
+		t.Fatalf("trailing blank command line should retain the connector, got %q", out)
+	}
+	if out := stripANSI(renderBashToolCall(`{"command":"\nfirst"}`, 100, "●")); strings.Contains(out, nestedBodyPrefix+"\n") || !strings.Contains(out, bashPrompt+"first\n") {
+		t.Fatalf("leading blank lines should be skipped and first visible command should retain the shell prompt, got %q", out)
 	}
 	if out := stripANSI(renderBashToolCall(`{"command":"   "}`, 100, "●")); !strings.Contains(out, bashPrompt+"(no command)\n") {
 		t.Fatalf("whitespace-only command should use the empty-command fallback, got %q", out)
@@ -923,7 +925,12 @@ func TestRenderToolCallsNestsBashFailureUnderCommand(t *testing.T) {
 	rendered := stripANSI(RenderToolCalls(ToolCallsParams{
 		ToolCalls: []core.ToolCall{call},
 		ResultMap: map[string]ToolResultData{
-			call.ID: {ToolName: "Bash", Content: "exit status 1\nstderr detail", IsError: true},
+			call.ID: {
+				ToolName: "Bash",
+				Content:  "test output\nstderr detail\nError: exit code 1",
+				IsError:  true,
+				Details:  toolresult.BashDetails{Error: "exit code 1", LineCount: 2},
+			},
 		},
 		Width: 100,
 	}))
@@ -931,8 +938,100 @@ func TestRenderToolCallsNestsBashFailureUnderCommand(t *testing.T) {
 	if strings.Count(rendered, "Bash") != 1 {
 		t.Fatalf("Bash should be named only in its call header, got %q", rendered)
 	}
-	if !strings.Contains(rendered, "  ┊ exit status 1\n  ┊ stderr detail\n  └ failed · 2 lines\n") {
-		t.Fatalf("Bash failure should report its line count and expanded detail, got %q", rendered)
+	if !strings.Contains(rendered, "  ┊ test output\n  ┊ stderr detail\n  └ failed · exit code 1 · 2 lines\n") {
+		t.Fatalf("Bash failure should move its error into the summary without counting it as output, got %q", rendered)
+	}
+	if strings.Contains(rendered, "Error: exit code 1") {
+		t.Fatalf("Bash failure should not repeat its model-facing error line in the output body, got %q", rendered)
+	}
+}
+
+func TestRenderToolCallsKeepsBashOutputConnectorAcrossBlankLines(t *testing.T) {
+	call := core.ToolCall{ID: "bash-1", Name: "Bash", Input: `{"command":"printf output; exit 1"}`}
+	rendered := stripANSI(RenderToolCalls(ToolCallsParams{
+		ToolCalls: []core.ToolCall{call},
+		ResultMap: map[string]ToolResultData{
+			call.ID: {
+				ToolName: "Bash",
+				Content:  "first\n\nthird\nError: exit code 1",
+				IsError:  true,
+				Details:  toolresult.BashDetails{Error: "exit code 1", LineCount: 3},
+			},
+		},
+		Width: 100,
+	}))
+
+	if !strings.Contains(rendered, "  ┊ first\n  ┊ \n  ┊ third\n  └ failed · exit code 1 · 3 lines\n") {
+		t.Fatalf("blank Bash output lines should retain the connector, got %q", rendered)
+	}
+}
+
+func TestRenderToolCallsRestoresLegacyBashFailureSummary(t *testing.T) {
+	call := core.ToolCall{ID: "bash-1", Name: "Bash", Input: `{"command":"false"}`}
+	rendered := stripANSI(RenderToolCalls(ToolCallsParams{
+		ToolCalls: []core.ToolCall{call},
+		ResultMap: map[string]ToolResultData{
+			call.ID: {
+				ToolName: "Bash",
+				Content:  "first\n\nthird\nError: exit code 1",
+				IsError:  true,
+			},
+		},
+		Width: 100,
+	}))
+
+	if !strings.Contains(rendered, "  ┊ first\n  ┊ \n  ┊ third\n  └ failed · exit code 1 · 3 lines\n") {
+		t.Fatalf("legacy Bash failures without details should retain the concise summary, got %q", rendered)
+	}
+	if strings.Contains(rendered, "Error: exit code 1") {
+		t.Fatalf("legacy Bash failure should not repeat its model-facing error line, got %q", rendered)
+	}
+}
+
+func TestRenderToolCallsNestsBashFailureWithoutOutput(t *testing.T) {
+	call := core.ToolCall{ID: "bash-1", Name: "Bash", Input: `{"command":"false"}`}
+	rendered := stripANSI(RenderToolCalls(ToolCallsParams{
+		ToolCalls: []core.ToolCall{call},
+		ResultMap: map[string]ToolResultData{
+			call.ID: {
+				ToolName: "Bash",
+				Content:  "Error: exit code 1",
+				IsError:  true,
+				Details:  toolresult.BashDetails{Error: "exit code 1"},
+			},
+		},
+		Width: 100,
+	}))
+
+	if !strings.Contains(rendered, "  $ false\n  └ failed · exit code 1\n") {
+		t.Fatalf("Bash failure without output should show only its reason in the summary, got %q", rendered)
+	}
+	if strings.Contains(rendered, "Error:") || strings.Contains(rendered, "no output") {
+		t.Fatalf("Bash failure without output should not add a body or no-output suffix, got %q", rendered)
+	}
+}
+
+func TestRenderToolCallsSummarizesBashTimeout(t *testing.T) {
+	const reason = "command timed out after 2s — if it was waiting for interactive input, re-run with a non-interactive flag"
+	call := core.ToolCall{ID: "bash-1", Name: "Bash", Input: `{"command":"sleep 10"}`}
+	rendered := stripANSI(RenderToolCalls(ToolCallsParams{
+		ToolCalls: []core.ToolCall{call},
+		ResultMap: map[string]ToolResultData{
+			call.ID: {
+				ToolName: "Bash",
+				Content:  "started\nError: " + reason,
+				IsError:  true,
+				Details:  toolresult.BashDetails{Error: reason, LineCount: 1},
+			},
+		},
+		Width: 100,
+	}))
+
+	if !strings.Contains(rendered, "  ┊ started\n  └ failed · timed out after 2s · 1 line\n") {
+		t.Fatalf("Bash timeout should use a concise reason and preserve output count, got %q", rendered)
+	}
+	if strings.Contains(rendered, "Error:") || strings.Contains(rendered, "non-interactive") {
+		t.Fatalf("Bash timeout should not repeat its long model-facing diagnostic, got %q", rendered)
 	}
 }
 

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -178,6 +178,19 @@ func renderNestedToolBodyLine(line string) string {
 	return toolResultStyle.Render(nestedBodyPrefix+line) + "\n"
 }
 
+func renderNestedToolBodyContinuous(content string) string {
+	content = strings.TrimRight(content, "\n")
+	if content == "" {
+		return ""
+	}
+
+	var sb strings.Builder
+	for line := range strings.SplitSeq(content, "\n") {
+		sb.WriteString(renderNestedToolBodyLine(line))
+	}
+	return sb.String()
+}
+
 func renderNestedToolTrailer(summary string, style lipgloss.Style) string {
 	return style.Render(nestedTrailerPrefix+summary) + "\n"
 }
@@ -239,17 +252,73 @@ func renderBashToolResultInline(data ToolResultData) string {
 	summary := formatLineCount(content)
 	style := toolResultStyle
 	if data.IsError {
-		summary = "failed · " + summary
+		content, summary = formatBashFailure(content, data.Details)
 		style = errorStyle
 	}
 
 	var sb strings.Builder
 	showBody := (data.Expanded || data.IsError) && content != ""
 	if showBody {
-		sb.WriteString(renderNestedToolBody(content))
+		sb.WriteString(renderNestedToolBodyContinuous(content))
 	}
 	sb.WriteString(renderNestedToolTrailer(summary, style))
 	return sb.String()
+}
+
+func formatBashFailure(content string, details any) (string, string) {
+	if bashDetails, ok := details.(toolresult.BashDetails); ok {
+		content = trimBashErrorSuffix(content, bashDetails.Error)
+		return content, formatBashFailureSummary(bashDetails.Error, bashDetails.LineCount)
+	}
+
+	if output, reason, ok := splitBashFailureContent(content); ok {
+		lineCount := 0
+		if strings.TrimSuffix(output, "\n") != "" {
+			lineCount = strings.Count(strings.TrimSuffix(output, "\n"), "\n") + 1
+		}
+		return output, formatBashFailureSummary(reason, lineCount)
+	}
+
+	return content, "failed · " + formatLineCount(content)
+}
+
+func formatBashFailureSummary(reason string, lineCount int) string {
+	summary := "failed"
+	if reason = formatBashFailureReason(reason); reason != "" {
+		summary += " · " + reason
+	}
+	if lineCount > 0 {
+		summary += " · " + formatLineCountValue(lineCount)
+	}
+	return summary
+}
+
+func splitBashFailureContent(content string) (output, reason string, ok bool) {
+	if reason, ok := strings.CutPrefix(content, "Error: "); ok {
+		return "", reason, true
+	}
+	const separator = "\nError: "
+	index := strings.LastIndex(content, separator)
+	if index < 0 {
+		return "", "", false
+	}
+	return content[:index], content[index+len(separator):], true
+}
+
+func trimBashErrorSuffix(content, errorMessage string) string {
+	if content == "Error: "+errorMessage {
+		return ""
+	}
+	return strings.TrimSuffix(content, "\nError: "+errorMessage)
+}
+
+func formatBashFailureReason(reason string) string {
+	const timeoutPrefix = "command timed out after "
+	if after, ok := strings.CutPrefix(reason, timeoutPrefix); ok {
+		duration, _, _ := strings.Cut(after, " — ")
+		return "timed out after " + duration
+	}
+	return reason
 }
 
 func renderNestedFileChangeResultInline(data ToolResultData) string {
@@ -1120,18 +1189,18 @@ func renderBashToolCall(input string, width int, icon string) string {
 	sb.WriteString(renderToolLineWithIcon(header, width, icon) + "\n")
 
 	// Soft-wrap every command line to the available width. The first row carries
-	// the shell prompt; later physical command lines use the same connector as
-	// result output, while soft-wrapped continuations hang under their text.
+	// the shell prompt; every later row uses the connector so the command and its
+	// result form one continuous block.
 	promptWidth := lipgloss.Width(bashPrompt)
-	contIndent := strings.Repeat(" ", promptWidth)
 	wrapWidth := budget - promptWidth
 	seenCommand := false
 	for commandLine := range strings.SplitSeq(command, "\n") {
-		// Preserve intentional blank lines between command rows as hanging rows,
-		// but skip leading whitespace so the first visible command retains "$".
+		// Preserve intentional blank lines after the command starts while keeping
+		// the connector continuous. Leading blank lines are still skipped so the
+		// first visible command retains "$".
 		if strings.TrimSpace(commandLine) == "" {
 			if seenCommand {
-				sb.WriteString(contIndent + "\n")
+				sb.WriteString(renderNestedToolBodyLine(""))
 			}
 			continue
 		}
@@ -1154,7 +1223,7 @@ func renderBashToolCall(input string, width int, icon string) string {
 				first = false
 				continue
 			}
-			sb.WriteString(contIndent + toolResultStyle.Render(segment) + "\n")
+			sb.WriteString(toolResultStyle.Render(nestedBodyPrefix+segment) + "\n")
 		}
 	}
 	return sb.String()

--- a/internal/session/message_convert.go
+++ b/internal/session/message_convert.go
@@ -186,8 +186,11 @@ func assistantContentToBlocks(content, thinking, thinkingSignature string, toolC
 
 func toolResultToBlocks(tr *core.ToolResult) []ContentBlock {
 	block := ContentBlock{Type: "tool_result", ToolUseID: tr.ToolCallID, IsError: tr.IsError}
-	if details, ok := tr.Details.(toolresult.FileChangeDetails); ok {
+	switch details := tr.Details.(type) {
+	case toolresult.FileChangeDetails:
 		block.EditDetails, _ = json.Marshal(details)
+	case toolresult.BashDetails:
+		block.BashDetails, _ = json.Marshal(details)
 	}
 	if tr.Content != "" {
 		block.Content = []ContentBlock{{Type: "text", Text: tr.Content}}
@@ -231,6 +234,11 @@ func extractUserContent(blocks []ContentBlock, msg *core.Message) {
 			if len(block.EditDetails) > 0 {
 				var details toolresult.FileChangeDetails
 				if json.Unmarshal(block.EditDetails, &details) == nil {
+					tr.Details = details
+				}
+			} else if len(block.BashDetails) > 0 {
+				var details toolresult.BashDetails
+				if json.Unmarshal(block.BashDetails, &details) == nil {
 					tr.Details = details
 				}
 			}

--- a/internal/session/message_convert_test.go
+++ b/internal/session/message_convert_test.go
@@ -143,12 +143,17 @@ func Test_messagesToNodes_roundtrip(t *testing.T) {
 			ToolCallID: "tc-1", ToolName: "Edit", Content: "Edited /tmp/test (1 replacements, +1 -1)",
 			Details: toolresult.FileChangeDetails{Path: "/tmp/test", EditCount: 1, AddedLines: 1, RemovedLines: 1, UnifiedDiff: "@@ -1 +1 @@\n-old\n+new"},
 		}},
+		{Role: core.RoleAssistant, ToolCalls: []core.ToolCall{{ID: "tc-2", Name: "Bash", Input: `{"command":"false"}`}}},
+		{Role: core.RoleUser, ToolResult: &core.ToolResult{
+			ToolCallID: "tc-2", ToolName: "Bash", Content: "Error: exit code 1", IsError: true,
+			Details: toolresult.BashDetails{Error: "exit code 1", LineCount: 0},
+		}},
 		{Role: core.RoleAssistant, Content: "I see the file."},
 	}
 
 	nodes := messagesToNodes(msgs, "/cwd", time.Time{}, "main")
-	if len(nodes) != 4 {
-		t.Fatalf("expected 4 nodes, got %d", len(nodes))
+	if len(nodes) != 6 {
+		t.Fatalf("expected 6 nodes, got %d", len(nodes))
 	}
 
 	// Verify node roles
@@ -164,8 +169,8 @@ func Test_messagesToNodes_roundtrip(t *testing.T) {
 
 	// Round-trip back to messages
 	restored := messagesFromNodes(nodes)
-	if len(restored) != 4 {
-		t.Fatalf("expected 4 messages after roundtrip, got %d", len(restored))
+	if len(restored) != 6 {
+		t.Fatalf("expected 6 messages after roundtrip, got %d", len(restored))
 	}
 	if restored[0].Content != "hello" {
 		t.Errorf("msg[0].Content: want 'hello', got %q", restored[0].Content)
@@ -186,6 +191,13 @@ func Test_messagesToNodes_roundtrip(t *testing.T) {
 	details, ok := restored[2].ToolResult.Details.(toolresult.FileChangeDetails)
 	if !ok || details.UnifiedDiff != "@@ -1 +1 @@\n-old\n+new" {
 		t.Errorf("restored Edit details = %#v", restored[2].ToolResult.Details)
+	}
+	if restored[4].ToolResult == nil || restored[4].ToolResult.ToolName != "Bash" {
+		t.Fatalf("restored Bash result = %#v", restored[4].ToolResult)
+	}
+	bashDetails, ok := restored[4].ToolResult.Details.(toolresult.BashDetails)
+	if !ok || bashDetails.Error != "exit code 1" || bashDetails.LineCount != 0 {
+		t.Errorf("restored Bash details = %#v", restored[4].ToolResult.Details)
 	}
 }
 

--- a/internal/session/transcript/records.go
+++ b/internal/session/transcript/records.go
@@ -212,6 +212,7 @@ type ContentBlock struct {
 	Content     []ContentBlock  `json:"content,omitempty"`
 	IsError     bool            `json:"is_error,omitempty"`
 	EditDetails json.RawMessage `json:"edit_details,omitempty"`
+	BashDetails json.RawMessage `json:"bash_details,omitempty"`
 
 	// Source marks the provenance of injected content (e.g. "hook:UserPromptSubmit",
 	// "command:/identity", "reminder:system-reminder"). Empty for user-authored

--- a/internal/tool/fs/bash.go
+++ b/internal/tool/fs/bash.go
@@ -143,7 +143,7 @@ func (t *BashTool) ExecuteApproved(ctx context.Context, params map[string]any, c
 func (t *BashTool) foregroundResult(ctx context.Context, description, output, errOutput string, err error, duration time.Duration, timeout time.Duration, trackedFile, cwd string) toolresult.ToolResult {
 	fullOutput := output
 	if errOutput != "" {
-		if fullOutput != "" {
+		if fullOutput != "" && !strings.HasSuffix(fullOutput, "\n") {
 			fullOutput += "\n"
 		}
 		fullOutput += errOutput
@@ -178,11 +178,13 @@ func (t *BashTool) foregroundResult(ctx context.Context, description, output, er
 	if err != nil {
 		// Check if it's a timeout
 		if ctx.Err() == context.DeadlineExceeded {
+			errorMsg := "command timed out after " + timeout.String() +
+				" — if it was waiting for interactive input, re-run with a non-interactive flag (e.g. -y, -m, BatchMode=yes) or supply input inline"
 			return toolresult.ToolResult{
-				Success: false,
-				Output:  fullOutput,
-				Error: "command timed out after " + timeout.String() +
-					" — if it was waiting for interactive input, re-run with a non-interactive flag (e.g. -y, -m, BatchMode=yes) or supply input inline",
+				Success:      false,
+				Output:       fullOutput,
+				Error:        errorMsg,
+				Details:      toolresult.BashDetails{Error: errorMsg, LineCount: lineCount},
 				HookResponse: hookResponse,
 				Metadata: toolresult.ResultMetadata{
 					Title:     t.Name(),
@@ -204,6 +206,7 @@ func (t *BashTool) foregroundResult(ctx context.Context, description, output, er
 			Success:      false,
 			Output:       fullOutput,
 			Error:        errorMsg,
+			Details:      toolresult.BashDetails{Error: errorMsg, LineCount: lineCount},
 			HookResponse: hookResponse,
 			Metadata: toolresult.ResultMetadata{
 				Title:     t.Name(),

--- a/internal/tool/fs/bash_test.go
+++ b/internal/tool/fs/bash_test.go
@@ -11,7 +11,46 @@ import (
 	"time"
 
 	"github.com/genai-io/san/internal/task"
+	"github.com/genai-io/san/internal/tool/toolresult"
 )
+
+func TestBashFailurePreservesStructuredDisplayDetails(t *testing.T) {
+	result := (&BashTool{}).ExecuteApproved(context.Background(), map[string]any{
+		"command": "printf 'line one\\nline two\\n'; printf 'stderr\\n' >&2; exit 7",
+	}, t.TempDir())
+	if result.Success {
+		t.Fatal("ExecuteApproved() succeeded, want exit failure")
+	}
+	if result.Error != "exit code 7" {
+		t.Fatalf("error = %q, want exit code 7", result.Error)
+	}
+	if got := result.FormatForLLM(); got != "line one\nline two\nstderr\n\nError: exit code 7" {
+		t.Fatalf("FormatForLLM() = %q, want stdout and stderr joined without an extra blank output line", got)
+	}
+	details, ok := result.Details.(toolresult.BashDetails)
+	if !ok {
+		t.Fatalf("details = %#v, want BashDetails", result.Details)
+	}
+	if details.Error != "exit code 7" || details.LineCount != 3 {
+		t.Fatalf("details = %#v, want exit code 7 and 3 output lines", details)
+	}
+}
+
+func TestBashFailureWithoutOutputHasZeroDisplayLines(t *testing.T) {
+	result := (&BashTool{}).ExecuteApproved(context.Background(), map[string]any{
+		"command": "exit 3",
+	}, t.TempDir())
+	if result.Success {
+		t.Fatal("ExecuteApproved() succeeded, want exit failure")
+	}
+	details, ok := result.Details.(toolresult.BashDetails)
+	if !ok || details.Error != "exit code 3" || details.LineCount != 0 {
+		t.Fatalf("details = %#v, want exit code 3 and no output lines", result.Details)
+	}
+	if got := result.FormatForLLM(); got != "Error: exit code 3" {
+		t.Fatalf("FormatForLLM() = %q, want unchanged error text", got)
+	}
+}
 
 func TestBashToolTracksChangedDirectory(t *testing.T) {
 	cwd := t.TempDir()

--- a/internal/tool/toolresult/render.go
+++ b/internal/tool/toolresult/render.go
@@ -16,6 +16,14 @@ type FileChangeDetails struct {
 	TruncatedDiffLines int // diff lines dropped by the storage cap (0 = complete)
 }
 
+// BashDetails preserves failure metadata separately from the model-facing text.
+// The UI uses it to show the process error in the summary without counting or
+// repeating the appended "Error: ..." line as command output.
+type BashDetails struct {
+	Error     string `json:"error"`
+	LineCount int    `json:"lineCount"`
+}
+
 // ToolResult represents the result of a tool execution
 type ToolResult struct {
 	Success      bool             // Whether the tool succeeded


### PR DESCRIPTION
Keep multiline Bash commands and output visually connected while making failure summaries concise and accurate.

- Preserve connectors across wrapped and blank command/output lines
- Separate Bash failure metadata from model-facing output and persist it across sessions
- Avoid extra stdout/stderr separator lines and gate the render demo behind an opt-in environment variable