### PR TITLE
fix(llm): retry transient HTTP/2 stream errors

### DIFF
--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -121,7 +121,7 @@ func (l *Client) Infer(ctx context.Context, req core.InferRequest) (<-chan core.
 			case ChunkTypeError:
 				// Classify here so the agent loop can decide whether to
 				// retry without importing the provider SDKs.
-				send(core.Chunk{Err: llmerr.Wrap(sc.Error)})
+				send(core.Chunk{Err: llmerr.WrapStream(sc.Error)})
 				return
 			}
 		}
@@ -187,7 +187,7 @@ func (l *Client) Complete(ctx context.Context,
 			return resp, nil
 		}
 		var re core.RetryableError
-		if !errors.As(llmerr.Wrap(err), &re) || attempt == completeMaxAttempts {
+		if !errors.As(llmerr.WrapStream(err), &re) || attempt == completeMaxAttempts {
 			return resp, err
 		}
 		if werr := core.BackoffSleep(ctx, attempt, re.RetryAfter()); werr != nil {

--- a/internal/llm/llm_stream_error_test.go
+++ b/internal/llm/llm_stream_error_test.go
@@ -1,0 +1,79 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/genai-io/san/internal/core"
+)
+
+type streamErrorProvider struct {
+	err error
+}
+
+func (p streamErrorProvider) Stream(context.Context, CompletionOptions) <-chan StreamChunk {
+	ch := make(chan StreamChunk, 1)
+	ch <- StreamChunk{Type: ChunkTypeError, Error: p.err}
+	close(ch)
+	return ch
+}
+
+func (streamErrorProvider) ListModels(context.Context) ([]ModelInfo, error) { return nil, nil }
+func (streamErrorProvider) Name() string                                    { return "stream-error" }
+
+type retryThenSuccessProvider struct {
+	calls int
+}
+
+func (p *retryThenSuccessProvider) Stream(context.Context, CompletionOptions) <-chan StreamChunk {
+	p.calls++
+	ch := make(chan StreamChunk, 1)
+	if p.calls == 1 {
+		ch <- StreamChunk{Type: ChunkTypeError, Error: errors.New("opaque terminal stream error")}
+	} else {
+		ch <- StreamChunk{Type: ChunkTypeDone, Response: &CompletionResponse{Content: "recovered"}}
+	}
+	close(ch)
+	return ch
+}
+
+func (*retryThenSuccessProvider) ListModels(context.Context) ([]ModelInfo, error) { return nil, nil }
+func (*retryThenSuccessProvider) Name() string                                    { return "retry-stream" }
+
+func TestInferWrapsOpaqueStreamErrorAsRetryable(t *testing.T) {
+	original := errors.New("opaque terminal stream error")
+	client := NewClient(streamErrorProvider{err: original}, "test-model", 1)
+
+	chunks, err := client.Infer(context.Background(), core.InferRequest{})
+	if err != nil {
+		t.Fatalf("Infer() error = %v", err)
+	}
+	chunk, ok := <-chunks
+	if !ok {
+		t.Fatal("Infer() returned no error chunk")
+	}
+	var retryable core.RetryableError
+	if !errors.As(chunk.Err, &retryable) {
+		t.Fatalf("chunk error %v is not retryable", chunk.Err)
+	}
+	if !errors.Is(chunk.Err, original) {
+		t.Fatal("chunk error does not preserve the provider error")
+	}
+}
+
+func TestCompleteRetriesOpaqueStreamError(t *testing.T) {
+	provider := &retryThenSuccessProvider{}
+	client := NewClient(provider, "test-model", 1)
+
+	resp, err := client.Complete(context.Background(), "", nil, 1)
+	if err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if resp.Content != "recovered" {
+		t.Fatalf("Complete() content = %q, want recovered", resp.Content)
+	}
+	if provider.calls != 2 {
+		t.Fatalf("Stream() calls = %d, want 2", provider.calls)
+	}
+}

--- a/internal/llm/llmerr/llmerr.go
+++ b/internal/llm/llmerr/llmerr.go
@@ -1,10 +1,11 @@
 // Package llmerr classifies LLM provider/stream errors so the agent loop can
 // decide whether a failure is worth retrying. It maps each provider SDK's error
-// type onto a small, provider-agnostic taxonomy and exposes a single Wrap entry
-// point that tags retryable errors with core.RetryableError.
+// type onto a small, provider-agnostic taxonomy and exposes phase-aware wrapping
+// entry points that tag retryable errors with core.RetryableError.
 package llmerr
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net"
@@ -24,23 +25,61 @@ import (
 type class int
 
 const (
-	fatal       class = iota // never retry: bad request, auth, not-found, content policy, context window
+	unknown     class = iota // no typed provider or transport signal
+	knownFatal               // never retry: cancellation, bad request, auth, not-found, content policy
 	retryable                // transient: 408/409, all 5xx (incl. 529), connection/network errors
 	rateLimited              // 429 — retry, honoring Retry-After when present
 )
 
-// Wrap classifies err and tags it for the turn loop: retryable failures
-// satisfy core.RetryableError (carrying any Retry-After hint), a prompt that
-// overflowed the context window satisfies core.ContextExceededError. Anything
-// else — and nil — is returned unchanged, so it satisfies neither and the turn
-// loop surfaces it immediately. The original error always stays in the chain.
+// Wrap conservatively classifies an error from a regular/non-streaming
+// operation. Unknown errors are returned unchanged and remain fatal.
 func Wrap(err error) error {
+	return wrap(err, false)
+}
+
+// WrapStream classifies a terminal streaming error. Streaming transports can
+// lose their typed error at the SDK boundary, so only an otherwise unknown
+// terminal error is additionally considered retryable. Known fatal errors keep
+// their conservative classification.
+func WrapStream(err error) error {
+	return wrap(err, true)
+}
+
+// MarkRetryable marks a provider error as a known transient failure. Providers
+// use this for structured in-band API errors whose retryability would otherwise
+// be lost at the generic stream boundary.
+func MarkRetryable(err error) error {
 	if err == nil {
 		return nil
 	}
-	// Checked before classify: an overflowed prompt arrives as a 400/422,
-	// which classify buckets as fatal, and it needs its own tag so the loop
-	// compacts instead of giving up.
+	var retryable core.RetryableError
+	if errors.As(err, &retryable) {
+		return err
+	}
+	return retryErr{err: err}
+}
+
+// MarkNonRetryable marks a provider error as a known semantic/API failure.
+// Providers use this to distinguish in-band API errors from opaque transport
+// termination errors without relying on provider error text.
+func MarkNonRetryable(err error) error {
+	if err == nil {
+		return nil
+	}
+	return nonRetryableErr{err: err}
+}
+
+func wrap(err error, retryUnknown bool) error {
+	if err == nil {
+		return nil
+	}
+	// Cancellation wins over message-based context overflow detection and every
+	// retryable transport classification, including when wrapped.
+	if errors.Is(err, context.Canceled) {
+		return err
+	}
+	// An overflowed prompt commonly arrives as a typed 400/422. Tag it before
+	// status classification so the loop compacts instead of giving up.
 	if isContextExceeded(err) {
 		return contextErr{err: err}
 	}
@@ -49,9 +88,23 @@ func Wrap(err error) error {
 		return retryErr{err: err}
 	case rateLimited:
 		return retryErr{err: err, after: after}
-	default:
-		return err
+	case unknown:
+		if retryUnknown {
+			return retryErr{err: err}
+		}
 	}
+	return err
+}
+
+type nonRetryableErr struct{ err error }
+
+func (e nonRetryableErr) Error() string { return e.err.Error() }
+func (e nonRetryableErr) Unwrap() error { return e.err }
+func (e nonRetryableErr) nonRetryable() {}
+
+type nonRetryableError interface {
+	error
+	nonRetryable()
 }
 
 // contextExceededSignatures are the ways providers say "this prompt exceeds
@@ -108,6 +161,16 @@ var _ core.RetryableError = retryErr{}
 // classify maps err onto the taxonomy, returning a Retry-After hint when the
 // provider supplied one (429 responses); 0 otherwise.
 func classify(err error) (class, time.Duration) {
+	// Cancellation is a known fatal classification. Check it explicitly here as
+	// well as in wrap so classify cannot collapse it into unknown.
+	if errors.Is(err, context.Canceled) {
+		return knownFatal, 0
+	}
+	var nonRetryable nonRetryableError
+	if errors.As(err, &nonRetryable) {
+		return knownFatal, 0
+	}
+
 	// Provider SDK typed errors carry an HTTP status — the most reliable
 	// signal. (openai.Error.Code is a string, so use .StatusCode.)
 	var anthErr *anthropic.Error
@@ -132,7 +195,7 @@ func classify(err error) (class, time.Duration) {
 		return retryable, 0
 	}
 
-	return fatal, 0
+	return unknown, 0
 }
 
 // fromStatus classifies an HTTP status code and extracts Retry-After for 429.
@@ -147,7 +210,7 @@ func fromStatus(code int, resp *http.Response) (class, time.Duration) {
 	default:
 		// 400/401/403/404/422, content policy, model-not-found, and
 		// context-window-exceeded all land here: retrying cannot help.
-		return fatal, 0
+		return knownFatal, 0
 	}
 }
 
@@ -157,10 +220,11 @@ func fromStatus(code int, resp *http.Response) (class, time.Duration) {
 //
 // net.Error intentionally also matches a per-request timeout
 // (context.DeadlineExceeded satisfies net.Error): a request that timed out is
-// worth retrying. A user interrupt (context.Canceled) is NOT a net.Error and
-// stays fatal — and the turn loop checks the caller ctx before classifying, so
-// a cancel never reaches here.
+// worth retrying. A user interrupt (context.Canceled) always stays fatal.
 func isNetworkError(err error) bool {
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
 	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 		return true
 	}

--- a/internal/llm/llmerr/llmerr_test.go
+++ b/internal/llm/llmerr/llmerr_test.go
@@ -3,6 +3,7 @@ package llmerr
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -137,6 +138,76 @@ func TestWrapClassification(t *testing.T) {
 				t.Fatalf("RetryAfter = %v, want %v", after, tc.wantAfter)
 			}
 		})
+	}
+}
+
+func TestWrapAndWrapStreamClassification(t *testing.T) {
+	issueGoAway := errors.New(`http2: server sent GOAWAY and closed the connection; LastStreamID=7, ErrCode=NO_ERROR, debug=""`)
+	issueStream := errors.New("stream error: stream ID 11; INTERNAL_ERROR; received from peer")
+	apiErr := func(code int, message string) error {
+		return &openai.Error{
+			StatusCode: code,
+			Message:    message,
+			Request:    dummyReq(),
+			Response:   httpResp(code, nil),
+		}
+	}
+	contextOverflow := errors.New("maximum context length exceeded")
+
+	tests := []struct {
+		name            string
+		err             error
+		wantWrapRetry   bool
+		wantStreamRetry bool
+		wantContext     bool
+	}{
+		{name: "issue GOAWAY text", err: issueGoAway, wantStreamRetry: true},
+		{name: "issue stream text", err: issueStream, wantStreamRetry: true},
+		{name: "ordinary opaque", err: errors.New("something opaque"), wantStreamRetry: true},
+		{name: "wrapped opaque", err: fmt.Errorf("reading response: %w", errors.New("opaque cause")), wantStreamRetry: true},
+		{name: "marked non-retryable", err: MarkNonRetryable(errors.New("semantic stream failure"))},
+		{name: "marked retryable", err: MarkRetryable(errors.New("transient stream failure")), wantWrapRetry: true, wantStreamRetry: true},
+		{name: "provider 400", err: apiErr(400, "bad request"), wantWrapRetry: false, wantStreamRetry: false},
+		{name: "provider 401", err: apiErr(401, "unauthorized"), wantWrapRetry: false, wantStreamRetry: false},
+		{name: "provider 429", err: apiErr(429, "rate limited"), wantWrapRetry: true, wantStreamRetry: true},
+		{name: "provider 503", err: apiErr(503, "unavailable"), wantWrapRetry: true, wantStreamRetry: true},
+		{name: "EOF", err: io.EOF, wantWrapRetry: true, wantStreamRetry: true},
+		{name: "net timeout", err: fakeTimeout{}, wantWrapRetry: true, wantStreamRetry: true},
+		{name: "context canceled", err: context.Canceled},
+		{name: "wrapped context canceled", err: fmt.Errorf("stopped: %w", context.Canceled)},
+		{name: "deadline exceeded", err: context.DeadlineExceeded, wantWrapRetry: true, wantStreamRetry: true},
+		{name: "context exceeded", err: contextOverflow, wantContext: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, variant := range []struct {
+				name          string
+				got           error
+				wantRetryable bool
+			}{
+				{name: "Wrap", got: Wrap(tc.err), wantRetryable: tc.wantWrapRetry},
+				{name: "WrapStream", got: WrapStream(tc.err), wantRetryable: tc.wantStreamRetry},
+			} {
+				t.Run(variant.name, func(t *testing.T) {
+					_, gotRetryable := retryInfo(variant.got)
+					if gotRetryable != variant.wantRetryable {
+						t.Fatalf("retryable = %v, want %v", gotRetryable, variant.wantRetryable)
+					}
+					var gotContext core.ContextExceededError
+					if errors.As(variant.got, &gotContext) != tc.wantContext {
+						t.Fatalf("context exceeded = %v, want %v", gotContext != nil, tc.wantContext)
+					}
+					if !errors.Is(variant.got, tc.err) {
+						t.Fatal("original error is not preserved in chain")
+					}
+				})
+			}
+		})
+	}
+
+	if WrapStream(nil) != nil {
+		t.Fatal("WrapStream(nil) must return nil")
 	}
 }
 

--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/llm/llmerr"
 	"github.com/genai-io/san/internal/llm/openaicompat"
 	streamutil "github.com/genai-io/san/internal/llm/stream"
 	"github.com/genai-io/san/internal/log"
@@ -272,7 +273,13 @@ func (c *Client) streamResponses(ctx context.Context, opts llm.CompletionOptions
 					if resp.Error.Message != "" {
 						errMsg = resp.Error.Message
 					}
-					state.Fail(ctx, ch, fmt.Errorf("responses API failed: %s", errMsg))
+					err := fmt.Errorf("responses API failed: %s", errMsg)
+					if retryableResponseError(resp.Error.Code) {
+						err = llmerr.MarkRetryable(err)
+					} else {
+						err = llmerr.MarkNonRetryable(err)
+					}
+					state.Fail(ctx, ch, err)
 					return
 				default:
 					state.Response.StopReason = core.StopReason(resp.Status)
@@ -280,7 +287,13 @@ func (c *Client) streamResponses(ctx context.Context, opts llm.CompletionOptions
 
 			case "error":
 				errEvent := event.AsError()
-				state.Fail(ctx, ch, fmt.Errorf("responses API error: %s", errEvent.Message))
+				err := fmt.Errorf("responses API error: %s", errEvent.Message)
+				if retryableResponseErrorCode(errEvent.Code) {
+					err = llmerr.MarkRetryable(err)
+				} else {
+					err = llmerr.MarkNonRetryable(err)
+				}
+				state.Fail(ctx, ch, err)
 				return
 			}
 		}
@@ -296,6 +309,21 @@ func (c *Client) streamResponses(ctx context.Context, opts llm.CompletionOptions
 	}()
 
 	return ch
+}
+
+func retryableResponseError(code responses.ResponseErrorCode) bool {
+	return retryableResponseErrorCode(string(code))
+}
+
+func retryableResponseErrorCode(code string) bool {
+	switch code {
+	case string(responses.ResponseErrorCodeServerError),
+		string(responses.ResponseErrorCodeRateLimitExceeded),
+		string(responses.ResponseErrorCodeVectorStoreTimeout):
+		return true
+	default:
+		return false
+	}
 }
 
 // ListModels returns the available models for OpenAI using the API

--- a/internal/llm/openai/client_test.go
+++ b/internal/llm/openai/client_test.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -200,6 +201,56 @@ func TestStreamResponsesIncludesReasoningSummaryAndEmitsThinking(t *testing.T) {
 	}
 	if !foundThinking {
 		t.Fatal("expected reasoning summary delta to emit a thinking chunk")
+	}
+}
+
+func TestResponseErrorCodeRetryability(t *testing.T) {
+	tests := []struct {
+		code      string
+		retryable bool
+	}{
+		{code: "server_error", retryable: true},
+		{code: "rate_limit_exceeded", retryable: true},
+		{code: "vector_store_timeout", retryable: true},
+		{code: "invalid_prompt"},
+		{code: "image_content_policy_violation"},
+		{code: "unknown_error"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.code, func(t *testing.T) {
+			if got := retryableResponseErrorCode(tc.code); got != tc.retryable {
+				t.Fatalf("retryableResponseErrorCode(%q) = %v, want %v", tc.code, got, tc.retryable)
+			}
+		})
+	}
+}
+
+func TestResponsesInBandErrorCarriesRetryMarker(t *testing.T) {
+	tests := []struct {
+		name      string
+		code      string
+		retryable bool
+	}{
+		{name: "transient", code: "server_error", retryable: true},
+		{name: "semantic", code: "invalid_prompt"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stream := "data: {\"type\":\"error\",\"code\":\"" + tc.code + "\",\"message\":\"failed\",\"param\":\"\",\"sequence_number\":1}\n\n"
+			chunks := drain(newTestClient(&captureStreamingTransport{stream: stream}).Stream(
+				context.Background(),
+				llm.CompletionOptions{Model: "gpt-5.4", Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}}},
+			))
+			if len(chunks) != 1 || chunks[0].Type != llm.ChunkTypeError {
+				t.Fatalf("chunks = %#v, want one error chunk", chunks)
+			}
+			var retryable core.RetryableError
+			if got := errors.As(chunks[0].Error, &retryable); got != tc.retryable {
+				t.Fatalf("retryable = %v, want %v", got, tc.retryable)
+			}
+		})
 	}
 }
 

--- a/internal/llm/openaicompat/errors.go
+++ b/internal/llm/openaicompat/errors.go
@@ -31,15 +31,27 @@ func IsAuthError(err error) bool {
 	return ok
 }
 
-// NormalizeAPIError converts OpenAI-compatible auth failures into actionable
-// provider-specific guidance while preserving all other errors as-is.
+type normalizedError struct {
+	message string
+	cause   error
+}
+
+func (e normalizedError) Error() string { return e.message }
+func (e normalizedError) Unwrap() error { return e.cause }
+
+func normalize(message string, cause error) error {
+	return normalizedError{message: message, cause: cause}
+}
+
+// NormalizeAPIError converts OpenAI-compatible errors into clearer display
+// messages while retaining the original error chain for status classification.
 func NormalizeAPIError(providerName string, err error) error {
 	apierr, ok := asAuthError(err)
 	if !ok {
 		var generic *openai.Error
 		if errors.As(err, &generic) {
 			if msg := apiErrorMessage(generic); msg != "" {
-				return fmt.Errorf("%s: %s", err, msg)
+				return normalize(msg, err)
 			}
 		}
 		return err
@@ -50,15 +62,15 @@ func NormalizeAPIError(providerName string, err error) error {
 
 	if envVar == "" {
 		if msg == "" {
-			return fmt.Errorf("%s authentication failed; reconnect the provider with /model", providerLabel)
+			return normalize(fmt.Sprintf("%s authentication failed; reconnect the provider with /model", providerLabel), err)
 		}
-		return fmt.Errorf("%s authentication failed: %s. Reconnect the provider with /model", providerLabel, msg)
+		return normalize(fmt.Sprintf("%s authentication failed: %s. Reconnect the provider with /model", providerLabel, msg), err)
 	}
 
 	if msg == "" {
-		return fmt.Errorf("%s authentication failed; check %s and reconnect the provider with /model", providerLabel, envVar)
+		return normalize(fmt.Sprintf("%s authentication failed; check %s and reconnect the provider with /model", providerLabel, envVar), err)
 	}
-	return fmt.Errorf("%s authentication failed: %s. Check %s and reconnect the provider with /model", providerLabel, msg, envVar)
+	return normalize(fmt.Sprintf("%s authentication failed: %s. Check %s and reconnect the provider with /model", providerLabel, msg, envVar), err)
 }
 
 func apiErrorMessage(apierr *openai.Error) string {

--- a/internal/llm/openaicompat/errors_test.go
+++ b/internal/llm/openaicompat/errors_test.go
@@ -8,14 +8,43 @@ import (
 	"github.com/openai/openai-go/v3"
 )
 
-func TestNormalizeAPIErrorIncludesNonAuthAPIMessage(t *testing.T) {
-	err := NormalizeAPIError("openai:subscription", &openai.Error{
-		StatusCode: 400,
-		Message:    "unsupported parameter: reasoning.summary",
-	})
+func TestNormalizeAPIErrorPreservesAPIErrorChain(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		apiErr   *openai.Error
+		want     []string
+	}{
+		{
+			name:     "authentication",
+			provider: "openai:subscription",
+			apiErr:   &openai.Error{StatusCode: 401, Message: "invalid key"},
+			want:     []string{"OpenAI authentication failed: invalid key", "OPENAI_API_KEY", "reconnect"},
+		},
+		{
+			name:     "generic API error",
+			provider: "openai:subscription",
+			apiErr:   &openai.Error{StatusCode: 400, Message: "unsupported parameter: reasoning.summary"},
+			want:     []string{"unsupported parameter: reasoning.summary"},
+		},
+	}
 
-	if !strings.Contains(err.Error(), "unsupported parameter") {
-		t.Fatalf("NormalizeAPIError() = %v, want server message", err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NormalizeAPIError(tc.provider, tc.apiErr)
+			for _, want := range tc.want {
+				if !strings.Contains(got.Error(), want) {
+					t.Fatalf("NormalizeAPIError() = %q, want substring %q", got, want)
+				}
+			}
+			var recovered *openai.Error
+			if !errors.As(got, &recovered) {
+				t.Fatal("normalized error does not retain *openai.Error in chain")
+			}
+			if recovered != tc.apiErr {
+				t.Fatalf("recovered API error = %p, want %p", recovered, tc.apiErr)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- classify terminal stream failures with a phase-aware `WrapStream` policy instead of matching private HTTP/2 error strings
- retry opaque stream termination errors with the existing bounded backoff while keeping typed 4xx, cancellation, context overflow, and semantic API errors non-retryable
- preserve the original OpenAI API error chain when presenting normalized user-facing messages
- classify structured OpenAI Responses API events explicitly, including retryable server/rate-limit/time-out failures
- apply the same stream-aware policy to utility completions

## Tests

- `go test ./...`

Fixes #397