### PR TITLE
feat(llm): add user-defined OpenAI/Claude-compatible custom provider

### DIFF
--- a/cmd/san/main.go
+++ b/cmd/san/main.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/genai-io/san/internal/llm/alibaba"
 	_ "github.com/genai-io/san/internal/llm/anthropic"
 	_ "github.com/genai-io/san/internal/llm/bigmodel"
+	_ "github.com/genai-io/san/internal/llm/custom"
 	_ "github.com/genai-io/san/internal/llm/deepseek"
 	_ "github.com/genai-io/san/internal/llm/google"
 	_ "github.com/genai-io/san/internal/llm/mimo"

--- a/internal/app/input/on_provider.go
+++ b/internal/app/input/on_provider.go
@@ -122,6 +122,12 @@ type ProviderSelector struct {
 	apiKeyProviderIdx int // index into allProviders
 	apiKeyAuthIdx     int // index into that provider's AuthMethods
 
+	// Inline custom provider form (baseURL / apiKey); see on_provider_custom.go
+	customFormActive bool
+	customFormInputs [2]textinput.Model
+	customFormFocus  int
+	customFormErr    string
+
 	// Inline confirm-remove prompt
 	confirmRemoveActive  bool
 	confirmRemoveEnvVar  string

--- a/internal/app/input/on_provider_auth.go
+++ b/internal/app/input/on_provider_auth.go
@@ -20,6 +20,16 @@ import (
 
 // HandlePaste inserts bracketed-paste content into the API key input when it's active.
 func (s *ProviderSelector) HandlePaste(content string) tea.Cmd {
+	if s.customFormActive {
+		content = strings.NewReplacer("\r", "", "\n", "").Replace(content)
+		content = strings.TrimSpace(content)
+		if content == "" {
+			return nil
+		}
+		s.customFormInputs[s.customFormFocus].SetValue(content)
+		s.customFormInputs[s.customFormFocus].CursorEnd()
+		return nil
+	}
 	if !s.apiKeyActive {
 		return nil
 	}
@@ -93,6 +103,12 @@ func (s *ProviderSelector) handleCredentialEditForProvider(item providerListItem
 		return nil
 	}
 	p := item.Provider
+
+	// The custom provider edits all three fields (ID / baseURL / apiKey) in its form.
+	if s.isCustomProvider(p.Provider) {
+		s.openCustomForm()
+		return nil
+	}
 
 	// Single auth method: activate API key input directly
 	if len(p.AuthMethods) == 1 {

--- a/internal/app/input/on_provider_custom.go
+++ b/internal/app/input/on_provider_custom.go
@@ -96,7 +96,7 @@ func (s *ProviderSelector) focusCustomFormField(i int) {
 // validateCustomForm normalizes and validates the two fields. An empty API key
 // means "keep the stored one" and only fails when nothing is stored.
 func (s *ProviderSelector) validateCustomForm() (baseURL, apiKey string, err error) {
-	baseURL = strings.TrimSuffix(strings.TrimSpace(s.customFormInputs[customFormFieldBaseURL].Value()), "/")
+	baseURL = strings.TrimRight(strings.TrimSpace(s.customFormInputs[customFormFieldBaseURL].Value()), "/")
 	if baseURL == "" {
 		return "", "", fmt.Errorf("base URL is required")
 	}

--- a/internal/app/input/on_provider_custom.go
+++ b/internal/app/input/on_provider_custom.go
@@ -1,0 +1,155 @@
+// Provider selector: the custom (third-party, OpenAI-compatible) provider form.
+// Built-in providers only need an API key, so Enter opens the single inline
+// input; the custom provider also needs a baseURL, so it gets a two-field form
+// instead. The provider ID is fixed (custom.DefaultID) — there is only one
+// custom provider, so a user-chosen ID would add rename bookkeeping without
+// distinguishing anything.
+package input
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/llm/custom"
+	"github.com/genai-io/san/internal/secret"
+)
+
+// customFormField indexes customFormInputs.
+const (
+	customFormFieldBaseURL = iota
+	customFormFieldAPIKey
+	customFormFieldCount
+)
+
+// isCustomProvider reports whether name is the custom provider's fixed name.
+func (s *ProviderSelector) isCustomProvider(name llm.Name) bool {
+	return name == llm.Name(custom.DefaultID)
+}
+
+// openCustomForm initializes the inline form, prefilled from the saved config.
+// The API key field starts empty like the built-in edit flow; on submit an
+// empty key keeps the stored one.
+func (s *ProviderSelector) openCustomForm() {
+	baseURL := ""
+	if s.store != nil {
+		if cfg := s.store.CustomProvider(); cfg != nil {
+			baseURL = cfg.BaseURL
+		}
+	}
+
+	urlInput := textinput.New()
+	urlInput.Placeholder = "https://api.example.com/v1"
+	urlInput.SetValue(baseURL)
+	urlInput.CharLimit = 256
+	urlInput.SetWidth(40)
+	urlInput.Focus()
+
+	keyInput := textinput.New()
+	keyInput.Placeholder = custom.APIKeyEnvVar
+	keyInput.CharLimit = 256
+	keyInput.SetWidth(40)
+	keyInput.EchoMode = textinput.EchoPassword
+
+	s.apiKeyActive = false
+	s.customFormInputs = [customFormFieldCount]textinput.Model{urlInput, keyInput}
+	s.customFormFocus = customFormFieldBaseURL
+	s.customFormErr = ""
+	s.customFormActive = true
+}
+
+func (s *ProviderSelector) closeCustomForm() {
+	s.customFormActive = false
+	s.customFormErr = ""
+}
+
+func (s *ProviderSelector) handleCustomFormKey(key tea.KeyMsg) tea.Cmd {
+	switch key.String() {
+	case "esc":
+		s.closeCustomForm()
+		return nil
+	case "tab", "down":
+		s.focusCustomFormField((s.customFormFocus + 1) % customFormFieldCount)
+		return nil
+	case "shift+tab", "up":
+		s.focusCustomFormField((s.customFormFocus + customFormFieldCount - 1) % customFormFieldCount)
+		return nil
+	case "enter":
+		return s.submitCustomForm()
+	default:
+		var cmd tea.Cmd
+		s.customFormInputs[s.customFormFocus], cmd = s.customFormInputs[s.customFormFocus].Update(key)
+		return cmd
+	}
+}
+
+func (s *ProviderSelector) focusCustomFormField(i int) {
+	s.customFormInputs[s.customFormFocus].Blur()
+	s.customFormFocus = i
+	s.customFormInputs[i].Focus()
+}
+
+// validateCustomForm normalizes and validates the two fields. An empty API key
+// means "keep the stored one" and only fails when nothing is stored.
+func (s *ProviderSelector) validateCustomForm() (baseURL, apiKey string, err error) {
+	baseURL = strings.TrimSuffix(strings.TrimSpace(s.customFormInputs[customFormFieldBaseURL].Value()), "/")
+	if baseURL == "" {
+		return "", "", fmt.Errorf("base URL is required")
+	}
+	if !strings.HasPrefix(baseURL, "https://") && !strings.HasPrefix(baseURL, "http://") {
+		return "", "", fmt.Errorf("base URL must start with https:// or http://")
+	}
+
+	apiKey = strings.TrimSpace(s.customFormInputs[customFormFieldAPIKey].Value())
+	if apiKey == "" && secret.Resolve(custom.APIKeyEnvVar) == "" {
+		return "", "", fmt.Errorf("API key is required")
+	}
+	return baseURL, apiKey, nil
+}
+
+// submitCustomForm persists the form (baseURL to the llm store, API key to the
+// secret store), then connects: a successful connect fetches the model list
+// into the Models tab.
+func (s *ProviderSelector) submitCustomForm() tea.Cmd {
+	baseURL, apiKey, err := s.validateCustomForm()
+	if err != nil {
+		s.customFormErr = err.Error()
+		return nil
+	}
+
+	if apiKey != "" {
+		if store := secret.Default(); store != nil {
+			_ = store.Set(custom.APIKeyEnvVar, apiKey)
+		}
+		os.Setenv(custom.APIKeyEnvVar, apiKey)
+	}
+
+	if err := s.store.SetCustomProvider(llm.CustomProviderConfig{ID: custom.DefaultID, BaseURL: baseURL}); err != nil {
+		s.customFormErr = err.Error()
+		return nil
+	}
+	s.closeCustomForm()
+
+	// Rebuild from the store so the Providers tab reflects the update, then
+	// point the selection at the custom row so the connect result renders there.
+	_, _ = s.loadProviderData()
+	s.rebuildVisibleItems()
+	for i := range s.allProviders {
+		p := &s.allProviders[i]
+		if p.Provider != llm.Name(custom.DefaultID) || len(p.AuthMethods) != 1 {
+			continue
+		}
+		for vi, item := range s.visibleItems {
+			if item.Kind == providerItemProvider && item.ProviderIdx == i {
+				s.selectedIdx = vi
+				break
+			}
+		}
+		return s.connectAuthMethod(p.AuthMethods[0], s.selectedIdx)
+	}
+	return nil
+}

--- a/internal/app/input/on_provider_custom_test.go
+++ b/internal/app/input/on_provider_custom_test.go
@@ -1,0 +1,270 @@
+package input
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/llm/custom"
+)
+
+// customModelsServer serves an OpenAI-compatible GET /models endpoint.
+func customModelsServer(t *testing.T, ids ...string) *httptest.Server {
+	t.Helper()
+	var data strings.Builder
+	for i, id := range ids {
+		if i > 0 {
+			data.WriteString(",")
+		}
+		data.WriteString(`{"id":"` + id + `","object":"model"}`)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[` + data.String() + `]}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestOpenCustomFormPrefillsSavedConfig(t *testing.T) {
+	store := newProviderTestStore(t)
+	if err := store.SetCustomProvider(llm.CustomProviderConfig{ID: custom.DefaultID, BaseURL: "https://api.example.com/v1"}); err != nil {
+		t.Fatalf("SetCustomProvider() error = %v", err)
+	}
+
+	m := NewProviderSelector()
+	m.store = store
+	m.openCustomForm()
+
+	if !m.customFormActive {
+		t.Fatal("openCustomForm should activate the form")
+	}
+	if got := m.customFormInputs[customFormFieldBaseURL].Value(); got != "https://api.example.com/v1" {
+		t.Fatalf("baseURL field = %q", got)
+	}
+	if got := m.customFormInputs[customFormFieldAPIKey].Value(); got != "" {
+		t.Fatalf("apiKey field should start empty, got %q", got)
+	}
+	if !m.isCustomProvider(custom.DefaultID) {
+		t.Fatal("isCustomProvider should recognize the fixed ID")
+	}
+}
+
+func TestValidateCustomForm(t *testing.T) {
+	isolateSecretStore(t)
+	t.Setenv(custom.APIKeyEnvVar, "")
+
+	tests := []struct {
+		name    string
+		baseURL string
+		apiKey  string
+		wantErr string
+	}{
+		{name: "missing baseURL", baseURL: "", apiKey: "k", wantErr: "base URL is required"},
+		{name: "baseURL without scheme", baseURL: "api.x.com", apiKey: "k", wantErr: "https://"},
+		{name: "missing api key", baseURL: "https://x.com", apiKey: "", wantErr: "API key is required"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewProviderSelector()
+			m.store, _ = llm.NewStore()
+			m.openCustomForm()
+			m.customFormInputs[customFormFieldBaseURL].SetValue(tt.baseURL)
+			m.customFormInputs[customFormFieldAPIKey].SetValue(tt.apiKey)
+
+			_, _, err := m.validateCustomForm()
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("validateCustomForm() error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateCustomFormKeepsStoredAPIKey(t *testing.T) {
+	isolateSecretStore(t)
+	t.Setenv(custom.APIKeyEnvVar, "stored-key")
+
+	m := NewProviderSelector()
+	m.store, _ = llm.NewStore()
+	m.openCustomForm()
+	m.customFormInputs[customFormFieldBaseURL].SetValue("https://api.example.com/v1/")
+
+	baseURL, apiKey, err := m.validateCustomForm()
+	if err != nil {
+		t.Fatalf("validateCustomForm() error = %v", err)
+	}
+	if apiKey != "" {
+		t.Fatalf("empty key field should mean keep-stored, got %q", apiKey)
+	}
+	if baseURL != "https://api.example.com/v1" {
+		t.Fatalf("trailing slash should be trimmed, got %q", baseURL)
+	}
+}
+
+func TestSubmitCustomFormSavesAndConnects(t *testing.T) {
+	isolateSecretStore(t)
+	t.Setenv(custom.APIKeyEnvVar, "")
+	t.Cleanup(func() { _ = os.Unsetenv(custom.APIKeyEnvVar) })
+
+	srv := customModelsServer(t, "model-1")
+	store, err := llm.NewStore()
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	m := NewProviderSelector()
+	m.active = true
+	m.activeTab = providerTabProviders
+	m.store = store
+	m.openCustomForm()
+	m.customFormInputs[customFormFieldBaseURL].SetValue(srv.URL)
+	m.customFormInputs[customFormFieldAPIKey].SetValue("sk-test")
+
+	cmd := m.submitCustomForm()
+	if cmd == nil {
+		t.Fatal("submitCustomForm should trigger a connect")
+	}
+	if m.customFormActive {
+		t.Fatal("form should close after a successful submit")
+	}
+
+	msg, ok := connectResultFromCmd(cmd)
+	if !ok {
+		t.Fatal("expected a providerConnectResultMsg")
+	}
+	if !msg.Success {
+		t.Fatalf("connect failed: %s", msg.Message)
+	}
+
+	cfg := m.store.CustomProvider()
+	if cfg == nil || cfg.BaseURL != srv.URL {
+		t.Fatalf("custom provider config not saved: %+v", cfg)
+	}
+	if !m.store.IsConnected(llm.Name(custom.DefaultID), llm.AuthAPIKey) {
+		t.Fatal("provider should be connected after submit")
+	}
+	if models, ok := m.store.GetCachedModels(llm.Name(custom.DefaultID), llm.AuthAPIKey); !ok || len(models) != 1 || models[0].ID != "model-1" {
+		t.Fatalf("models should be cached after connect: %+v", models)
+	}
+	if got := os.Getenv(custom.APIKeyEnvVar); got != "sk-test" {
+		t.Fatalf("api key env = %q, want sk-test", got)
+	}
+}
+
+func TestSubmitCustomFormConnectFailureKeepsConfig(t *testing.T) {
+	isolateSecretStore(t)
+	t.Setenv(custom.APIKeyEnvVar, "")
+	t.Cleanup(func() { _ = os.Unsetenv(custom.APIKeyEnvVar) })
+
+	// Point at a closed port so the connect fails.
+	store, err := llm.NewStore()
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	m := NewProviderSelector()
+	m.active = true
+	m.activeTab = providerTabProviders
+	m.store = store
+	m.openCustomForm()
+	m.customFormInputs[customFormFieldBaseURL].SetValue("http://127.0.0.1:1")
+	m.customFormInputs[customFormFieldAPIKey].SetValue("sk-test")
+
+	cmd := m.submitCustomForm()
+	if cmd == nil {
+		t.Fatal("submitCustomForm should trigger a connect even when it will fail")
+	}
+	if m.customFormActive {
+		t.Fatal("form should close after submit regardless of connect outcome")
+	}
+
+	msg, ok := connectResultFromCmd(cmd)
+	if !ok {
+		t.Fatal("expected a providerConnectResultMsg")
+	}
+	if msg.Success {
+		t.Fatal("connect to a closed port should fail")
+	}
+
+	// The config is saved so the user can Ctrl+E to fix the key or URL; the
+	// connection is not.
+	if cfg := m.store.CustomProvider(); cfg == nil || cfg.BaseURL != "http://127.0.0.1:1" {
+		t.Fatalf("config should be saved despite connect failure: %+v", cfg)
+	}
+	if m.store.IsConnected(llm.Name(custom.DefaultID), llm.AuthAPIKey) {
+		t.Fatal("failed connect must not mark the provider connected")
+	}
+}
+
+func TestSelectProviderOpensCustomForm(t *testing.T) {
+	store := newProviderTestStore(t)
+
+	m := NewProviderSelector()
+	m.active = true
+	m.activeTab = providerTabProviders
+	m.store = store
+	m.allProviders = []providerProviderItem{{
+		Provider:    llm.Name(custom.DefaultID),
+		DisplayName: "Custom",
+		AuthMethods: []providerAuthMethodItem{{
+			Provider:    llm.Name(custom.DefaultID),
+			AuthMethod:  llm.AuthAPIKey,
+			DisplayName: "Direct API",
+			Status:      llm.StatusNotConfigured,
+			EnvVars:     []string{custom.APIKeyEnvVar},
+		}},
+	}}
+	m.rebuildVisibleItems()
+	m.selectedIdx = 0
+
+	if cmd := m.selectProvider(m.visibleItems[0]); cmd != nil {
+		t.Fatal("opening the form should not return a command")
+	}
+	if !m.customFormActive {
+		t.Fatal("Enter on the custom provider should open the form")
+	}
+	if m.apiKeyActive {
+		t.Fatal("custom provider should not open the single API-key input")
+	}
+}
+
+func TestCustomFormKeyRouting(t *testing.T) {
+	m := NewProviderSelector()
+	m.store = newProviderTestStore(t)
+	m.openCustomForm()
+
+	// Tab cycles focus through the two fields.
+	m.handleCustomFormKey(tea.KeyPressMsg{Code: tea.KeyTab})
+	if m.customFormFocus != customFormFieldAPIKey {
+		t.Fatalf("focus after Tab = %d, want apiKey field", m.customFormFocus)
+	}
+	m.handleCustomFormKey(tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift})
+	if m.customFormFocus != customFormFieldBaseURL {
+		t.Fatalf("focus after Shift+Tab = %d, want baseURL field", m.customFormFocus)
+	}
+
+	// Esc closes the form without submitting.
+	m.handleCustomFormKey(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if m.customFormActive {
+		t.Fatal("Esc should close the form")
+	}
+}
+
+func TestGoBackClosesCustomForm(t *testing.T) {
+	m := NewProviderSelector()
+	m.store = newProviderTestStore(t)
+	m.openCustomForm()
+
+	if !m.GoBack() {
+		t.Fatal("GoBack should consume the event while the form is open")
+	}
+	if m.customFormActive {
+		t.Fatal("GoBack should close the form")
+	}
+}

--- a/internal/app/input/on_provider_custom_test.go
+++ b/internal/app/input/on_provider_custom_test.go
@@ -93,7 +93,7 @@ func TestValidateCustomFormKeepsStoredAPIKey(t *testing.T) {
 	m := NewProviderSelector()
 	m.store, _ = llm.NewStore()
 	m.openCustomForm()
-	m.customFormInputs[customFormFieldBaseURL].SetValue("https://api.example.com/v1/")
+	m.customFormInputs[customFormFieldBaseURL].SetValue("https://api.example.com/v1//")
 
 	baseURL, apiKey, err := m.validateCustomForm()
 	if err != nil {
@@ -103,7 +103,7 @@ func TestValidateCustomFormKeepsStoredAPIKey(t *testing.T) {
 		t.Fatalf("empty key field should mean keep-stored, got %q", apiKey)
 	}
 	if baseURL != "https://api.example.com/v1" {
-		t.Fatalf("trailing slash should be trimmed, got %q", baseURL)
+		t.Fatalf("all trailing slashes should be trimmed, got %q", baseURL)
 	}
 }
 

--- a/internal/app/input/on_provider_data.go
+++ b/internal/app/input/on_provider_data.go
@@ -22,6 +22,7 @@ func (s *ProviderSelector) Enter(ctx context.Context, width, height int) (tea.Cm
 	s.resetConnectionResult()
 	s.expandedProviderIdx = -1
 	s.apiKeyActive = false
+	s.closeCustomForm()
 	s.active = true
 	s.activeTab = providerTabModels
 	s.width = width
@@ -426,6 +427,7 @@ func (s *ProviderSelector) Cancel() {
 	s.visibleItems = nil
 	s.expandedProviderIdx = -1
 	s.apiKeyActive = false
+	s.closeCustomForm()
 	s.store = nil
 	s.resetNavigation()
 	s.resetModelSearch()

--- a/internal/app/input/on_provider_nav.go
+++ b/internal/app/input/on_provider_nav.go
@@ -54,6 +54,7 @@ func (s *ProviderSelector) switchTab(t providerTab) {
 	s.resetConnectionResult()
 	s.expandedProviderIdx = -1
 	s.apiKeyActive = false
+	s.closeCustomForm()
 	s.rebuildVisibleItems()
 }
 
@@ -61,6 +62,10 @@ func (s *ProviderSelector) NextTab() { s.switchTab((s.activeTab + 1) % 2) }
 func (s *ProviderSelector) PrevTab() { s.switchTab((s.activeTab + 1 + 2) % 2) }
 
 func (s *ProviderSelector) GoBack() bool {
+	if s.customFormActive {
+		s.closeCustomForm()
+		return true
+	}
 	if s.apiKeyActive {
 		s.apiKeyActive = false
 		return true
@@ -104,6 +109,11 @@ func (s *ProviderSelector) appendModelSearch(text string) {
 }
 
 func (s *ProviderSelector) HandleKeypress(key tea.KeyMsg) tea.Cmd {
+	// Route to the custom provider form if active
+	if s.customFormActive {
+		return s.handleCustomFormKey(key)
+	}
+
 	// Route to API key input if active
 	if s.apiKeyActive {
 		return s.handleAPIKeyInput(key)
@@ -303,6 +313,13 @@ func (s *ProviderSelector) selectProvider(item providerListItem) tea.Cmd {
 		return nil
 	}
 	p := item.Provider
+
+	// The custom provider needs ID + baseURL + apiKey, so it gets its own form
+	// instead of the single API-key input. Once connected, Enter refreshes as usual.
+	if len(p.AuthMethods) == 1 && s.isCustomProvider(p.Provider) && p.AuthMethods[0].Status != llm.StatusConnected {
+		s.openCustomForm()
+		return nil
+	}
 
 	if len(p.AuthMethods) == 1 {
 		am := p.AuthMethods[0]

--- a/internal/app/input/on_provider_view.go
+++ b/internal/app/input/on_provider_view.go
@@ -95,6 +95,12 @@ func (s *ProviderSelector) renderItemList(sb *strings.Builder) {
 			sb.WriteString("\n")
 		}
 
+		// Inline custom provider form (render below the relevant item)
+		if s.customFormActive && isSelected {
+			sb.WriteString(s.renderCustomForm())
+			sb.WriteString("\n")
+		}
+
 		// Inline confirm-remove prompt (render below the relevant item)
 		if s.confirmRemoveActive && i == s.confirmRemoveItemIdx {
 			sb.WriteString(s.renderConfirmRemove())
@@ -312,6 +318,29 @@ func (s *ProviderSelector) renderAPIKeyInput() string {
 	return "      " + boxStyle.Render(inputView)
 }
 
+// renderCustomForm renders the custom provider's two-field form (baseURL and
+// apiKey) below its provider row, one labeled input per line, with the
+// validation error underneath when present.
+func (s *ProviderSelector) renderCustomForm() string {
+	labels := [customFormFieldCount]string{"Base URL", "API Key"}
+
+	inputBg := kit.AdaptiveColor{Dark: "#1E293B", Light: "#F1F5F9"}
+	boxStyle := lipgloss.NewStyle().
+		Background(inputBg).
+		Padding(0, 1)
+
+	lines := make([]string, 0, customFormFieldCount+1)
+	for i, input := range s.customFormInputs {
+		label := kit.DimStyle().Render(fmt.Sprintf("%-9s", labels[i]+":"))
+		lines = append(lines, "      "+boxStyle.Render(label+input.View()))
+	}
+	if s.customFormErr != "" {
+		errStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Error)
+		lines = append(lines, "      "+errStyle.Render(s.customFormErr))
+	}
+	return strings.Join(lines, "\n")
+}
+
 func (s *ProviderSelector) renderConfirmRemove() string {
 	warnStyle := lipgloss.NewStyle().
 		Foreground(kit.AdaptiveColor{Dark: "#F87171", Light: "#DC2626"})
@@ -329,6 +358,9 @@ func (s *ProviderSelector) renderConfirmRemove() string {
 // ── Footer hints ────────────────────────────────────────────────────────────
 
 func (s *ProviderSelector) renderHints() string {
+	if s.customFormActive {
+		return kit.DimStyle().Render("Tab/↑/↓ switch field · Enter save & connect · Esc cancel")
+	}
 	if s.apiKeyActive {
 		return kit.DimStyle().Render("Paste API key · Enter confirm · Esc cancel")
 	}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -230,7 +231,15 @@ func resolveProvider(ctx context.Context) (llm.Provider, string, error) {
 	}
 	modelID := resolved.ModelID
 	if modelID == "" {
-		modelID = setting.DefaultModel(resolved.Provider.Name(), string(resolved.AuthMethod))
+		// Provider.Name() carries the "name:auth" form; DefaultModel keys on the
+		// bare provider name.
+		name, _, _ := strings.Cut(resolved.Provider.Name(), ":")
+		modelID = setting.DefaultModel(name, string(resolved.AuthMethod))
+	}
+	if modelID == "" {
+		// Providers without a built-in default model (e.g. a custom provider)
+		// need an explicit selection.
+		return nil, "", fmt.Errorf("no model selected for %s. Run 'san' and use /model to select one", resolved.Provider.Name())
 	}
 	return resolved.Provider, modelID, nil
 }

--- a/internal/llm/custom/custom.go
+++ b/internal/llm/custom/custom.go
@@ -1,0 +1,120 @@
+// Package custom implements a user-defined, OpenAI-compatible provider.
+//
+// Unlike the built-in providers, its baseURL is supplied at runtime through the
+// /model Providers tab and persisted in the llm Store; the API key lives in the
+// secret store under APIKeyEnvVar. The provider ID is fixed (DefaultID) — there
+// is only one custom provider, so a user-chosen ID would add rename bookkeeping
+// without distinguishing anything. Registration is static (init) since the ID
+// never changes; newClient reads the persisted baseURL lazily on connect.
+package custom
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+
+	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/llm/openaicompat"
+	"github.com/genai-io/san/internal/secret"
+)
+
+const (
+	// DefaultID is the custom provider's fixed ID.
+	DefaultID = "custom"
+	// APIKeyEnvVar is the env/secret-store key holding the custom provider's API key.
+	APIKeyEnvVar = "SAN_CUSTOM_API_KEY"
+	// displayOrder places Custom after every built-in provider (max built-in is 130).
+	displayOrder = 140
+)
+
+// meta is the registration metadata for the custom provider.
+var meta = llm.Meta{
+	Provider:    llm.Name(DefaultID),
+	AuthMethod:  llm.AuthAPIKey,
+	EnvVars:     []string{APIKeyEnvVar},
+	DisplayName: "Direct API",
+}
+
+func init() {
+	llm.RegisterProviderDisplay(llm.Name(DefaultID), llm.ProviderDisplay{Name: "Custom", Order: displayOrder})
+	llm.Register(meta, newClient)
+}
+
+// newClient builds a client from the persisted config (baseURL) and the secret
+// store (API key).
+func newClient(_ context.Context) (llm.Provider, error) {
+	store, err := llm.NewStore()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load store: %w", err)
+	}
+	cfg := store.CustomProvider()
+	if cfg == nil || cfg.BaseURL == "" {
+		return nil, fmt.Errorf("custom provider not configured: set a base URL under /model > Providers > Custom")
+	}
+	return &client{
+		api: openai.NewClient(
+			option.WithAPIKey(secret.Resolve(APIKeyEnvVar)),
+			option.WithBaseURL(cfg.BaseURL),
+			option.WithMaxRetries(0),
+		),
+		name: DefaultID + ":" + string(llm.AuthAPIKey),
+	}, nil
+}
+
+// client implements llm.Provider for any OpenAI-compatible endpoint.
+type client struct {
+	api  openai.Client
+	name string
+}
+
+// Name returns the provider name.
+func (c *client) Name() string { return c.name }
+
+// Stream sends a completion request and returns a channel of streaming chunks.
+func (c *client) Stream(ctx context.Context, opts llm.CompletionOptions) <-chan llm.StreamChunk {
+	return openaicompat.StreamChatCompletions(ctx, openaicompat.ChatStreamConfig{
+		Client:           c.api,
+		ProviderName:     c.name,
+		Options:          opts,
+		ConvertAssistant: openaicompat.DefaultAssistantMessage,
+		// Compatible platforms commonly pass reasoning_content through from the
+		// upstream model; extracting it is a no-op when absent.
+		ExtractReasoning: true,
+	})
+}
+
+// ListModels returns the models exposed by the endpoint's GET /models.
+func (c *client) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
+	page, err := c.api.Models.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	models := make([]llm.ModelInfo, 0, len(page.Data))
+	for _, m := range page.Data {
+		info := llm.ModelInfo{ID: m.ID, Name: m.ID, DisplayName: m.ID}
+		// OpenAI-compatible platforms expose a context window in the raw model
+		// object; pull it into InputTokenLimit so the picker hides the
+		// no-context-window warning when the platform reports one.
+		if raw := m.RawJSON(); raw != "" {
+			var extra struct {
+				ContextLength    int `json:"context_length"`
+				MaxContextLength int `json:"max_context_length"`
+				ContextWindow    int `json:"context_window"`
+			}
+			if json.Unmarshal([]byte(raw), &extra) == nil {
+				info.InputTokenLimit = max(extra.ContextLength, extra.MaxContextLength, extra.ContextWindow)
+			}
+		}
+		models = append(models, info)
+	}
+	if len(models) == 0 {
+		return nil, fmt.Errorf("endpoint returned no models")
+	}
+	return models, nil
+}
+
+// Ensure client implements Provider.
+var _ llm.Provider = (*client)(nil)

--- a/internal/llm/custom/custom_test.go
+++ b/internal/llm/custom/custom_test.go
@@ -1,0 +1,140 @@
+package custom
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/genai-io/san/internal/llm"
+)
+
+func newTestStore(t *testing.T) *llm.Store {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	store, err := llm.NewStore()
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	return store
+}
+
+// modelsServer serves an OpenAI-compatible GET /models endpoint returning the
+// given model IDs.
+func modelsServer(t *testing.T, ids ...string) *httptest.Server {
+	t.Helper()
+	var data strings.Builder
+	for i, id := range ids {
+		if i > 0 {
+			data.WriteString(",")
+		}
+		data.WriteString(`{"id":"` + id + `","object":"model"}`)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[` + data.String() + `]}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestRegisteredUnderFixedID(t *testing.T) {
+	if !llm.IsProvider(llm.Name(DefaultID)) {
+		t.Fatal("custom provider should be registered under the fixed ID at init")
+	}
+	if llm.ProviderDisplayName(llm.Name(DefaultID)) != "Custom" {
+		t.Fatalf("display name = %q, want Custom", llm.ProviderDisplayName(llm.Name(DefaultID)))
+	}
+}
+
+func TestNewClientFailsWithoutConfig(t *testing.T) {
+	newTestStore(t) // empty store: no custom provider config
+
+	_, err := llm.GetProvider(context.Background(), llm.Name(DefaultID), llm.AuthAPIKey)
+	if err == nil || !strings.Contains(err.Error(), "not configured") {
+		t.Fatalf("expected not-configured error, got %v", err)
+	}
+}
+
+func TestListModelsViaEndpoint(t *testing.T) {
+	store := newTestStore(t)
+	srv := modelsServer(t, "model-a", "model-b")
+	if err := store.SetCustomProvider(llm.CustomProviderConfig{ID: DefaultID, BaseURL: srv.URL}); err != nil {
+		t.Fatalf("SetCustomProvider() error = %v", err)
+	}
+	t.Setenv(APIKeyEnvVar, "test-key")
+
+	p, err := llm.GetProvider(context.Background(), llm.Name(DefaultID), llm.AuthAPIKey)
+	if err != nil {
+		t.Fatalf("GetProvider() error = %v", err)
+	}
+	if p.Name() != DefaultID+":"+string(llm.AuthAPIKey) {
+		t.Fatalf("Name() = %q", p.Name())
+	}
+
+	models, err := p.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+	if len(models) != 2 || models[0].ID != "model-a" || models[1].ID != "model-b" {
+		t.Fatalf("unexpected models: %+v", models)
+	}
+}
+
+func TestListModelsParsesContextLength(t *testing.T) {
+	store := newTestStore(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[
+			{"id":"with-ctx","object":"model","context_length":131072},
+			{"id":"with-max","object":"model","max_context_length":65536},
+			{"id":"no-ctx","object":"model"}
+		]}`))
+	}))
+	t.Cleanup(srv.Close)
+	if err := store.SetCustomProvider(llm.CustomProviderConfig{ID: DefaultID, BaseURL: srv.URL}); err != nil {
+		t.Fatalf("SetCustomProvider() error = %v", err)
+	}
+	t.Setenv(APIKeyEnvVar, "test-key")
+
+	p, err := llm.GetProvider(context.Background(), llm.Name(DefaultID), llm.AuthAPIKey)
+	if err != nil {
+		t.Fatalf("GetProvider() error = %v", err)
+	}
+	models, err := p.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+	want := map[string]int{"with-ctx": 131072, "with-max": 65536, "no-ctx": 0}
+	got := make(map[string]int, len(models))
+	for _, m := range models {
+		got[m.ID] = m.InputTokenLimit
+	}
+	for id, limit := range want {
+		if got[id] != limit {
+			t.Fatalf("InputTokenLimit for %s = %d, want %d", id, got[id], limit)
+		}
+	}
+}
+
+func TestListModelsEmptyEndpointFails(t *testing.T) {
+	store := newTestStore(t)
+	srv := modelsServer(t)
+	if err := store.SetCustomProvider(llm.CustomProviderConfig{ID: DefaultID, BaseURL: srv.URL}); err != nil {
+		t.Fatalf("SetCustomProvider() error = %v", err)
+	}
+	t.Setenv(APIKeyEnvVar, "test-key")
+
+	p, err := llm.GetProvider(context.Background(), llm.Name(DefaultID), llm.AuthAPIKey)
+	if err != nil {
+		t.Fatalf("GetProvider() error = %v", err)
+	}
+	if _, err := p.ListModels(context.Background()); err == nil || !strings.Contains(err.Error(), "no models") {
+		t.Fatalf("expected no-models error, got %v", err)
+	}
+}

--- a/internal/llm/store.go
+++ b/internal/llm/store.go
@@ -44,6 +44,14 @@ type tokenLimitOverride struct {
 	OutputTokenLimit int `json:"outputTokenLimit"`
 }
 
+// CustomProviderConfig stores the user-defined OpenAI-compatible provider added
+// via the /model Providers tab. The API key is not kept here — it lives in the
+// secret store under the provider's env var.
+type CustomProviderConfig struct {
+	ID      string `json:"id"`
+	BaseURL string `json:"baseURL"`
+}
+
 // storeData is the persisted data structure
 type storeData struct {
 	Connections     map[string]ConnectionInfo     `json:"connections"`               // key: provider
@@ -52,6 +60,7 @@ type storeData struct {
 	SearchProvider  *string                       `json:"searchProvider,omitempty"`  // search provider name (exa, serper, brave)
 	TokenLimits     map[string]tokenLimitOverride `json:"tokenLimits,omitempty"`     // key: modelID
 	ThinkingEfforts map[string]string             `json:"thinkingEfforts,omitempty"` // key: modelID; value: provider-native effort label
+	CustomProvider  *CustomProviderConfig         `json:"customProvider,omitempty"`  // user-defined OpenAI-compatible provider
 }
 
 // Store manages provider configuration persistence
@@ -538,4 +547,26 @@ func (s *Store) GetTokenLimit(modelID string) (inputLimit, outputLimit int, ok b
 		return 0, 0, false
 	}
 	return override.InputTokenLimit, override.OutputTokenLimit, true
+}
+
+// CustomProvider returns the stored custom provider config, or nil when the
+// user hasn't defined one. Returns a copy so callers can't mutate the store.
+func (s *Store) CustomProvider() *CustomProviderConfig {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.data.CustomProvider == nil {
+		return nil
+	}
+	cfg := *s.data.CustomProvider
+	return &cfg
+}
+
+// SetCustomProvider saves the custom provider config.
+func (s *Store) SetCustomProvider(cfg CustomProviderConfig) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.data.CustomProvider = &cfg
+	return s.save()
 }

--- a/internal/setting/client_options.go
+++ b/internal/setting/client_options.go
@@ -1,5 +1,7 @@
 package setting
 
+import "github.com/genai-io/san/internal/secret"
+
 const (
 	DefaultMaxTokens    = 8192
 	DefaultSystemPrompt = "You are a helpful AI coding assistant."
@@ -31,6 +33,15 @@ func DefaultModel(providerName string, authMethod string) string {
 		return "deepseek-v4-flash"
 	case "sensenova":
 		return "sensenova-6.7-flash-lite"
+	case "ollama":
+		return "llama4"
+	case "mimo":
+		return "xiaomi/mimo-v2.5-pro"
+	case "volcengine":
+		// Volcengine has no static catalog; the user picks the model via
+		// VOLCENGINE_MODEL. Empty means the caller must require an explicit
+		// selection.
+		return secret.Resolve("VOLCENGINE_MODEL")
 	default:
 		// Unknown provider (e.g. a user-defined custom provider) — there is no
 		// sensible default; the caller must require an explicit selection.

--- a/internal/setting/client_options.go
+++ b/internal/setting/client_options.go
@@ -32,6 +32,8 @@ func DefaultModel(providerName string, authMethod string) string {
 	case "sensenova":
 		return "sensenova-6.7-flash-lite"
 	default:
-		return "claude-sonnet-4-20250514"
+		// Unknown provider (e.g. a user-defined custom provider) — there is no
+		// sensible default; the caller must require an explicit selection.
+		return ""
 	}
 }

--- a/internal/setting/client_options_test.go
+++ b/internal/setting/client_options_test.go
@@ -1,0 +1,31 @@
+package setting
+
+import "testing"
+
+func TestDefaultModel(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		auth     string
+		envModel string // VOLCENGINE_MODEL, only relevant for volcengine
+		want     string
+	}{
+		{name: "anthropic vertex", provider: "anthropic", auth: "vertex", want: "claude-sonnet-4-5@20250929"},
+		{name: "anthropic", provider: "anthropic", want: "claude-sonnet-4-20250514"},
+		{name: "openai", provider: "openai", want: "gpt-4o"},
+		{name: "ollama", provider: "ollama", want: "llama4"},
+		{name: "mimo", provider: "mimo", want: "xiaomi/mimo-v2.5-pro"},
+		{name: "volcengine from env", provider: "volcengine", envModel: "doubao-pro-256k", want: "doubao-pro-256k"},
+		{name: "volcengine without env", provider: "volcengine", want: ""},
+		{name: "unknown provider", provider: "custom", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("VOLCENGINE_MODEL", tt.envModel)
+			if got := DefaultModel(tt.provider, tt.auth); got != tt.want {
+				t.Fatalf("DefaultModel(%q, %q) = %q, want %q", tt.provider, tt.auth, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a "Custom" provider for any OpenAI-compatible endpoint, configured in-place from the /model Providers tab via a two-field form (base URL + API key) rather than the single API-key input built-in providers use.

Supported cases:
1. Using a token-billing platform API (e.g. an OpenAI-compatible gateway).
2. Using a self-deployed LLM (e.g. vLLM, LocalAI, or any OpenAI-compatible server).

- internal/llm/custom: new provider with fixed ID "custom"; baseURL read lazily from the store on connect, API key from the secret store under SAN_CUSTOM_API_KEY. ListModels pulls context_length variants into InputTokenLimit.
- internal/llm/store: persist CustomProviderConfig (ID + baseURL) and expose CustomProvider / SetCustomProvider.
- internal/app/input: inline form (on_provider_custom.go) with Tab/arrow field switching, paste support, validation, and a connect flow that refreshes the Providers tab; routed through nav, view, auth, and data lifecycle hooks.
- internal/app/run: DefaultModel now keys on the bare provider name (provider names carry name:auth) and requires an explicit selection when no default applies (e.g. the custom provider).

<!-- Thanks for contributing! Keep this concise. -->

## What & why

<!-- What does this change and what problem does it solve? -->

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] Other:

## Testing

<!-- How did you verify this? Commands run, cases covered. -->

```bash
GOCACHE=/private/tmp/san-go-build-cache go test ./...
```

## Checklist

- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, …)
- [ ] All commits signed off (`git commit -s`) — certifies the [DCO](https://developercertificate.org)
- [ ] Tests pass locally
- [ ] Docs updated (if behavior or config changed)
- [ ] Read and follow the [Code of Conduct](CODE_OF_CONDUCT.md)
