### PR TITLE
fix(tui): serialize native scrollback commits

### DIFF
--- a/internal/app/model_scrollback.go
+++ b/internal/app/model_scrollback.go
@@ -6,19 +6,12 @@ package app
 
 import (
 	"strings"
-	"time"
 
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/genai-io/san/internal/app/conv"
 	"github.com/genai-io/san/internal/core"
 )
-
-// scrollbackPrintDelay gives Bubble Tea one frame to paint a committed block's
-// handoff copy before Println moves it into native scrollback. Keeping the copy
-// visible during this wait avoids the old blank-frame flash; waiting remains
-// necessary so insertAbove sees the same managed frame that is on the terminal.
-const scrollbackPrintDelay = 24 * time.Millisecond
 
 type scrollbackPrintReadyMsg struct {
 	id      uint64
@@ -32,9 +25,8 @@ type pendingScrollbackPrint struct {
 	content string
 }
 
-func waitToPrintScrollback(id uint64, content string) tea.Cmd {
+func printScrollback(id uint64, content string) tea.Cmd {
 	return func() tea.Msg {
-		time.Sleep(scrollbackPrintDelay)
 		return scrollbackPrintReadyMsg{id: id, content: content}
 	}
 }
@@ -81,8 +73,8 @@ type flushState struct {
 	rendering     bool                     // one render in flight at a time, so Printlns stay ordered
 	renderer      *conv.MDRenderer         // background renderer, off the live-view MDRenderer's mutex
 	width         int                      // width the renderer was built for; rebuild when it changes
-	nextPrintID   uint64                   // monotonic identity for scrollback handoffs
-	pendingPrints []pendingScrollbackPrint // visible until their Println has been processed
+	nextPrintID   uint64                   // monotonic identity for queued scrollback prints
+	pendingPrints []pendingScrollbackPrint // FIFO queue; only the head may be in flight
 }
 
 // flushResultMsg is the result of rendering a flushSnapshot off-thread, carrying
@@ -274,36 +266,37 @@ func (m *model) renderAndCommit(checkReady bool) []tea.Cmd {
 	return []tea.Cmd{m.queueScrollbackPrint(strings.Join(parts, "\n"))}
 }
 
-// queueScrollbackPrint keeps content in the managed view while Bubble Tea
-// prepares to insert the same content into native scrollback. The matching
-// done message removes this handoff copy only after Println has been processed,
-// so there is never a frame where the committed block is absent from both.
+// queueScrollbackPrint appends content to a single-flight FIFO. Only an empty
+// queue starts a print; finishScrollbackPrint starts the next item after Bubble
+// Tea has processed the current Println. Committed content never returns to the
+// managed View, so the renderer barrier cannot scroll a handoff copy, footer, or
+// later live content into native history.
 func (m *model) queueScrollbackPrint(content string) tea.Cmd {
 	m.flush.nextPrintID++
-	id := m.flush.nextPrintID
-	m.flush.pendingPrints = append(m.flush.pendingPrints, pendingScrollbackPrint{
-		id:      id,
+	pending := pendingScrollbackPrint{
+		id:      m.flush.nextPrintID,
 		content: content,
-	})
-	return waitToPrintScrollback(id, content)
+	}
+	m.flush.pendingPrints = append(m.flush.pendingPrints, pending)
+	if len(m.flush.pendingPrints) > 1 {
+		return nil
+	}
+	return printScrollback(pending.id, pending.content)
 }
 
-func (m *model) finishScrollbackPrint(id uint64) {
-	for i := range m.flush.pendingPrints {
-		if m.flush.pendingPrints[i].id != id {
-			continue
-		}
-		m.flush.pendingPrints = append(m.flush.pendingPrints[:i], m.flush.pendingPrints[i+1:]...)
-		return
+// finishScrollbackPrint completes only the in-flight queue head. A stale or
+// out-of-order done message is ignored; the next print cannot start until the
+// head's Println has been processed.
+func (m *model) finishScrollbackPrint(id uint64) tea.Cmd {
+	if len(m.flush.pendingPrints) == 0 || m.flush.pendingPrints[0].id != id {
+		return nil
 	}
-}
-
-func (m model) pendingScrollbackView() string {
-	parts := make([]string, 0, len(m.flush.pendingPrints))
-	for _, pending := range m.flush.pendingPrints {
-		parts = append(parts, pending.content)
+	m.flush.pendingPrints = m.flush.pendingPrints[1:]
+	if len(m.flush.pendingPrints) == 0 {
+		return nil
 	}
-	return strings.Join(parts, "\n")
+	next := m.flush.pendingPrints[0]
+	return printScrollback(next.id, next.content)
 }
 
 // takeWelcomeBanner freezes the startup splash into scrollback once, on the

--- a/internal/app/model_scrollback_test.go
+++ b/internal/app/model_scrollback_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/genai-io/san/internal/app/conv"
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/subagent"
+	"github.com/genai-io/san/internal/todo"
+	"github.com/genai-io/san/internal/tool/toolresult"
 )
 
 func flushTestModel(msg core.ChatMessage) *model {
@@ -98,55 +101,136 @@ func TestFlushStreamingBlocksCommitsThinkingParagraph(t *testing.T) {
 	if m.flush.rendering {
 		t.Fatal("flush.rendering should clear once the render has landed")
 	}
-	if got := m.pendingScrollbackView(); !strings.Contains(got, "first paragraph of reasoning") {
-		t.Fatalf("pending scrollback handoff = %q, want committed block to remain visible", got)
+	if len(m.flush.pendingPrints) != 1 || !strings.Contains(m.flush.pendingPrints[0].content, "first paragraph of reasoning") {
+		t.Fatalf("scrollback queue = %#v, want the committed block queued once", m.flush.pendingPrints)
 	}
 }
 
-func TestScrollbackHandoffStaysVisibleUntilPrintDone(t *testing.T) {
+func TestScrollbackPrintQueueIsSingleFlightFIFO(t *testing.T) {
 	m := flushTestModel(core.ChatMessage{})
-	cmd := m.queueScrollbackPrint("rendered block")
-
-	if got := m.pendingScrollbackView(); got != "rendered block" {
-		t.Fatalf("pendingScrollbackView() = %q, want %q", got, "rendered block")
+	firstCmd := m.queueScrollbackPrint("A")
+	if firstCmd == nil {
+		t.Fatal("the first queued print must start immediately")
+	}
+	if secondCmd := m.queueScrollbackPrint("B"); secondCmd != nil {
+		t.Fatal("a second print must wait until the in-flight head completes")
 	}
 
-	ready, ok := cmd().(scrollbackPrintReadyMsg)
-	if !ok {
-		t.Fatalf("scrollback handoff command returned an unexpected message")
+	first := firstCmd().(scrollbackPrintReadyMsg)
+	if first.content != "A" {
+		t.Fatalf("first print content = %q, want A", first.content)
 	}
-	if got := m.pendingScrollbackView(); got == "" {
-		t.Fatal("handoff disappeared before Println was processed")
+	if next := m.finishScrollbackPrint(first.id + 1); next != nil {
+		t.Fatal("an out-of-order done message must not advance the queue")
+	}
+	if len(m.flush.pendingPrints) != 2 {
+		t.Fatalf("out-of-order done changed queue length to %d, want 2", len(m.flush.pendingPrints))
 	}
 
-	m.finishScrollbackPrint(ready.id)
-	if got := m.pendingScrollbackView(); got != "" {
-		t.Fatalf("pendingScrollbackView() after done = %q, want empty", got)
+	secondCmd := m.finishScrollbackPrint(first.id)
+	if secondCmd == nil {
+		t.Fatal("finishing the queue head must start the next print")
+	}
+	second := secondCmd().(scrollbackPrintReadyMsg)
+	if second.content != "B" {
+		t.Fatalf("second print content = %q, want B", second.content)
+	}
+	if next := m.finishScrollbackPrint(second.id); next != nil {
+		t.Fatal("finishing the final print must leave no command")
+	}
+	if len(m.flush.pendingPrints) != 0 {
+		t.Fatalf("finished queue length = %d, want 0", len(m.flush.pendingPrints))
 	}
 }
 
-func TestScrollbackHandoffsStayOrderedAcrossPrints(t *testing.T) {
-	m := flushTestModel(core.ChatMessage{})
-	m.queueScrollbackPrint("A")
-	m.queueScrollbackPrint("B")
-
-	// Monotonic ids keep the two in-flight handoffs in queue order in the view,
-	// mirroring the scrollback order their Printlns will land in.
-	if got := m.pendingScrollbackView(); got != "A\nB" {
-		t.Fatalf("pendingScrollbackView() = %q, want %q", got, "A\nB")
+func TestConsecutiveToolCommitsStayOutOfManagedFrameAndPrintOnceInOrder(t *testing.T) {
+	m := &model{
+		env:  env{Width: 100, Height: 24, Ready: true},
+		conv: conv.NewModel(100),
+		services: services{
+			Subagent: subagent.NewRegistry(),
+			Tracker:  todo.NewStore(),
+		},
 	}
 
-	first, second := m.flush.pendingPrints[0].id, m.flush.pendingPrints[1].id
-
-	// Finishing the first handoff leaves the second visible and in place.
-	m.finishScrollbackPrint(first)
-	if got := m.pendingScrollbackView(); got != "B" {
-		t.Fatalf("after finishing the first print, pendingScrollbackView() = %q, want %q", got, "B")
+	bashCall := core.ToolCall{ID: "bash-1", Name: "Bash", Input: `{"command":"git status"}`}
+	m.conv.Messages = append(m.conv.Messages,
+		core.ChatMessage{Role: core.RoleAssistant, ToolCalls: []core.ToolCall{bashCall}},
+		core.ChatMessage{Role: core.RoleUser, Expanded: true, ToolResult: &core.ToolResult{
+			ToolCallID: bashCall.ID,
+			ToolName:   "Bash",
+			Content:    "BASH_RESULT_SENTINEL",
+		}},
+	)
+	firstCmds := m.CommitMessages()
+	if len(firstCmds) != 1 || firstCmds[0] == nil {
+		t.Fatalf("first commit commands = %#v, want one active print", firstCmds)
 	}
 
-	m.finishScrollbackPrint(second)
-	if got := m.pendingScrollbackView(); got != "" {
-		t.Fatalf("after finishing both prints, pendingScrollbackView() = %q, want empty", got)
+	editCall := core.ToolCall{ID: "edit-1", Name: "Edit", Input: `{"file_path":"main.go","old_string":"old","new_string":"EDIT_RESULT_SENTINEL"}`}
+	m.conv.Messages = append(m.conv.Messages,
+		core.ChatMessage{Role: core.RoleAssistant, ToolCalls: []core.ToolCall{editCall}},
+		core.ChatMessage{Role: core.RoleUser, ToolResult: &core.ToolResult{
+			ToolCallID: editCall.ID,
+			ToolName:   "Edit",
+			Content:    "Edited main.go",
+			Details: toolresult.FileChangeDetails{
+				Path:         "main.go",
+				EditCount:    1,
+				AddedLines:   1,
+				RemovedLines: 1,
+				UnifiedDiff:  "@@ -1 +1 @@\n-old\n+EDIT_RESULT_SENTINEL",
+			},
+		}},
+	)
+	secondCmds := m.CommitMessages()
+	if len(secondCmds) != 1 || secondCmds[0] != nil {
+		t.Fatalf("second commit commands = %#v, want one queued nil command", secondCmds)
+	}
+	if len(m.flush.pendingPrints) != 2 {
+		t.Fatalf("queued prints = %d, want 2", len(m.flush.pendingPrints))
+	}
+
+	// A live repaint may contain later tool activity, blank fill, input, and the
+	// footer, but never either committed result. The renderer barrier can safely
+	// flush this frame before insertAbove because no handoff copy is present.
+	liveFrame := "LIVE_EDIT_ACTIVITY\n" + strings.Repeat("\n", 12) + "INPUT_SENTINEL\nFOOTER_SENTINEL"
+	managed := m.renderChatSection(liveFrame, "")
+	for _, committed := range []string{"BASH_RESULT_SENTINEL", "EDIT_RESULT_SENTINEL"} {
+		if strings.Contains(managed, committed) {
+			t.Fatalf("managed frame contains committed result %q: %q", committed, managed)
+		}
+	}
+	for _, live := range []string{"INPUT_SENTINEL", "FOOTER_SENTINEL"} {
+		if !strings.Contains(managed, live) {
+			t.Fatalf("managed frame should retain live marker %q: %q", live, managed)
+		}
+	}
+
+	first := firstCmds[0]().(scrollbackPrintReadyMsg)
+	secondCmd := m.finishScrollbackPrint(first.id)
+	if secondCmd == nil {
+		t.Fatal("finishing Bash must start the queued Edit print")
+	}
+	second := secondCmd().(scrollbackPrintReadyMsg)
+	m.finishScrollbackPrint(second.id)
+
+	nativePayloads := first.content + "\n" + second.content
+	for _, result := range []string{"BASH_RESULT_SENTINEL", "EDIT_RESULT_SENTINEL"} {
+		if count := strings.Count(nativePayloads, result); count != 1 {
+			t.Fatalf("native payload count for %q = %d, want 1: %q", result, count, nativePayloads)
+		}
+	}
+	if strings.Index(nativePayloads, "BASH_RESULT_SENTINEL") > strings.Index(nativePayloads, "EDIT_RESULT_SENTINEL") {
+		t.Fatalf("native payload order is not Bash then Edit: %q", nativePayloads)
+	}
+	for _, live := range []string{"LIVE_EDIT_ACTIVITY", "INPUT_SENTINEL", "FOOTER_SENTINEL"} {
+		if strings.Contains(nativePayloads, live) {
+			t.Fatalf("native payload contains live-frame marker %q: %q", live, nativePayloads)
+		}
+	}
+	if strings.Contains(nativePayloads, strings.Repeat("\n", 8)) {
+		t.Fatalf("native payload contains live blank repaint space: %q", nativePayloads)
 	}
 }
 

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -272,15 +272,15 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case flushResultMsg:
 		return m, m.handleFlushResult(msg)
 	case scrollbackPrintReadyMsg:
-		// Keep the handoff copy visible while Println is inserted. Sequence
-		// guarantees the done message cannot clear it before insertAbove runs.
+		// Bubble Tea's renderer barrier flushes the latest managed View before
+		// insertAbove. The View contains no queued scrollback copies, so only this
+		// payload enters native history. Sequence ensures done follows Println.
 		return m, tea.Sequence(
 			tea.Println(msg.content),
 			func() tea.Msg { return scrollbackPrintDoneMsg{id: msg.id} },
 		)
 	case scrollbackPrintDoneMsg:
-		m.finishScrollbackPrint(msg.id)
-		return m, nil
+		return m, m.finishScrollbackPrint(msg.id)
 	case conv.QuestionResponseMsg:
 		return m, m.handleQuestionResponse(msg)
 	case input.SecretPromptResponseMsg:

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -179,10 +179,6 @@ func (m model) renderInputView() string {
 func (m model) renderChatSection(activeContent, trackerView string) string {
 	var parts []string
 
-	if pending := m.pendingScrollbackView(); pending != "" {
-		parts = append(parts, pending)
-	}
-
 	if banner := m.liveWelcome(); banner != "" {
 		// Trailing blank line so the splash isn't cramped against the
 		// separator/input strip below it — matching the blank line it gets


### PR DESCRIPTION
Remove the live-frame scrollback handoff that conflicted with the renderer barrier and serialize native commits.

- keep committed blocks out of the managed frame
- print queued blocks through a single-flight FIFO
- cover consecutive Bash and Edit commits without duplicate results or footer contamination