### PR TITLE
feat(agent): load and manage custom agents

### DIFF
--- a/.san/personas/software-engineer/skills/simplify/SKILL.md
+++ b/.san/personas/software-engineer/skills/simplify/SKILL.md
@@ -34,14 +34,14 @@ earlier in this conversation.
 ## Phase 2: Review across three lenses (one parallel batch)
 
 Use the Agent tool to launch exactly three subagent reviewers concurrently in one
-foreground batch: Reuse, Quality, and Efficiency. Use the single default Agent with
-`mode=explore` for all three. Include the complete diff text from Phase 1 directly
-in every reviewer prompt; do not ask a reviewer to run `git diff` or recover
+foreground batch: Reuse, Quality, and Efficiency. Omit `name` to use the default
+agent and set `mode=explore` for all three. Include the complete diff text from
+Phase 1 directly in every reviewer prompt; do not ask a reviewer to run `git diff` or recover
 omitted context itself. Each returns a short list of concrete, located findings.
 
 Launch no second reviewer batch. If a reviewer reports a missing tool, capability,
 or context failure, record that reviewer as unavailable and continue with the
-other results and your own review. Do not retry it, switch agent type, or delegate
+other results and your own review. Do not retry it, select another custom agent, or delegate
 the same lens again.
 
 - **Reuse.** New code that duplicates an existing helper or utility; hand-rolled

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ san --resume                     # pick a past session to resume
 
 # Subcommands (run `san <command> --help` for the full list)
 san inspector                    # session transcript viewer
-san agent run --prompt "..."        # run a headless subagent
+san agent run --prompt "..."                    # run the implicit default headless agent
+san agent run --name test-runner --prompt "..." # run an exact custom agent
 san plugin <list|install|enable|...>          # manage plugins
 san mcp <add|list|remove|...>                 # manage MCP servers
 ```
@@ -127,7 +128,7 @@ san mcp <add|list|remove|...>                 # manage MCP servers
 | Cycle thinking budget | `Ctrl+T` or `/think` (levels vary by provider) |
 | Toggle permission mode | `Shift+Tab` (ask · auto-accept · autopilot) |
 | Search / persona / memory | `/search` · `/persona` · `/memory` |
-| Skills / tools | `/skills` · `/tools` |
+| Skills / agents / tools | `/skills` · `/agents` · `/tools` |
 | Plugins / MCP / config | `/plugin` · `/mcp` · `/config` |
 | Session / loop / misc | `/fork` · `/compact` · `/loop` · `/glob` · `/init` · `/clear` |
 | All slash commands | `/help` |
@@ -176,6 +177,7 @@ settings.json     # Permissions, hooks, env, active persona
 skills.json       # Skill states
 personas/         # Persona bundles: system prompt parts, skills, settings
 skills/           # Custom skill definitions
+agents/           # Custom agent definitions
 commands/         # Custom slash commands
 plugins/          # Installed plugins
 projects/         # Session transcripts + indexes
@@ -188,6 +190,7 @@ settings.json       # Permissions, hooks, disabled tools
 mcp.json            # MCP server definitions (team shared)
 mcp.local.json      # MCP server definitions (personal, git-ignored)
 personas/           # Project-scoped persona bundles (override user-level)
+agents/*.md         # Subagent definitions
 skills/*/SKILL.md   # Skills
 commands/*.md       # Slash commands
 plugins/            # Project-level plugins
@@ -218,8 +221,8 @@ See full details: [docs/operations/benchmark.md](docs/operations/benchmark.md)
 - [Documentation Index](docs/index.md) — map of architecture, features, operations, and references
 - [Architecture](docs/concepts/architecture.md) — architecture entrypoint and reading order
 - [Package Map](docs/reference/package-map.md) — package ownership and dependency boundaries
-- [Personas](docs/concepts/persona.md) — bundled system prompt, skills, and settings
-- [System Prompt](docs/concepts/harness-channels.md) — slot model, persona, skill, and reminder injection
+- [Personas](docs/concepts/persona.md) — bundled system prompt, skills, agents, and settings
+- [System Prompt](docs/concepts/harness-channels.md) — Slot model, persona, skill/agent injection
 - [Subagents](docs/packages/2-feature/subagent.md) · [Skills](docs/packages/2-feature/skill.md) · [Plugins](docs/packages/2-feature/plugin.md) · [MCP](docs/packages/2-feature/mcp.md)
 - [Hooks](docs/packages/2-feature/hook.md) · [Permissions](docs/concepts/permission-model.md) · [Tasks](docs/packages/2-feature/task.md)
 - [Inspector](docs/packages/2-feature/inspector.md) — local web UI for transcript replay and debugging

--- a/README.zh.md
+++ b/README.zh.md
@@ -115,7 +115,7 @@ san --resume                     # 选择历史会话恢复
 
 # 子命令（运行 `san <command> --help` 查看完整列表）
 san inspector                    # 会话转录查看器
-san agent run --prompt "..."                  # 运行 headless agent
+san agent run --name test-runner --prompt "..."   # 运行自定义 headless agent
 san plugin <list|install|enable|...>          # 管理插件
 san mcp <add|list|remove|...>                 # 管理 MCP 服务器
 ```
@@ -126,7 +126,7 @@ san mcp <add|list|remove|...>                 # 管理 MCP 服务器
 | 切换 thinking 级别 | `Ctrl+T` 或 `/think`（可选级别因提供商而异） |
 | 切换权限模式 | `Shift+Tab`（询问 · 自动接受 · 自动审查） |
 | 搜索 / 人设 / 记忆 | `/search` · `/persona` · `/memory` |
-| 技能 / 工具 | `/skills` · `/tools` |
+| 技能 / 代理 / 工具 | `/skills` · `/agents` · `/tools` |
 | 插件 / MCP / 配置 | `/plugin` · `/mcp` · `/config` |
 | 会话 / 循环 / 其他 | `/fork` · `/compact` · `/loop` · `/glob` · `/init` · `/clear` |
 | 全部 slash 命令 | `/help` |
@@ -175,6 +175,7 @@ settings.json     # 权限、hooks、env、当前 persona
 skills.json       # 技能状态
 personas/         # persona 包：系统 prompt 片段、技能、设置
 skills/           # 自定义技能定义
+agents/           # 自定义 agent 定义
 commands/         # 自定义 slash 命令
 plugins/          # 已安装插件
 projects/         # 会话记录与索引
@@ -187,6 +188,7 @@ settings.json       # 权限、hooks、禁用工具
 mcp.json            # MCP server 定义（团队共享）
 mcp.local.json      # MCP server 定义（个人，git-ignored）
 personas/           # 项目级 persona 包（覆盖用户级）
+agents/*.md         # Subagent 定义
 skills/*/SKILL.md   # 技能
 commands/*.md       # Slash 命令
 plugins/            # 项目级插件
@@ -217,8 +219,8 @@ plugins-local/      # 本地插件（git-ignored）
 - [文档索引](docs/index.md) —— 架构、特性、运维、参考资料的入口
 - [架构](docs/concepts/architecture.md) —— 架构入口与阅读顺序
 - [包结构图](docs/reference/package-map.md) —— 包归属与依赖边界
-- [人设 Persona](docs/concepts/persona.md) —— 打包的系统 prompt、技能与设置
-- [系统 Prompt](docs/concepts/harness-channels.md) —— Slot 模型、persona、技能与 reminder 注入
+- [人设 Persona](docs/concepts/persona.md) —— 打包的系统 prompt、技能、agent 与设置
+- [系统 Prompt](docs/concepts/harness-channels.md) —— Slot 模型、persona、技能/agent 注入
 - [Subagents](docs/packages/2-feature/subagent.md) · [Skills](docs/packages/2-feature/skill.md) · [Plugins](docs/packages/2-feature/plugin.md) · [MCP](docs/packages/2-feature/mcp.md)
 - [Hooks](docs/packages/2-feature/hook.md) · [Permissions](docs/concepts/permission-model.md) · [Tasks](docs/packages/2-feature/task.md)
 - [Inspector](docs/packages/2-feature/inspector.md) —— 本地 Web UI，用于转录回放与调试

--- a/cmd/san/agent.go
+++ b/cmd/san/agent.go
@@ -9,6 +9,7 @@ import (
 var agentRunOpts app.AgentRunOptions
 
 func init() {
+	agentRunCmd.Flags().StringVar(&agentRunOpts.Name, "name", "", "Optional custom agent name")
 	agentRunCmd.Flags().StringVar(&agentRunOpts.Prompt, "prompt", "", "Task prompt")
 	agentRunCmd.Flags().StringVar(&agentRunOpts.Model, "model", "", "Model override")
 	agentRunCmd.Flags().IntVar(&agentRunOpts.MaxSteps, "max-steps", 500, "Maximum LLM inference steps (minimum 500)")
@@ -28,7 +29,8 @@ var agentRunCmd = &cobra.Command{
 	Long: `Run a subagent in headless mode without TUI.
 
 Example:
-  san agent run --prompt "find main.go"`,
+  san agent run --prompt "find main.go"
+  san agent run --name test-runner --prompt "run the tests"`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return app.RunAgent(agentRunOpts)
 	},

--- a/cmd/san/plugin.go
+++ b/cmd/san/plugin.go
@@ -13,11 +13,11 @@ import (
 var pluginCmd = &cobra.Command{
 	Use:   "plugin",
 	Short: "Manage plugins",
-	Long: `Manage plugins for extending San with skills, commands, hooks, and MCP servers.
+	Long: `Manage plugins for extending San with skills, agents, hooks, and MCP servers.
 
 Plugins bundle multiple components:
   - Skills: Custom skills invokable via slash commands
-  - Commands: Custom slash commands
+  - Agents: Subagent definitions
   - Hooks: Event handlers
   - MCP Servers: Model Context Protocol servers
   - LSP Servers: Language Server Protocol servers
@@ -120,6 +120,9 @@ func formatPluginComponents(p *plugin.Plugin) []string {
 	var components []string
 	if n := len(p.Components.Skills); n > 0 {
 		components = append(components, fmt.Sprintf("%d skills", n))
+	}
+	if n := len(p.Components.Agents); n > 0 {
+		components = append(components, fmt.Sprintf("%d agents", n))
 	}
 	if n := len(p.Components.Commands); n > 0 {
 		components = append(components, fmt.Sprintf("%d commands", n))
@@ -310,6 +313,12 @@ var pluginInfoCmd = &cobra.Command{
 			fmt.Printf("  Skills (%d):\n", len(p.Components.Skills))
 			for _, s := range p.Components.Skills {
 				fmt.Printf("    - %s\n", s)
+			}
+		}
+		if len(p.Components.Agents) > 0 {
+			fmt.Printf("  Agents (%d):\n", len(p.Components.Agents))
+			for _, a := range p.Components.Agents {
+				fmt.Printf("    - %s\n", a)
 			}
 		}
 		if p.Components.Hooks != nil && len(p.Components.Hooks.Hooks) > 0 {

--- a/docs/concepts/extension-model.md
+++ b/docs/concepts/extension-model.md
@@ -1,73 +1,96 @@
 # Extension Model
 
-San is built so users can extend it without touching Go. There are **three
-extension primitives** plus a **plugin source** that packages them. Each
-primitive is a small markdown-or-process artifact placed in a known location.
+San is built so users can extend it without touching Go. There are
+**four extension primitives** plus a **plugin source** that packages them.
+Each primitive is a small markdown-or-process artifact the user puts in a
+known directory; San discovers it at startup and exposes it through a
+runtime registry.
 
 | Primitive | What it is | Package | Where it lives |
 |---|---|---|---|
-| **Skill** | A markdown capability the model can discover and invoke. | [`skill`](../packages/2-feature/skill.md) | `~/.san/skills/<name>/SKILL.md` and project equivalents |
-| **Slash Command** | A markdown file that injects a parameterized prompt. | [`command`](../packages/2-feature/command.md) | `~/.san/commands/<name>.md` and project equivalents |
+| **Skill** | A markdown file the model can be made aware of, or invoke via slash command. | [`skill`](../packages/2-feature/skill.md) | `~/.san/skills/<name>/SKILL.md` and project equivalents |
+| **Subagent** | A markdown-defined custom agent with its own system prompt and tool subset; spawned via the `Agent` tool. | [`subagent`](../packages/2-feature/subagent.md) | `~/.san/agents/<name>.md` and project equivalents |
+| **Slash Command** | A markdown file that injects a parameterized prompt; invoked from the input box. | [`command`](../packages/2-feature/command.md) | `~/.san/commands/<name>.md` and project equivalents |
 | **Hook** | A shell command, HTTP endpoint, LLM call, or in-process callback fired at a named event. | [`hook`](../packages/2-feature/hook.md) | `settings.json` (`hooks` field) |
 
-Tools are the inbound capability surface: built-ins live in [`tool`](../packages/2-feature/tool.md), and MCP contributes external tools through [`mcp`](../packages/2-feature/mcp.md).
+Plus the inbound side:
 
-Subagents are runtime workers, not an extension primitive. The `Agent` tool
-launches one implicit general-purpose worker; San does not load selectable agent
-definitions from user, project, persona, or plugin directories. See
-[`subagent`](../packages/2-feature/subagent.md).
+| Primitive | What it is | Package |
+|---|---|---|
+| **Tool** | A capability the agent calls. Built-in or contributed by MCP. | [`tool`](../packages/2-feature/tool.md), [`mcp`](../packages/2-feature/mcp.md) |
 
 ## Plugin is a Source, Not a Primitive
 
-A **plugin** bundles any combination of skills, commands, MCP servers, hooks,
-and environment variables. Skills and commands can also live standalone under
-`~/.san/*` or `<project>/.san/*`.
+A **plugin** is a *bundle* of any combination of the above. It is a single
+directory the user installs; the plugin contributes some skills, some
+agents, some commands, some MCP servers, some hooks, and optionally env
+vars. The four primitives can also live without a plugin — they exist
+standalone under `~/.san/*` or `<project>/.san/*`.
 
-```text
-       ┌──────────────────────────────────────┐
-       │               Plugin                 │
-       │  skills · commands · MCP · hooks     │
-       └───────────┬──────────┬───────────────┘
-                   ▼          ▼
-                 skill     command       + MCP, hooks, env
-                   ▲          ▲
-       ┌───────────┴──────────┴───────────────┐
-       │ ~/.san/<surface>/ + project scope    │
-       └──────────────────────────────────────┘
+So the right mental model:
+
+```
+       ┌────────────────────────────────────────┐
+       │                Plugin                  │
+       │   (one directory, version-pinnable)    │
+       └──────┬────────┬───────┬──────┬─────────┘
+              │        │       │      │
+              ▼        ▼       ▼      ▼
+          skill    agent   command   mcp    + hooks, env
+              ▲        ▲       ▲      ▲
+              │        │       │      │
+       ┌──────┴────────┴───────┴──────┴─────────┐
+       │     ~/.san/<surface>/  + project       │
+       │     (loose files, no plugin needed)    │
+       └────────────────────────────────────────┘
 ```
 
-[`plugin`](../packages/2-feature/plugin.md) discovers plugins and pushes each
-contribution to its consuming package. Consumers do not import plugin state
-through a shared extension registry.
+[`plugin`](../packages/2-feature/plugin.md) discovers plugins and **pushes** the
+per-primitive contributions to each consuming package at startup via
+callbacks (see `Options.PluginSkillPaths`, `Options.PluginAgentPaths`,
+etc.). The consumer doesn't import `plugin`.
 
 ## Discovery Order
 
-Markdown extension primitives resolve this precedence chain:
+Agent definitions use this precedence, from highest to lowest:
 
-```text
-project (.san/<surface>/)
-    overrides
-project plugins (.san/plugins/*/...)
-    overrides
-user (~/.san/<surface>/)
-    overrides
-user plugins (~/.san/plugins/*/...)
-    overrides
-Claude-compatible sources where supported
+```
+project .san/agents/
+user ~/.san/agents/
+project .claude/agents/
+user ~/.claude/agents/
+plugin agents
 ```
 
-Higher-priority entries shadow lower ones by name (or by `name:path` for skill
-namespaces). Enable state is persisted per scope.
+Loose definitions shadow lower-priority entries by case-insensitive exact name.
+Plugin Agents are namespaced as `<plugin-name>:<agent-name>`, so they do not
+shadow loose definitions. Enable state is persisted per user or project scope.
 
 ## Frontmatter Convention
 
-Markdown-defined skills and commands use YAML frontmatter followed by prompt or
-instruction content. Exact fields vary by primitive; see the package docs for
-[`skill`](../packages/2-feature/skill.md) and
+All markdown-defined primitives share the same general shape:
+
+```markdown
+---
+name: my-skill              # required
+description: One-liner      # required for selectors
+namespace: optional         # only skills support this
+allowed-tools: [Read, Bash] # tool subset (subagent + skill)
+argument-hint: <hint>       # for slash commands
+---
+
+The body of the file becomes the prompt / instruction content.
+```
+
+Exact frontmatter fields vary by primitive — see the per-package docs:
+[`skill`](../packages/2-feature/skill.md), [`subagent`](../packages/2-feature/subagent.md),
 [`command`](../packages/2-feature/command.md).
 
 ## See Also
 
-- [`harness-channels`](harness-channels.md) — how skills and reminders reach the model.
-- [`permission-model`](permission-model.md) — main and subagent permission modes.
-- [`plugin`](../packages/2-feature/plugin.md) — install, marketplace, and enable mechanics.
+- [`concepts/harness-channels.md`](harness-channels.md) — how skill /
+  reminder content reaches the model.
+- [`concepts/permission-model.md`](permission-model.md) — how a
+  subagent's `allowed-tools` interacts with the permission gate.
+- [`packages/plugin.md`](../packages/2-feature/plugin.md) — install / marketplace /
+  enable mechanics.

--- a/docs/concepts/harness-channels.md
+++ b/docs/concepts/harness-channels.md
@@ -59,8 +59,10 @@ slot 4   environment     cwd, git, date, platform, model — volatile,
 ```
 
 Slot constants live in `internal/core/section.go`; the default applier
-and renderers live in `internal/core/system/catalog.go`. Skills and memory are
-intentionally **not** slots — they ride on the reminder channel instead.
+and renderers live in `internal/core/system/catalog.go`. Skills, memory,
+and the agent directory are intentionally **not** slots — they ride on
+the reminder channel (skills, memory) or on tool schemas (agent
+directory) instead.
 
 See [`packages/core.md`](../packages/3-core/core.md) for the `Section` and
 `System` types.
@@ -125,8 +127,9 @@ framing, mirroring how the skills directory self-introduces.
 `reminder.WrapMemory` owns this shape.
 
 **Subagent memory is mode-dependent.** Every worker receives the skills
-directory. Edit-capable workers also receive project memory so changes follow
-project conventions; read-only workers and all workers omit user memory. See
+directory when its tool set includes `Skill`. Edit-capable workers also receive
+project memory so changes follow project conventions; read-only workers and all
+workers omit user memory. See
 `internal/subagent/executor.go` (`collectSubagentReminders`).
 
 ## Compaction

--- a/docs/concepts/permission-model.md
+++ b/docs/concepts/permission-model.md
@@ -54,8 +54,8 @@ out-of-working-dir writes) — are skipped by `bypassPermissions` mode.
 The foreground and subagent gates both use `setting.ModeDefault` for
 mode-specific default decisions, but otherwise have separate pipelines:
 foreground requests may use settings, session rules, hooks, and the approval
-bridge, while subagents use only their effective mode and deny requests that
-would require a user prompt.
+bridge, while subagents apply their `deny_tools`/`allow_tools` rules and deny
+requests that would require a user prompt.
 
 - Foreground: yes. `agent.PermissionBridge` synchronously waits for the
   TUI approval, then routes the answer back into the running tool call.
@@ -65,8 +65,8 @@ would require a user prompt.
   - `default` — reads auto-allow; everything that would ask is denied.
   - `acceptEdits` (spelled `edit` on the Agent tool) — Edit/Write
     auto-allow; other gated tools are denied.
-  - `bypassPermissions` — everything allowed after the root/home-removal
-    circuit breaker; parent-only tools stay blocked.
+  - `bypassPermissions` — everything allowed after `deny_tools` and the
+    root/home-removal circuit breaker; parent-only tools stay blocked.
 
 Both gates share the same mode table (`setting.ModeDefault`); the subagent
 side only swaps "prompt the user" for "deny".

--- a/docs/concepts/persona.md
+++ b/docs/concepts/persona.md
@@ -162,10 +162,10 @@ Notes:
 
 ## 4. settings.json: the config overlay
 
-A persona's `settings.json` is a **`setting.Data` config overlay plus a
-persona-scoped skills-state map**. The overlay is applied as the **highest
-file-level layer** through the existing merger; the skills selection applies
-in-memory while the persona is active.
+A persona's `settings.json` is a **`setting.Data` config overlay plus two
+persona-scoped selections — a skills-state map and a subagent allow-list**. The
+overlay is applied as the **highest file-level layer** through the existing
+merger; the two selections apply in-memory while the persona is active.
 
 ```json
 {
@@ -176,6 +176,7 @@ in-memory while the persona is active.
     "git:commit": "enable",
     "deep-research": "disable"
   },
+  "agents": ["test-runner", "project-reviewer"],
   "disabledTools": { "WebSearch": false, "SomeHeavyTool": true },
   "permissions": {
     "defaultMode": "acceptEdits",
@@ -201,6 +202,7 @@ The load order (lowest → highest, see `internal/setting/settings.go`):
 | Field | Merge | What a persona can do |
 |---|---|---|
 | `skills` | per-key override | **full override**: listed skills take the persona's state; unlisted keep the lower layer |
+| `agents` | allow-list (replace) | **restrict visibility**: when non-empty, only the listed subagents are spawnable/shown; empty/omitted = all visible |
 | `disabledTools` | per-key override (`mergeMaps`) | **full override**: can disable, and can re-enable a tool a lower layer disabled (`false`) |
 | `permissions.defaultMode` | `coalesce` | persona wins if set |
 | `permissions.allow/deny/ask` | union (`mergeStringSlices`) | **add only** — can tighten with new `deny`; **cannot remove** a lower-layer rule |
@@ -210,9 +212,11 @@ The one asymmetry is deliberate and safety-biased: **a persona can tighten
 permissions but not loosen them.** It cannot silently remove a project-level
 `deny`. (`managed-settings.json` remains above personas and is never overridable.)
 
-`skills` is a **persona-scoped selection applied in-memory** while the persona
-is active. It is not part of the layered config merge and is never written to
-`skills.json`.
+`skills` and `agents` are **persona-scoped selections applied in-memory** while
+the persona is active — they are not part of the layered config merge and are
+never written to `skills.json` or the agent enable/disable stores. The `agents`
+allow-list composes with those stores: an agent must be on the allow-list *and*
+not disabled to be visible.
 
 The overlay also ignores any `persona` selector inside a persona's own
 `settings.json` — a persona cannot re-select the active persona, which would be
@@ -244,6 +248,7 @@ rebuild.
 |---|---|---|
 | system prompt | immediate | `SwapPersona(sys)` → replaces parts by name |
 | skills (in-memory) | immediate | registry overlay + `RequeueSystemReminders()` |
+| subagent allow-list | enforcement immediate; prompt listing next rebuild | registry allow-list gates spawns live; the agents directory re-renders on the next `buildAgent` |
 | tools / permissions | next agent rebuild | recomputed overlay read at the next `buildAgent` |
 
 The UI tells the user which parts went live and which await a rebuild, so a
@@ -302,7 +307,7 @@ plain alias of `/persona`.
 | D3 | Persona skill state | in-memory, persona-lifetime (not `skills.json`) | clean switch; no pollution of global toggles |
 | D4 | System prompt parts | 4: `identity` / `behavior` / `rules` / `environment` | first-principles who/how/what-rules/where |
 | D5 | Part override | every prose part replaceable by file; missing file → default | uniform, no special cases |
-| D6 | `settings.json` | reuse `setting.Data` overlay + `skills` map | free reuse of `merger.go`; skill selection stays in-memory |
+| D6 | `settings.json` | reuse `setting.Data` overlay + `skills` map + `agents` allow-list | free reuse of `merger.go`; visibility selections stay in-memory |
 | D7 | tools/permissions timing | next agent rebuild (prompt + skills immediate) | low risk; avoids hot-swapping the live tool set |
 | D8 | Permission override | `deny` is add-only (tighten, never loosen) | safety: a persona can't strip project-level denies |
 | D9 | Naming | `behavior` + `rules` (not `conduct` / `guidelines`) | self-style vs imposed-rules, plain words |
@@ -315,9 +320,10 @@ Not yet supported; natural extensions if a need appears:
 
 - **Optional `system/context.md`** for appended static context (distinct from the
   live, computed `environment` block).
-- **Subagent personas** — let the implicit worker run *as* a persona, receiving
-  persona-specific prompt parts and skills. Today personas are a main-agent
-  concept.
+- **Subagent personas** — let a subagent run *as* a persona. A persona already
+  controls *which* subagents are visible (the `agents` allow-list, §4); this is
+  the inverse — giving a spawned subagent a persona's prompt and skills. Today
+  subagents keep their own charter mechanism; personas are a main-agent concept.
 - **`permissions.replace` escape hatch** to let a persona fully take over
   permissions (D8 is add-only).
 - **Plugin-provided personas** — personas shipped inside a plugin, like plugin

--- a/docs/guides/explore-mode.md
+++ b/docs/guides/explore-mode.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`explore` is the subagent permission mode for fast, non-mutating codebase investigation. Use it with the implicit default `subagent` when a task requires reading, searching, and cross-referencing multiple files before answering.
+`explore` is the subagent permission mode for fast, non-mutating codebase investigation. Omit the Agent tool's `name` field to use the implicit default agent when a task requires reading, searching, and cross-referencing multiple files before answering.
 
 This feature exists to document the contract that was previously split across the general agent docs, non-mutating mode docs, and subagent notes.
 
@@ -10,10 +10,10 @@ This feature exists to document the contract that was previously split across th
 
 | Property | Value |
 |----------|-------|
-| Agent type | implicit default `subagent` |
+| Agent selection | omit `name` for the implicit default |
 | Permission mode | `explore` |
 | Tools | Read, Bash (read-only commands), WebFetch, WebSearch, Skill, AskUserQuestion |
-| Max steps | 500 |
+| Max steps | 500 minimum |
 | Execution style | Foreground in explore mode |
 
 **Use `mode=explore` when:**
@@ -36,7 +36,7 @@ This feature exists to document the contract that was previously split across th
 
 ## Relationship To Other Features
 
-- [Subagent package](../packages/2-feature/subagent.md) documents the implicit worker and its runtime modes.
+- [Writing a Subagent](writing-a-subagent.md) covers the generic agent system and custom agent format.
 - `explore` is the investigative permission boundary used by subagents.
 
 ## Automated Tests

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -92,9 +92,9 @@ san --continue                       # resume the last session
 |---|---|---|
 | User | `~/.san/providers.json` | Provider connections, current model |
 | User | `~/.san/settings.json` | Permissions, hooks, env, persona, search provider |
-| User | `~/.san/skills/` `~/.san/commands/` `~/.san/plugins/` | Your personal extensions |
+| User | `~/.san/skills/` `~/.san/agents/` `~/.san/commands/` `~/.san/plugins/` | Your personal extensions |
 | Project | `<project>/.san/settings.json` | Per-project overrides |
-| Project | `<project>/.san/{skills,commands}/` | Project-scoped extensions |
+| Project | `<project>/.san/{skills,agents,commands}/` | Project-scoped extensions |
 | Project | `<project>/SAN.md` or `CLAUDE.md` | Auto-loaded into the system prompt |
 
 See [`reference/configuration.md`](../reference/configuration.md) for the
@@ -103,8 +103,8 @@ full schema.
 ## What to Read Next
 
 - [Writing a skill](writing-a-skill.md) — your first user extension.
-- [Using subagents](../packages/2-feature/subagent.md) — delegate isolated work through the Agent tool.
-- [Writing a plugin](writing-a-plugin.md) — bundle skills + commands.
+- [Writing a subagent](writing-a-subagent.md) — define a parallel agent.
+- [Writing a plugin](writing-a-plugin.md) — bundle skills + agents + commands.
 - [`docs/concepts/architecture.md`](../concepts/architecture.md) — how the system is built.
 - [`reference/slash-commands.md`](../reference/slash-commands.md) —
   every `/command`.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -11,5 +11,6 @@ Task-oriented how-tos. For conceptual background see
 | [`explore-mode`](explore-mode.md) | Use the read-only Explore subagent for fan-out search. |
 | [`autopilot`](autopilot.md) | Configure the autopilot copilot: steers, mission, the `/autopilot` panel, and the `/goal` preset. |
 | [`writing-a-skill`](writing-a-skill.md) | Author a Skill. |
-| [`writing-a-plugin`](writing-a-plugin.md) | Bundle skills / hooks / commands into a plugin. |
+| [`writing-a-subagent`](writing-a-subagent.md) | Author a custom subagent. |
+| [`writing-a-plugin`](writing-a-plugin.md) | Bundle skills / agents / hooks / commands into a plugin. |
 | [`writing-a-provider`](writing-a-provider.md) | Add a new LLM provider. |

--- a/docs/guides/writing-a-plugin.md
+++ b/docs/guides/writing-a-plugin.md
@@ -1,8 +1,10 @@
 # Writing a Plugin
 
 A plugin is a single directory that bundles any combination of skills,
-slash commands, MCP servers, hooks, and env vars. Plugins are
-the distribution unit: one git repo, one tarball, one `pluginspec.json`.
+subagents, slash commands, MCP servers, hooks, and env vars. Plugins are
+the distribution unit: one git repo or tarball with a
+`.san-plugin/plugin.json` manifest (`.claude-plugin/plugin.json` is also
+accepted).
 
 For the system-level design see [`packages/plugin.md`](../packages/2-feature/plugin.md)
 and [`concepts/extension-model.md`](../concepts/extension-model.md).
@@ -11,9 +13,12 @@ and [`concepts/extension-model.md`](../concepts/extension-model.md).
 
 ```
 my-plugin/
-├── pluginspec.json          # required: manifest
+├── .san-plugin/
+│   └── plugin.json            # required manifest
 ├── skills/
 │   └── <name>/SKILL.md      # any number of skills
+├── agents/
+│   └── <name>.md            # any number of subagents
 ├── commands/
 │   └── <name>.md            # any number of slash commands
 ├── mcp/
@@ -24,10 +29,10 @@ my-plugin/
     └── .env                 # env vars to merge when plugin is enabled
 ```
 
-Everything except `pluginspec.json` is optional — a plugin can contribute
-as little as one skill.
+Everything except `.san-plugin/plugin.json` is optional — a plugin can
+contribute as little as one skill.
 
-## Manifest (`pluginspec.json`)
+## Manifest (`.san-plugin/plugin.json`)
 
 ```json
 {
@@ -76,11 +81,12 @@ disable, uninstall, switch scope, browse the marketplace.
 ## Enable State
 
 Plugins are enabled per scope. Disabling a plugin removes its
-contributions (skills / commands / MCP / hooks) without
+contributions (skills / agents / commands / MCP / hooks) without
 deleting files. Re-enable to restore.
 
-State is persisted in `~/.san/plugins.json` and
-`<project>/.san/plugins.json`.
+State is persisted in the scope's settings file under `enabledPlugins`:
+`~/.san/settings.json`, `<project>/.san/settings.json`, or
+`<project>/.san/settings.local.json`.
 
 ## Contributions Push, Not Pull
 
@@ -89,10 +95,11 @@ into the relevant feature package:
 
 | Contribution | Consumer |
 |---|---|
-| `skills/*/SKILL.md` | `internal/skill` (via `AddPluginSkills`) |
-| `commands/*.md` | `internal/command` (via `PluginCommandPaths` callback) |
-| `mcp/servers.json` | `internal/mcp` (merged into `mcp.json`) |
-| `hooks/hooks.json` | `internal/setting` (merged into `settings.json`'s `hooks`) |
+| `skills/*/SKILL.md` | `internal/skill` via `GetPluginSkillPaths` |
+| `agents/*.md` | `internal/subagent` via `GetPluginAgentPaths` |
+| `commands/*.md` | `internal/command` via `GetPluginCommandPaths` |
+| `.mcp.json` or manifest `mcpServers` | `internal/mcp` via `GetPluginMCPServers` |
+| `hooks/hooks.json` | `internal/setting` via `GetPluginHooks` |
 | `env/.env` | `internal/setting` (merged into runtime env) |
 
 This means the consumer packages do not import `plugin`; they receive
@@ -102,13 +109,14 @@ contributions as data.
 
 ```
 my-plugin/
-├── pluginspec.json
+├── .san-plugin/
+│   └── plugin.json
 └── skills/
     └── say-hello/
         └── SKILL.md
 ```
 
-`pluginspec.json`:
+`.san-plugin/plugin.json`:
 
 ```json
 {
@@ -169,8 +177,11 @@ the marketplace.
 
 ## Common Pitfalls
 
-- **Forgot `pluginspec.json`.** Plugin is silently skipped at load time.
-  Check `~/.san/logs/` for the warning.
+- **Forgot `.san-plugin/plugin.json`.** Validation rejects the plugin. A
+  `.claude-plugin/plugin.json` manifest is also accepted.
+- **Plugin Agent name omitted.** Agents are namespaced automatically: an Agent
+  named `reviewer` in plugin `github-flow` is selected as
+  `name: "github-flow:reviewer"`.
 - **Skill name collisions across plugins.** Disambiguate with `namespace:`
   in the SKILL.md frontmatter (e.g. `namespace: github`, then invoked as
   `/github:create-pr`).
@@ -183,6 +194,6 @@ the marketplace.
 
 - [`packages/plugin.md`](../packages/2-feature/plugin.md) — loader, installer,
   marketplace internals.
-- [`writing-a-skill.md`](writing-a-skill.md).
+- [`writing-a-skill.md`](writing-a-skill.md), [`writing-a-subagent.md`](writing-a-subagent.md).
 - [`concepts/extension-model.md`](../concepts/extension-model.md) — how
-  the three primitives relate.
+  the four primitives relate.

--- a/docs/guides/writing-a-subagent.md
+++ b/docs/guides/writing-a-subagent.md
@@ -1,0 +1,179 @@
+# Writing a Subagent
+
+A custom subagent is a markdown-defined **agent** — a system prompt + tool
+subset + permission mode that the foreground agent can spawn via the
+`Agent` tool. Foreground subagents return a tool result; background ones notify
+the main conversation when done.
+
+For the system-level design see [`packages/subagent.md`](../packages/2-feature/subagent.md)
+and [`concepts/extension-model.md`](../concepts/extension-model.md).
+
+## Where to Put It
+
+| Scope | Path |
+|---|---|
+| Project | `<project>/.san/agents/<name>.md` |
+| User | `~/.san/agents/<name>.md` |
+| Claude-compat | `<project>/.claude/agents/<name>.md`, `~/.claude/agents/<name>.md` |
+
+Project `.san` definitions override user `.san`, project `.claude`, user
+`.claude`, then plugin definitions by case-insensitive exact name. Plugin Agents
+are selected by their namespaced name, `<plugin-name>:<agent-name>`.
+
+## Minimal Example
+
+`./.san/agents/test-runner.md`:
+
+```markdown
+---
+name: test-runner
+description: Run the test suite and surface failures
+allow_tools: [Bash, Read]
+mode: bypass
+---
+
+You are a test runner. Your job is to:
+
+1. Detect the project's test command from package.json / Makefile / go.mod.
+2. Run it. Capture stdout/stderr.
+3. If failures exist, summarize the failing tests with file:line and
+   one-line reasons. If everything passes, say "all green".
+
+Be terse. No code suggestions — that is the parent agent's job.
+```
+
+## Frontmatter Fields
+
+| Field | Required | Purpose |
+|---|---|---|
+| `name` | yes | Custom agent identifier; used in the `Agent` tool's `name` field. |
+| `description` | yes | Helps the foreground model decide when to spawn this agent. |
+| `allow_tools` | no | Allowed tools. Defaults to all; aliases: `allowed-tools`, `tools`. |
+| `deny_tools` | no | Removes tools or `Tool(pattern)` rules. |
+| `mode` | no | `default`, `explore`, `edit` (`acceptEdits`), or `bypassPermissions`; alias: `permission-mode`. |
+| `model` | no | Defaults to the parent's model. Aliases/bare IDs use its provider; `vendor/model` uses a connected provider or falls back to the parent. |
+| `max-steps` | no | Maximum LLM steps; default and minimum: 500. Alias: `max_steps`. |
+| `skills` | no | Skills preloaded into the agent charter. |
+
+Canonical keys win when both a canonical key and its alias are present.
+
+## Cross-Provider Models
+
+The `model:` field selects a model for this subagent. `vendor/model` routes to
+a connected provider:
+
+| Agent | `model:` | Why |
+|---|---|---|
+| `planner` | `anthropic/claude-opus-4-7` | strongest reasoning for decomposition |
+| `coder` | `deepseek/deepseek-v4` | cheap, fast bulk implementation |
+| `reviewer` | `anthropic/claude-sonnet-4-6` | independent review on a *different* model |
+
+`model:` accepts:
+
+- `inherit` (or empty) — the parent conversation's model.
+- an alias (`opus` / `sonnet` / `haiku`) or a bare id — served by the parent's
+  provider.
+- `vendor/model` (e.g. `deepseek/deepseek-v4`) — routed to another **connected**
+  provider.
+
+The vendor names the model family, not its hosting platform: Claude on Vertex
+is still `anthropic/…`. If unavailable, San uses the parent's provider and
+model.
+
+The foreground agent selects an agent by `description` / `when-to-use`; that
+also selects its model.
+
+## Permission Mode
+
+Subagents have no UI, so permission prompts cannot be shown. The mode
+controls what happens when a tool call would normally `ask`:
+
+| Mode | Behavior |
+|---|---|
+| `explore` | Read-only; mutating tools are unavailable. |
+| `default` | Reads allowed; `ask` becomes `deny`, unless allowed by `allow_tools`. |
+| `edit` (= `acceptEdits`) | Edit/Write allowed; other gated tools, such as unrestricted Bash, are denied. |
+| `bypassPermissions` | Allows everything after `deny_tools`; only a root/home-directory removal stays denied (circuit breaker). Use only for trusted agents. |
+
+Subagents cannot spawn subagents. `SendMessage(to="main", ...)` follows the
+normal mode rules.
+
+See [`packages/broker.md`](../packages/2-feature/broker.md)
+for the message queue and [`concepts/permission-model.md`](../concepts/permission-model.md)
+for the full decision pipeline.
+
+## How the Parent Spawns It
+
+San resolves `name` before requesting permission or starting an LLM/tool loop:
+
+- Omit `name` or pass an empty value to run the implicit default agent.
+- A non-empty value selects that exact enabled custom Agent definition.
+- Unknown or disabled names fail immediately. The literal `subagent` is not a
+  special alias; it selects a custom Agent named `subagent` only if one exists
+  and is enabled.
+
+For the example above, the foreground agent calls the `Agent` tool with:
+
+```json
+{
+  "name": "test-runner",
+  "description": "Run the unit tests for the auth package",
+  "prompt": "Focus on internal/auth/*_test.go and report failures."
+}
+```
+
+San:
+
+1. Looks up `test-runner` in the subagent registry.
+2. Builds a `core.Agent` with the subagent's charter and tool subset.
+3. Runs it foreground, or as a `task.AgentTask` when `run_in_background` is true.
+4. Returns a tool result (foreground) or completion `<task-notification>`
+   (background).
+
+## Talking to a Running Worker
+
+A background subagent registers with the broker while running:
+
+- **Steer**: `SendMessage(to=<task id>, message)` sends a message that it reads
+  on its next step. Delivery is best-effort.
+- **Report to main**: `SendMessage(to="main", message)` sends an interim note.
+  The final answer returns automatically on completion.
+- **Stop**: `AgentStop` with the task id cancels the run. This optional tool is disabled by default; enable it with `/tool` when the model should manage running workers. Start a new subagent to continue.
+
+## Trying It
+
+1. Save the agent file.
+2. Restart `san`.
+3. Ask the foreground model something that should trigger spawning:
+   "use the test-runner agent to check whether tests pass".
+4. Watch the task panel for a background subagent's progress; its final
+   result arrives as a `<task-notification>` in the parent's conversation.
+   A foreground subagent returns its final result directly as the `Agent`
+   tool result.
+
+## Common Pitfalls
+
+- **No prompt argument.** The `Agent` call fails because `prompt` is
+  required.
+- **`allow_tools` too narrow.** Forgot `Bash`? The subagent can't run
+  anything — and a whitelist without `SendMessage` also removes reporting
+  to main.
+- **`bypassPermissions` on a write-class subagent.** Verify carefully
+  — the subagent has no human in the loop.
+- **Plugin Agent name omitted.** Plugin Agents are namespaced automatically;
+  for example, `reviewer.md` from plugin `github-flow` is selected with
+  `name: "github-flow:reviewer"`.
+- **Same name in several locations.** Priority is project `.san` > user
+  `~/.san` > project `.claude` > user `~/.claude` > plugins; the
+  higher-priority definition wins.
+
+## See Also
+
+- [`packages/broker.md`](../packages/2-feature/broker.md) —
+  how the main conversation and its subagents message each other.
+- [`packages/subagent.md`](../packages/2-feature/subagent.md) — registry +
+  executor design.
+- [`packages/agent.md`](../packages/2-feature/agent.md) — foreground agent
+  lifecycle.
+- [`concepts/extension-model.md`](../concepts/extension-model.md).
+- [`concepts/permission-model.md`](../concepts/permission-model.md).

--- a/docs/packages/2-feature/command.md
+++ b/docs/packages/2-feature/command.md
@@ -21,7 +21,7 @@ commands loaded from disk.
 
 ## Contract
 
-Slash command registry. Combines built-in handlers, dynamic providers (currently skills), and custom markdown commands. The package exposes `*Registry` directly — no Service interface.
+Slash command registry. Combines built-in handlers, dynamic providers (skill/agent surfaces), and custom markdown commands. The package exposes `*Registry` directly — no Service interface.
 
 ```go
 package command
@@ -52,7 +52,7 @@ func ResetDefaultRegistry()          // test-only
 - `registry.go` — combines three sources at query time:
   - **Built-ins** registered from `builtin/` subpackage at init.
   - **Dynamic** — `DynamicProviders` callbacks returning `Info` slices
-    (used by the skill slash-command surface).
+    (used by skill/agent slash-command surfaces).
   - **Custom** — markdown files under `~/.san/commands/` and
     `<project>/.san/commands/`, plus plugin-scoped paths returned by
     `PluginCommandPaths`.
@@ -61,7 +61,8 @@ func ResetDefaultRegistry()          // test-only
 ## Lifecycle
 
 - Construction: `Initialize(Options{CWD, DynamicProviders, PluginCommandPaths})`
-  at app startup after skills are initialized so the dynamic provider is wired in.
+  at app startup, after `skill` and `subagent` are initialized so their
+  dynamic providers are wired in.
 - Reload on plugin reload: callers re-call `Initialize` with refreshed
   provider closures.
 
@@ -75,6 +76,6 @@ internal/command/registry_test.go    — name lookup, fuzzy matching,
 ## See Also
 
 - Code: `internal/command/`
-- Related: [`packages/skill.md`](skill.md), [`packages/plugin.md`](plugin.md)
+- Related: [`packages/skill.md`](skill.md), [`packages/subagent.md`](subagent.md) (dynamic providers), [`packages/plugin.md`](plugin.md)
 - Reference: [`reference/slash-commands.md`](../../reference/slash-commands.md)
 - Layer: `feature`

--- a/docs/packages/2-feature/plugin.md
+++ b/docs/packages/2-feature/plugin.md
@@ -8,26 +8,27 @@ layer: feature
 > 中文版本：[`plugin.zh.md`](plugin.zh.md)
 
 Plugin loader, installer, marketplace, and aggregator. A plugin is a
-single package (directory) that may contribute skills, slash commands, MCP
-servers, hooks, and env vars — this package discovers them, enables/disables
-them, and exposes their contributions to the consuming feature packages.
+single package (directory) that may contribute skills, subagent
+definitions, slash commands, MCP servers, hooks, and env vars — this
+package discovers them, enables/disables them, and exposes their
+contributions to the consuming feature packages.
 
 ## Purpose
 
 San's "everything else" extension surface. Plugins are how a user
-installs a bundle of skills + commands + MCP servers + hooks in one shot. This
-package handles install/uninstall, marketplace lookup, load order, and the
-cross-cutting callbacks that let `skill`, `command`, `mcp`, `hook`, and
-`setting` see what each enabled plugin contributes without importing `plugin`
-directly.
+installs a bundle of skills + agents + commands + MCP servers + hooks in
+one shot. This package handles install/uninstall, marketplace lookup,
+load order, and the cross-cutting callbacks that let `skill`, `subagent`,
+`command`, `mcp`, `hook`, and `setting` see what each enabled plugin
+contributes without importing `plugin` directly.
 
 ## Contract
 
 The package exposes `*Registry` directly plus package-level free
 functions for the cross-domain integration surface. No producer-side
-interface — each downstream consumer (skill / command / mcp / setting) pulls a
-different small set of free functions, so a unified interface would just
-collect unrelated methods.
+interface — each downstream consumer (skill / subagent / command / mcp
+/ setting) pulls a different small set of free functions, so a unified
+interface would just collect unrelated methods.
 
 ```go
 package plugin
@@ -61,6 +62,7 @@ func NewInstaller(reg *Registry, cwd string) *Installer
 // Cross-domain integration (package-level free functions; read from
 // the package-level default registry). Each consumer that needs
 // plugin-contributed data imports plugin and calls one of these:
+func GetPluginAgentPaths() []PluginPath
 func GetPluginSkillPaths() []PluginPath
 func GetPluginCommandPaths() []PluginPath
 func GetPluginMCPServers() []PluginMCPServer
@@ -97,8 +99,8 @@ func ResetDefaultRegistry()           // test-only
 - Construction: `Initialize(ctx, Options{CWD})` is one of the first
   `Initialize` calls because every feature package's `Initialize`
   pulls `plugin.*Paths()`.
-- Reload: enabling/disabling a plugin triggers a reload of the affected feature
-  packages (commands/skills/MCP).
+- Reload: enabling/disabling a plugin triggers a reload of the
+  affected feature packages (commands/skills/subagents/MCP).
 
 ## Marketplace & install flow
 
@@ -125,8 +127,8 @@ flowchart TD
     K --> L
     L --> M["record in installed_plugins.json"]
     M --> N["LoadPlugin → Register → Enable"]
-    N --> O["resolve components:<br/>skills / commands / hooks / mcp / lsp"]
-    O --> P["app feeds them to the feature packages<br/>skill / command / mcp / hook"]
+    N --> O["resolve components:<br/>skills / agents / commands / hooks / mcp / lsp"]
+    O --> P["app feeds them to the feature packages<br/>skill / subagent / command / mcp / hook"]
 ```
 
 **Plugin `source` formats** (in `marketplace.json` `plugins[]`):
@@ -155,6 +157,6 @@ internal/plugin/marketplace_manifest_test.go — manifest source parsing,
 ## See Also
 
 - Code: `internal/plugin/`
-- Consumers: [`packages/skill.md`](skill.md), [`packages/command.md`](command.md), [`packages/mcp.md`](mcp.md), [`packages/hook.md`](hook.md), [`packages/setting.md`](setting.md)
+- Consumers: [`packages/skill.md`](skill.md), [`packages/subagent.md`](subagent.md), [`packages/command.md`](command.md), [`packages/mcp.md`](mcp.md), [`packages/hook.md`](hook.md), [`packages/setting.md`](setting.md)
 - Concepts: [`concepts/extension-model.md`](../../concepts/extension-model.md)
 - Layer: `feature`

--- a/docs/packages/2-feature/plugin.zh.md
+++ b/docs/packages/2-feature/plugin.zh.md
@@ -8,21 +8,24 @@ layer: feature
 > English version: [`plugin.md`](plugin.md)
 
 插件的加载器、安装器、marketplace 和聚合器。一个插件就是一个包（目录），
-它可以贡献 skills、斜杠命令、MCP servers、hooks 和环境变量——本包负责发现它们、启用/禁用它们，并把它们的贡献暴露给上层的
+它可以贡献 skills、subagent 定义、斜杠命令、MCP servers、hooks 和环境
+变量——本包负责发现它们、启用/禁用它们，并把它们的贡献暴露给上层的
 feature 包。
 
 ## 用途
 
-San 的"其余一切"扩展面。插件让用户一次性安装一整套 skills + commands +
-MCP servers + hooks。本包处理安装/卸载、marketplace 查找、加载顺序，以及
-那些跨切面的回调——让 `skill`、`command`、`mcp`、`hook`、`setting` 无需
-直接 import `plugin` 就能看到每个已启用插件贡献了什么。
+San 的"其余一切"扩展面。插件让用户一次性安装一整套 skills + agents +
+commands + MCP servers + hooks。本包处理安装/卸载、marketplace 查找、
+加载顺序，以及那些跨切面的回调——让 `skill`、`subagent`、`command`、
+`mcp`、`hook`、`setting` 无需直接 import `plugin` 就能看到每个已启用插件
+贡献了什么。
 
 ## 契约
 
 本包直接暴露 `*Registry`，外加一组包级自由函数作为跨域集成面。没有
-生产者侧的接口——每个下游消费者（skill / command / mcp / setting）各自取用
-一小撮不同的自由函数，统一成一个接口只会把互不相关的方法凑到一起。
+生产者侧的接口——每个下游消费者（skill / subagent / command / mcp /
+setting）各自取用一小撮不同的自由函数，统一成一个接口只会把互不相关的
+方法凑到一起。
 
 ```go
 package plugin
@@ -55,6 +58,7 @@ func NewInstaller(reg *Registry, cwd string) *Installer
 
 // 跨域集成（包级自由函数；从包级默认 registry 读取）。
 // 每个需要插件贡献数据的消费者 import plugin 并调用其中之一：
+func GetPluginAgentPaths() []PluginPath
 func GetPluginSkillPaths() []PluginPath
 func GetPluginCommandPaths() []PluginPath
 func GetPluginMCPServers() []PluginMCPServer
@@ -89,7 +93,7 @@ func ResetDefaultRegistry()           // 仅测试
 - 构造：`Initialize(ctx, Options{CWD})` 是最早一批 `Initialize` 调用之一，
   因为每个 feature 包的 `Initialize` 都会拉 `plugin.*Paths()`。
 - 重载：启用/禁用一个插件会触发受影响 feature 包
-  （commands/skills/MCP）的重载。
+  （commands/skills/subagents/MCP）的重载。
 
 ## Marketplace 与安装流程
 
@@ -115,8 +119,8 @@ flowchart TD
     K --> L
     L --> M["写入 installed_plugins.json"]
     M --> N["LoadPlugin → Register → Enable"]
-    N --> O["解析组件：<br/>skills / commands / hooks / mcp / lsp"]
-    O --> P["app 把它们交给 feature 包<br/>skill / command / mcp / hook"]
+    N --> O["解析组件：<br/>skills / agents / commands / hooks / mcp / lsp"]
+    O --> P["app 把它们交给 feature 包<br/>skill / subagent / command / mcp / hook"]
 ```
 
 **插件 `source` 格式**（位于 `marketplace.json` 的 `plugins[]`）：
@@ -145,6 +149,6 @@ internal/plugin/marketplace_manifest_test.go — 清单 source 解析、
 ## 另见
 
 - 代码：`internal/plugin/`
-- 消费者：[`packages/skill.md`](skill.md)、[`packages/command.md`](command.md)、[`packages/mcp.md`](mcp.md)、[`packages/hook.md`](hook.md)、[`packages/setting.md`](setting.md)
+- 消费者：[`packages/skill.md`](skill.md)、[`packages/subagent.md`](subagent.md)、[`packages/command.md`](command.md)、[`packages/mcp.md`](mcp.md)、[`packages/hook.md`](hook.md)、[`packages/setting.md`](setting.md)
 - 概念：[`concepts/extension-model.md`](../../concepts/extension-model.md)
 - 层级：`feature`

--- a/docs/packages/2-feature/subagent.md
+++ b/docs/packages/2-feature/subagent.md
@@ -5,84 +5,128 @@ layer: feature
 
 # subagent
 
-Executor for the single implicit subagent launched through the `Agent` tool.
-Each invocation creates an isolated `core.Agent` loop; there is no user,
-project, persona, or plugin registry of selectable agent types.
+Registry of custom **agents** (markdown-defined personas with their
+own system prompt, tool subset, and permission mode) plus the **Executor**
+that spawns foreground or background `core.Agent` instances from within the
+main agent's tool loop.
 
 ## Purpose
 
-Where [`agent`](agent.md) owns the main conversation session, this package owns
-one-shot worker runs. A foreground subagent blocks the spawning tool call and
-returns its result. A background run executes under `task.AgentTask`, registers
-with the [`broker`](broker.md), and can receive `SendMessage` updates while it
-runs.
-
-Multiple workers may run concurrently. They share the current working directory
-but have isolated conversations and lifecycle hooks.
+Where [`packages/agent.md`](agent.md) owns the *foreground* agent session,
+this package owns the subagents that session spawns via the Agent tool.
+Each subagent runs its own `core.Agent` loop (event observation via
+`OnEvent`; no outbox) with an isolated conversation and its own
+tool/permission set, sharing the session's working directory. A foreground subagent blocks the
+spawning turn and returns its result as the tool result; a background
+subagent runs in a goroutine under a `task.AgentTask` and registers its task
+id with the [`broker`](broker.md) for the length of the run — main can
+`SendMessage` it while it runs, and its completion is routed to the `main`
+address when it finishes.
 
 ## Contract
 
+The Agent tool selects a custom definition through its optional `name` field. Omitting `name` runs the implicit default agent. The schema does not expose `subagent_type`. Unknown or disabled names fail before execution. The implicit default inherits the parent session mode; custom definitions use their configured mode unless the request explicitly selects `explore` or `edit`. All runs use a minimum of 500 inference steps.
+
+The package exposes the concrete `*Registry` directly. The four
+production caller sites use four different subsets of its surface, so
+no producer-side role interface earns its keep — TEMPLATE Rule 3.
+
+| Caller | Methods used |
+|---|---|
+| `cmd/san agent` | `Get` (CLI argument validation) |
+| TUI view | `ListConfigs` (color enumeration) |
+| Agent build site | `PromptSection` (twice) |
+| TUI selector adapter | full surface — `ListConfigs`, `IsEnabled`, `SetEnabled`, `GetDisabledAt` for the `/agents` menu |
+
+Executor construction goes through the package-level `NewExecutor`
+free function (in `executor.go`), not a method on the registry. The
+free function takes `hook.Handler`, keeping subagent decoupled from
+the concrete `*hook.Engine`.
+
 ```go
+package subagent
+
+// Registry is an opaque handle to the custom agent registry. The type is
+// exported so callers can hold and pass *Registry values; all fields
+// are unexported so internal state is reached only through methods.
+type Registry struct { /* internal fields */ }
+
+// Query
+func (r *Registry) ListConfigs() []*AgentConfig
+func (r *Registry) Get(name string) (*AgentConfig, bool)
+func (r *Registry) IsEnabled(name string) bool
+
+// State mutation (used by the TUI selector adapter)
+func (r *Registry) SetEnabled(name string, enabled bool, userLevel bool) error
+func (r *Registry) GetDisabledAt(userLevel bool) map[string]bool
+
+// System prompt
+func (r *Registry) PromptSection() string
+
+// Loader bootstrapping
+func (r *Registry) Register(config *AgentConfig)
+func (r *Registry) InitStores(cwd string) error
+
+// Executor construction (package-level free function)
 func NewExecutor(provider llm.Provider, cwd, parentModelID string, hooks hook.Handler) *Executor
 
-func (e *Executor) Run(ctx context.Context, req tool.AgentExecRequest) (*AgentResult, error)
-func (e *Executor) RunBackground(req tool.AgentExecRequest) (*task.AgentTask, error)
-func (e *Executor) SetParentPermissionMode(getMode func() PermissionMode)
+// Package-level access
+func Initialize(opts Options) error
+func Default() *Registry
+func SetDefaultRegistry(r *Registry)  // test-only
+func ResetDefaultRegistry()           // test-only
 ```
-
-The model-facing request has no `subagent_type`. The only selectable runtime
-policy is `mode`:
-
-- `default` dynamically inherits the parent session's effective mode when the
-  run starts, including bypass mode.
-- `explore` is an authoritative read-only ceiling.
-- `edit` uses the accept-edits policy.
-
-`bypass` is an internal permission value, not a model-facing request option.
-The default and minimum `max_steps` are both 500; larger explicit values are
-honored.
 
 ## Internals
 
-- `executor.go` — run preparation, model routing, tool construction, permission
-  gate, reminders, and lifecycle hooks.
-- `executor_prompt.go` — worker identity, display names, and activity labels.
-- `executor_run.go` — LLM loop event aggregation and progress reporting.
-- `executor_session.go` — transcript persistence and result attribution.
-- `adapter.go` — projection onto the Agent tool's executor interface.
-- `activity_tools.go` — streams worker tool calls into parent-visible activity.
-
-The tool set is fixed by the effective mode. Calls that would require an
-interactive approval are denied because no user is attached to a worker loop.
-The root/home removal circuit breaker and parent-only tool boundary remain in
-force even when a worker inherits bypass mode.
+- `Registry` (`registry.go`) — `AgentConfig` map keyed by name, plus
+  enable state stores (user + project).
+- `Executor` (`executor.go`) — spawns a `core.Agent` for one subagent
+  invocation, manages its lifecycle (workspace, permission gate, hooks,
+  session persistence), and returns the aggregated result.
+- `executor_prompt.go` / `executor_run.go` / `executor_session.go` —
+  split executor concerns (charter assembly, run loop, session attribution).
+- `loader.go` — reads markdown agent definitions from `.san/agents/`
+  (project, then user), `.claude/agents/` (Claude Code compatible), and
+  plugin paths; lower-priority sources load first so higher ones win by
+  name. Accepts alias frontmatter keys (`tools`, `allowed-tools`,
+  `permission-mode`) alongside the canonical ones.
+- `match.go` — `ToolList` pattern matching (allow/deny semantics) shared
+  with the permission gate.
+- `activity_tools.go` — decorator around the worker's tools that streams
+  each call into the parent-visible activity trail.
 
 ## Lifecycle
 
-1. The app creates an `Executor` and supplies a thread-safe parent permission
-   getter.
-2. `Run` resolves the request mode and model, creates a fresh `core.Agent`, and
-   fires `SubagentStart` with the fixed protocol identity `subagent`.
-3. The worker receives the skills directory; edit-capable runs also receive
-   project instructions.
-4. Every exit path persists available conversation state and fires
-   `SubagentStop` with the same agent id.
-
-The agent model is flat: `Agent` is parent-only, so workers cannot spawn more
-workers.
+- Construction: `Initialize(Options{CWD, PluginAgentPaths})` loads
+  definitions, initializes state stores.
+- Per-invocation: `NewExecutor(provider, cwd, model, hookEngine)` →
+  `Executor.Run(ctx, req)` spawns a `core.Agent`, blocks until end of
+  turn, returns the aggregated `AgentResult`. `RunBackground(req)` wraps
+  the same run in a `task.AgentTask` goroutine and registers with the broker under
+  the task id so main can message it mid-run.
+- Every exit path — success, cancel, error — fires `SubagentStop` with
+  the same agent id `SubagentStart` carried. Subagents are one-shot: a run
+  is not resumable; to continue a line of work, spawn a fresh subagent.
+- The agent model is flat: only the main conversation spawns subagents. The
+  `Agent` tool is parent-only in `tool.Set`, so a subagent never sees it —
+  nothing to enforce at runtime.
+- Concurrency: multiple executors may run in parallel; the registry is
+  RWMutex-protected.
 
 ## Tests
 
 ```
-internal/subagent/executor_test.go   — run config, mode inheritance, permissions,
-                                       model routing, lifecycle, persistence.
-internal/subagent/scenarios_test.go  — fixed permission-mode truth table.
-tests/integration/agent/             — end-to-end Agent execution.
+internal/subagent/executor_test.go      — end-to-end run scenarios.
+internal/subagent/lazy_loading_test.go  — config files read on demand.
+internal/subagent/scenarios_test.go     — common invocation shapes.
 ```
 
 ## See Also
 
+- Code: `internal/subagent/`
 - Message routing: [`broker`](broker.md)
-- Parent agent: [`agent`](agent.md)
-- Spawning tools: [`tool`](tool.md)
-- Permissions: [`../../concepts/permission-model.md`](../../concepts/permission-model.md)
+- Parent agent: [`packages/agent.md`](agent.md)
+- Spawning tools: [`packages/tool.md`](tool.md) (Agent, SendMessage)
+- Background tasks: [`packages/task.md`](task.md)
+- Layer: `feature`

--- a/docs/packages/index.md
+++ b/docs/packages/index.md
@@ -54,7 +54,7 @@ visible right next to its original. Every page follows [`TEMPLATE.md`](TEMPLATE.
 | [`setting`](2-feature/setting.md) | Settings loader + central permission decision gate. |
 | [`selflearn`](2-feature/selflearn.md) | Background review loop that writes durable memory and agent-created skills. |
 | [`skill`](2-feature/skill.md) | Skill loader, state store, active-skills block consumed by the `skills-directory` reminder. |
-| [`subagent`](2-feature/subagent.md) | Executes the single implicit worker in foreground or background. |
+| [`subagent`](2-feature/subagent.md) | Subagent registry + `Executor` that spawns background `core.Agent` instances. |
 | [`task`](2-feature/task.md) | Background task manager (bash and agent tasks). |
 | [`tool`](2-feature/tool.md) | Tool registry, schemas, permission gate, side-effect store. |
 

--- a/docs/reference/claude-permission-compat.md
+++ b/docs/reference/claude-permission-compat.md
@@ -88,21 +88,138 @@ Spacing matters: `Bash(ls *)` matches `ls -la` but NOT `lsof`. Use `Bash(ls*)` t
    claude --disallowedTools "Bash(rm *)"
    ```
 
-## San Subagent Permissions
+## Subagent vs Main Loop Permissions
 
-San does not load `.claude/agents/*.md` definitions or their `allow_tools` /
-`deny_tools` frontmatter. The Agent tool launches one implicit worker and accepts
-only these model-facing modes:
+Custom agents do **not** inherit the main session's allow/deny rules. Their
+frontmatter defines an independent permission policy. The implicit default Agent
+is the exception: when the Agent tool omits `name` and uses `mode: default`, it
+inherits the parent session's current mode.
 
 | Agent mode | Behavior |
-|------------|----------|
-| `default` | Dynamically inherits the parent session's effective mode, including bypass. |
-| `explore` | Authoritative read-only ceiling; mutations stay blocked. |
-| `edit` | Reads and file edits are allowed; other calls that need approval are denied. |
+|---|---|
+| `explore` | Authoritative read-only ceiling; mutating tools stay blocked even if listed in `allow_tools`. |
+| `default` | Read-only calls run; calls requiring approval are denied because subagents have no approval UI. |
+| `edit` / `acceptEdits` | Reads and file edits run; other gated calls are denied. |
+| `bypassPermissions` | Custom-definition-only privileged mode; all worker tools run after `deny_tools`, the root/home removal circuit breaker, and the parent-only tool boundary. |
 
-Workers have no interactive approval channel, so an `ask` decision collapses to
-deny. The model cannot explicitly request bypass mode. See
-[`concepts/permission-model.md`](../concepts/permission-model.md).
+A model-facing Agent call can request only `explore`, `edit`, or `default`.
+Privileged spellings such as `bypassPermissions` are accepted only in trusted
+custom-agent frontmatter. The main session's configured allow/deny rules are not
+propagated to custom agents.
+
+### Agent Definition Tool Restrictions (YAML)
+
+Custom agents are defined in `.claude/agents/*.md` with YAML frontmatter. Two fields control tool access:
+
+#### allow_tools — Schema Filter
+
+When specified, the LLM only sees these tools in its schema and cannot attempt to use others. When omitted, all tools are available.
+
+```yaml
+# Comma-separated string
+allow_tools: Read, Bash
+
+# Array form
+allow_tools: [Read, Bash]
+
+# Array with patterns
+allow_tools:
+  - Read
+  - Bash(git diff*)       # Only git diff commands
+  - Bash(go test*)        # Only go test commands
+```
+
+An `allow_tools` entry naming a tool San does not ship (for example `Glob`
+or `Grep` from a Claude Code agent definition) is simply inert: no schema
+matches it, so it grants nothing. If such an agent needs to search, list
+`Bash` (optionally with patterns) — read-only commands (`rg`, `grep`,
+`find`, `ls`, read-only `git`, …) auto-permit in every mode, and a
+whitelisted agent only sees the tools its list names.
+
+#### deny_tools — Denylist (Always Wins)
+
+Always overrides `allow_tools` and permission mode. Denied tools are removed from the LLM schema entirely.
+
+```yaml
+deny_tools:
+  - Agent
+  - SendMessage
+  - Bash(rm *)            # Block dangerous bash patterns
+```
+
+#### Evaluation Order
+
+```
+1. deny_tools check    → matching calls are always blocked
+2. circuit breaker     → root/home removal is always blocked
+3. confirmation tiers  → destructive calls are blocked outside bypass mode
+4. allow_tools check   → matching constrained calls may run
+5. mode default        → prompts collapse to deny because workers have no approval UI
+```
+
+#### Examples
+
+**Read-only code reviewer:**
+
+```yaml
+---
+name: project-reviewer
+description: Reviews code for bugs and security issues
+mode: explore
+allow_tools:
+  - Read
+  - Bash(git diff*)
+  - Bash(git log*)
+  - Bash(git show*)
+  - WebFetch
+deny_tools:
+  - Agent
+  - Write
+  - Edit
+---
+
+You are a code reviewer. Analyze the code for correctness, security, and style...
+```
+
+**Implementation agent (can edit, restricted bash):**
+
+```yaml
+---
+name: implementer
+description: Implements code changes
+mode: acceptEdits
+allow_tools:
+  - Read
+  - Write
+  - Edit
+  - Bash(go test*)
+  - Bash(go build*)
+  - Bash(make *)
+deny_tools:
+  - Agent
+---
+
+You are an implementation agent. Write clean, tested code...
+```
+
+**Full agent definition fields:**
+
+```yaml
+---
+name: agent-name
+description: "What this agent does"
+model: opus                  # inherit | sonnet | opus | haiku
+mode: explore                # explore | acceptEdits | default | bypassPermissions
+allow_tools: [Read, Bash]    # Schema filter
+deny_tools: [Agent]          # Always wins
+max-steps: 500
+color: blue                  # UI display color
+when-to-use: "When to use this agent"
+skills: []                   # Additional skills to load
+---
+
+System prompt content goes here in the markdown body...
+```
 
 ## Bash Compound Command Injection Protection
 
@@ -127,7 +244,7 @@ Extends Claude Code's file access scope beyond the working directory:
 
 - Files in these directories become **readable** (same treatment as cwd)
 - File editing still follows the current permission mode
-- **Security boundary**: `.claude/` configuration (hooks, settings, etc.) in additional directories is **not loaded** — only `.claude/skills/` is discovered
+- **Security boundary**: `.claude/` configuration (hooks, settings, agents, etc.) in additional directories is **not loaded** — only `.claude/skills/` is discovered
 - Can be set via CLI `--add-dir ../shared-docs/`, in-session `/add-dir`, or persisted in settings.json
 
 ## Ask Approval Behavior

--- a/docs/reference/package-map.md
+++ b/docs/reference/package-map.md
@@ -41,7 +41,7 @@ Agent, persistence, and orchestration:
 | `internal/session/transcript` | `feature` | Transcript records, filesystem store, projection, renderable views. |
 | `internal/task` | `feature` | Background task management, bash and agent task execution, output storage. |
 | `internal/todo` | `feature` | Agent to-do list state and background tracker service (lifted from `task/tracker`). |
-| `internal/subagent` | `feature` | Executes the implicit subagent, including permissions, model routing, persistence, and progress. |
+| `internal/subagent` | `feature` | Subagent registry, loading, matching, execution, storage, progress tools. |
 | `internal/cron` | `feature` | Cron definitions, storage, service, loop. |
 | `internal/selflearn` | `feature` | Background self-learning reviewer, durable memory store, and restricted skill-update surface. |
 

--- a/docs/reference/slash-commands.md
+++ b/docs/reference/slash-commands.md
@@ -16,6 +16,7 @@ Slash commands are typed directly in the TUI input box. They trigger local UI ac
 | `/tools` | Enable / disable tools |
 | `/plan` | Enter plan mode |
 | `/skills` | Manage skill states |
+| `/agents` | Manage agents |
 | `/tokenlimit` | View / set token budget |
 | `/compact` | Compress conversation history |
 | `/init` | Create SAN.md and config files |
@@ -195,31 +196,37 @@ sleep 1
 tmux capture-pane -t t_cmds -p
 # Expected: skill selector titled "Manage Skills"
 
-# Test 13: /mcp
+# Test 13: /agents
+tmux send-keys -t t_cmds '/agents' Enter
+sleep 1
+tmux capture-pane -t t_cmds -p
+# Expected: agent selector titled "Manage Agents"
+
+# Test 14: /mcp
 tmux send-keys -t t_cmds '/mcp' Enter
 sleep 1
 tmux capture-pane -t t_cmds -p
 # Expected: MCP selector titled "MCP Servers"
 
-# Test 14: /plugin
+# Test 15: /plugin
 tmux send-keys -t t_cmds '/plugin' Enter
 sleep 1
 tmux capture-pane -t t_cmds -p
 # Expected: plugin management panel titled "Plugin Manager"
 
-# Test 15: /memory
+# Test 16: /memory
 tmux send-keys -t t_cmds '/memory' Enter
 sleep 1
 tmux capture-pane -t t_cmds -p
 # Expected: loaded memory files displayed
 
-# Test 16: /resume
+# Test 17: /resume
 tmux send-keys -t t_cmds '/resume' Enter
 sleep 1
 tmux capture-pane -t t_cmds -p
 # Expected: session picker overlay is shown
 
-# Test 17: /tools
+# Test 18: /tools
 tmux send-keys -t t_cmds '/tools' Enter
 sleep 1
 tmux capture-pane -t t_cmds -p

--- a/internal/agent/build.go
+++ b/internal/agent/build.go
@@ -29,6 +29,12 @@ type BuildParams struct {
 	StreamFirstChunkTimeout time.Duration
 	StreamIdleTimeout       time.Duration
 
+	// AgentDirectory, when non-nil, supplies the available-agents listing
+	// embedded into the Agent tool's description. Returning an empty string
+	// hides the listing entirely (used by subagent contexts to discourage
+	// recursive spawning).
+	AgentDirectory func() string
+
 	// Persona overrides the system-prompt parts (identity / behavior / rules)
 	// from the active persona. Empty fields keep San's built-in defaults.
 	Persona system.Persona
@@ -80,8 +86,9 @@ func buildAgent(p BuildParams) (core.Agent, *PermissionGate, error) {
 	}
 
 	schemas := (&tool.Set{
-		Disabled:   p.DisabledTools,
-		ExtraTools: p.ExtraTools,
+		Disabled:       p.DisabledTools,
+		AgentDirectory: p.AgentDirectory,
+		ExtraTools:     p.ExtraTools,
 	}).Tools()
 	var adaptOpts []tool.AdaptOption
 	if p.AskUser != nil {

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -78,6 +78,17 @@ func (m *model) applyPersonaSkills() {
 	m.services.Skill.ClearPersona()
 }
 
+// applyPersonaAgents restricts the visible subagents to the active persona's
+// `agents` allow-list (empty/none = all visible), or clears the restriction
+// when no persona is selected. In-memory, mirroring applyPersonaSkills.
+func (m *model) applyPersonaAgents() {
+	if p := m.activePersona(); p != nil && p.Settings != nil && len(p.Settings.Agents) > 0 {
+		m.services.Subagent.LoadPersona(p.Settings.Agents)
+		return
+	}
+	m.services.Subagent.ClearPersona()
+}
+
 func (m *model) buildAgentParams() agent.BuildParams {
 	schemas := m.services.MCP.GetToolSchemas()
 	mcpTools := mcp.AsCoreTools(schemas, mcp.NewCaller(m.services.MCP))
@@ -132,7 +143,8 @@ func (m *model) buildAgentParams() agent.BuildParams {
 		CWD:     m.env.CWD,
 		CWDFunc: func() string { return m.env.CWD },
 
-		Persona: m.personaPrompt(),
+		AgentDirectory: func() string { return m.services.Subagent.PromptSection() },
+		Persona:        m.personaPrompt(),
 
 		DisabledTools: m.services.Setting.DisabledTools(),
 		MCPTools:      mcpTools,

--- a/internal/app/conv/agent_activity.go
+++ b/internal/app/conv/agent_activity.go
@@ -210,6 +210,8 @@ type PendingToolSpinnerParams struct {
 	SpinnerView string
 	// Blink drives the agent running icon.
 	Blink int
+	// AgentColors maps agent type names to display colors.
+	AgentColors map[string]string
 	// Width is the terminal width for label truncation.
 	Width int
 	// SuppressAgentLabel avoids duplicating the active agent title when the
@@ -244,7 +246,7 @@ func RenderPendingToolSpinner(params PendingToolSpinnerParams) string {
 			tc := params.PendingCalls[params.CurrentIdx]
 			agent := parseAgentInput(tc.Input)
 			label := formatAgentLabel(agent)
-			sb.WriteString(renderAgentToolLine(label, params.Width, agentIcon(params.Blink)) + "\n")
+			sb.WriteString(renderAgentToolLine(label, params.Width, agentIcon(params.Blink), configuredAgentColor(agent, params.AgentColors)) + "\n")
 		}
 		sb.WriteString(renderAgentActivity(params.TaskActivity[params.CurrentIdx]))
 		return sb.String()

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -499,6 +499,7 @@ type ToolCallsParams struct {
 	InputTokens  int
 	OutputTokens int
 	Blink        int
+	AgentColors  map[string]string
 	SpinnerView  string
 	TaskOwnerMap map[string]string
 	MDRenderer   *MDRenderer
@@ -543,11 +544,12 @@ func RenderToolCalls(params ToolCallsParams) string {
 		if tool.IsAgentToolName(tc.Name) {
 			agent := parseAgentInput(tc.Input)
 			label := formatAgentLabel(agent)
+			color := configuredAgentColor(agent, params.AgentColors)
 			_, hasResult := params.ResultMap[tc.ID]
 			if hasResult {
-				sb.WriteString(renderAgentToolLine(label, params.Width, "●") + "\n")
+				sb.WriteString(renderAgentToolLine(label, params.Width, "●", color) + "\n")
 			} else {
-				sb.WriteString(renderAgentToolLine(label, params.Width, agentIcon(params.Blink)))
+				sb.WriteString(renderAgentToolLine(label, params.Width, agentIcon(params.Blink), color))
 				if !params.ToolCallsExpanded && params.Interactive {
 					sb.WriteString(ThinkingStyle.Render("  (ctrl+o to expand)"))
 				}

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -696,13 +696,13 @@ func TestRenderToolCallsShowsGapForPendingAgent(t *testing.T) {
 		ToolCalls: []core.ToolCall{{
 			ID:    "tc-1",
 			Name:  "Agent",
-			Input: `{"description":"HA code structure","prompt":"Inspect the codebase","mode":"explore"}`,
+			Input: `{"name":"Explore","description":"HA code structure","prompt":"Inspect the codebase"}`,
 		}},
 		ResultMap: map[string]ToolResultData{},
 		PendingCalls: []core.ToolCall{{
 			ID:    "tc-1",
 			Name:  "Agent",
-			Input: `{"description":"HA code structure","prompt":"Inspect the codebase","mode":"explore"}`,
+			Input: `{"name":"Explore","description":"HA code structure","prompt":"Inspect the codebase"}`,
 		}},
 		CurrentIdx:  0,
 		Blink:       agentBlinkTicks,
@@ -711,7 +711,7 @@ func TestRenderToolCallsShowsGapForPendingAgent(t *testing.T) {
 	}
 
 	rendered := stripANSI(RenderToolCalls(params))
-	want := agentIcon(params.Blink) + " Explorer: HA code structure"
+	want := agentIcon(params.Blink) + " Agent - Explore: HA code structure"
 	if !strings.Contains(rendered, want) {
 		t.Fatalf("RenderToolCalls() = %q, want a single visible gap before explicit agent label", rendered)
 	}
@@ -734,9 +734,32 @@ func TestRenderToolCallsNamesGeneralAgentByMode(t *testing.T) {
 	}
 
 	rendered := stripANSI(RenderToolCalls(params))
-	want := agentIcon(params.Blink) + " Explorer: audit git changes"
+	want := agentIcon(params.Blink) + " Agent - Explorer: audit git changes"
 	if !strings.Contains(rendered, want) {
 		t.Fatalf("RenderToolCalls() = %q, want mode-based agent label", rendered)
+	}
+}
+
+func TestRenderToolCallsPreservesLiteralSubagentName(t *testing.T) {
+	call := core.ToolCall{
+		ID:    "tc-literal",
+		Name:  "Agent",
+		Input: `{"name":"subagent","description":"audit git changes","mode":"explore"}`,
+	}
+	params := ToolCallsParams{
+		ToolCalls:    []core.ToolCall{call},
+		ResultMap:    map[string]ToolResultData{},
+		PendingCalls: []core.ToolCall{call},
+		CurrentIdx:   0,
+		Blink:        agentBlinkTicks,
+		SpinnerView:  "◓",
+		Width:        100,
+	}
+
+	rendered := stripANSI(RenderToolCalls(params))
+	want := agentIcon(params.Blink) + " Agent - Subagent: audit git changes"
+	if !strings.Contains(rendered, want) {
+		t.Fatalf("RenderToolCalls() = %q, want exact custom agent label", rendered)
 	}
 }
 
@@ -744,7 +767,7 @@ func TestRenderToolCallsShowsSingleAgentRuntimeActivity(t *testing.T) {
 	call := core.ToolCall{
 		ID:    "tc-1",
 		Name:  "Agent",
-		Input: `{"description":"audit git changes before review","prompt":"Inspect the codebase","mode":"explore"}`,
+		Input: `{"name":"Explore","description":"audit git changes before review","prompt":"Inspect the codebase","mode":"explore"}`,
 	}
 	params := ToolCallsParams{
 		ToolCalls:    []core.ToolCall{call},
@@ -770,7 +793,7 @@ func TestRenderToolCallsShowsSingleAgentRuntimeActivity(t *testing.T) {
 	}
 
 	rendered := stripANSI(RenderToolCalls(params))
-	want := agentIcon(params.Blink) + " Explorer: audit git changes before review"
+	want := agentIcon(params.Blink) + " Agent - Explore: audit git changes before review"
 	if !strings.Contains(rendered, want) {
 		t.Fatalf("RenderToolCalls() = %q, want agent header", rendered)
 	}
@@ -791,7 +814,7 @@ func TestRenderToolCallsShowsAgentStatusBeforeToolCalls(t *testing.T) {
 	call := core.ToolCall{
 		ID:    "tc-1",
 		Name:  "Agent",
-		Input: `{"description":"audit git changes","prompt":"Inspect the codebase","mode":"explore"}`,
+		Input: `{"name":"Explore","description":"audit git changes","prompt":"Inspect the codebase","mode":"explore"}`,
 	}
 	params := ToolCallsParams{
 		ToolCalls:    []core.ToolCall{call},
@@ -822,7 +845,7 @@ func TestRenderToolCallsUsesActivityModelForAgentSummary(t *testing.T) {
 	call := core.ToolCall{
 		ID:    "tc-1",
 		Name:  "Agent",
-		Input: `{"description":"audit git changes","prompt":"Inspect the codebase","mode":"explore","model":"sonnet"}`,
+		Input: `{"name":"Explore","description":"audit git changes","prompt":"Inspect the codebase","mode":"explore","model":"sonnet"}`,
 	}
 	params := ToolCallsParams{
 		ToolCalls:    []core.ToolCall{call},

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -949,10 +949,11 @@ func formatAgentLabel(agent agentInput) string {
 		desc = conciseAgentDescription(agent.Prompt)
 	}
 
+	name := displayAgentName(agent.Name, agent.Mode, agent.ImplicitDefault)
 	if desc != "" {
-		return fmt.Sprintf("%s: %s", agent.Name, desc)
+		return fmt.Sprintf("Agent - %s: %s", name, desc)
 	}
-	return agent.Name
+	return fmt.Sprintf("Agent - %s", name)
 }
 
 func conciseAgentDescription(desc string) string {
@@ -963,8 +964,8 @@ func conciseAgentDescription(desc string) string {
 	return kit.TruncateText(desc, 60)
 }
 
-func displayAgentName(agentType, mode string) string {
-	if isGenericAgentName(agentType) {
+func displayAgentName(agentType, mode string, implicitDefault bool) string {
+	if implicitDefault {
 		switch strings.ToLower(strings.TrimSpace(mode)) {
 		case "explore":
 			return "Explorer"
@@ -983,22 +984,14 @@ func displayAgentName(agentType, mode string) string {
 	return shortAgentName(agentType)
 }
 
-func isGenericAgentName(name string) bool {
-	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "", "agent", "subagent", "general", "general-purpose", "explore", "explorer", "edit", "editor":
-		return true
-	default:
-		return false
-	}
-}
-
 type agentInput struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Prompt      string `json:"prompt"`
-	Mode        string `json:"mode"`
-	Background  bool   `json:"run_in_background"`
-	Valid       bool   `json:"-"`
+	Name            string `json:"name"`
+	Description     string `json:"description"`
+	Prompt          string `json:"prompt"`
+	Mode            string `json:"mode"`
+	Background      bool   `json:"run_in_background"`
+	Valid           bool   `json:"-"`
+	ImplicitDefault bool   `json:"-"`
 }
 
 func parseAgentInput(input string) agentInput {
@@ -1007,8 +1000,9 @@ func parseAgentInput(input string) agentInput {
 		return agentInput{}
 	}
 	agent.Valid = true
-	if agent.Name == "" {
-		agent.Name = displayAgentName("subagent", agent.Mode)
+	agent.ImplicitDefault = strings.TrimSpace(agent.Name) == ""
+	if agent.ImplicitDefault {
+		agent.Name = displayAgentName("", agent.Mode, true)
 	}
 	return agent
 }
@@ -1251,10 +1245,46 @@ func extractBashCommand(input string) (command, description string) {
 	return params.Command, params.Description
 }
 
-func renderAgentToolLine(label string, width int, iconText string) string {
-	style := toolCallStyle.Foreground(kit.CurrentTheme.Success)
+func renderAgentToolLine(label string, width int, iconText string, color string) string {
+	style := agentStyle(color)
 	icon := style.Width(2).Render(iconText)
 	return lipgloss.JoinHorizontal(lipgloss.Top, icon, style.Render(truncateToolLabel(label, width)))
+}
+
+func agentStyle(color string) lipgloss.Style {
+	return toolCallStyle.Foreground(agentColor(color))
+}
+
+func agentColor(color string) kit.AdaptiveColor {
+	switch strings.ToLower(strings.TrimSpace(color)) {
+	case "blue":
+		return kit.CurrentTheme.Primary
+	case "yellow":
+		return kit.CurrentTheme.Warning
+	case "gray", "grey":
+		return kit.CurrentTheme.Muted
+	case "accent":
+		return kit.CurrentTheme.Accent
+	case "ai":
+		return kit.CurrentTheme.AI
+	case "green", "":
+		return kit.CurrentTheme.Success
+	default:
+		if strings.HasPrefix(color, "#") {
+			return kit.AdaptiveColor{Dark: color, Light: color}
+		}
+		return kit.CurrentTheme.Success
+	}
+}
+
+// configuredAgentColor returns the color set for this agent's type in its
+// subagent config (a name like "blue" or a "#rrggbb" hex), or "" when none is
+// set. It is later resolved to a theme color by agentColor.
+func configuredAgentColor(agent agentInput, colors map[string]string) string {
+	if len(colors) == 0 {
+		return ""
+	}
+	return colors[strings.ToLower(agent.Name)]
 }
 
 // agentBlinkTicks is the number of spinner ticks per ● / ○ swap.

--- a/internal/app/conv/tracker_view.go
+++ b/internal/app/conv/tracker_view.go
@@ -37,6 +37,11 @@ type TrackerListParams struct {
 	// Blink is the shared frame-tick counter (see FrameClock.Frame) that
 	// drives the in-progress pulse via trackerPulseTicks.
 	Blink int
+	// AgentColors maps an agent's name to its display color. An item owned by a
+	// background agent (Owner set) is tinted with that color, matching the
+	// agent's launch line in the flow. Plain user todos have no owner and keep
+	// the status palette.
+	AgentColors map[string]string
 }
 
 // RenderTrackerList renders the tracker panel above the input area.
@@ -87,7 +92,7 @@ func RenderTrackerList(params TrackerListParams) string {
 	// no worker can still be advancing.
 	for _, t := range visible {
 		phase := phaseOf(t, params.Executing != nil && params.Executing(t))
-		sb.WriteString(renderItem(t, phase, params.Width, idWidth, params.Blockers, params.Blink))
+		sb.WriteString(renderItem(t, phase, params.Width, idWidth, params.Blockers, params.Blink, params.AgentColors))
 	}
 
 	return sb.String()
@@ -159,12 +164,24 @@ func activeText(t *todo.Item, maxTextLen int) string {
 	return kit.TruncateText(text, maxTextLen)
 }
 
-func renderItem(t *todo.Item, phase itemPhase, width, idWidth int, blockers func(string) []string, blink int) string {
+func renderItem(t *todo.Item, phase itemPhase, width, idWidth int, blockers func(string) []string, blink int, agentColors map[string]string) string {
 	indent := "  "
 	idTag := fmt.Sprintf("%-*s", idWidth, "#"+t.ID)
 	maxTextLen := max(width-len(indent)-idWidth-8, 12)
 	subject := kit.TruncateText(t.Subject, maxTextLen)
 	mutedStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
+
+	// A row owned by a background agent wears that agent's color (icon + text),
+	// mirroring its launch line in the flow; a plain todo keeps the status
+	// palette. Aborted rows stay error-red and stalled rows stay muted — those
+	// states carry more meaning than whose agent produced them.
+	agentFg, owned := agentForeground(t, agentColors)
+	tint := func(s lipgloss.Style) lipgloss.Style {
+		if owned {
+			return s.Foreground(agentFg)
+		}
+		return s
+	}
 
 	switch phase {
 	case itemAborted:
@@ -173,7 +190,7 @@ func renderItem(t *todo.Item, phase itemPhase, width, idWidth int, blockers func
 		return renderItemLine(indent, abortedStyle.Render("!"), idTag, subject, detail)
 
 	case itemFinished:
-		return renderItemLine(indent, trackerCompletedStyle.Render("●"), idTag, subject, "")
+		return renderItemLine(indent, tint(trackerCompletedStyle).Render("●"), idTag, tint(lipgloss.NewStyle()).Render(subject), "")
 
 	case itemStalled:
 		// Nothing is executing this item, so draw it at rest. Reaching here
@@ -187,7 +204,7 @@ func renderItem(t *todo.Item, phase itemPhase, width, idWidth int, blockers func
 		// rather than the wall clock, which only sampled on redraws and so
 		// flickered irregularly.
 		activeIcon := "●"
-		activeStyle := trackerInProgressStyle
+		activeStyle := tint(trackerInProgressStyle)
 		if (blink/trackerPulseTicks)%2 == 1 {
 			activeIcon = "◌"
 			activeStyle = mutedStyle
@@ -196,7 +213,7 @@ func renderItem(t *todo.Item, phase itemPhase, width, idWidth int, blockers func
 		if elapsed := formatElapsedTime(t.StatusChangedAt); elapsed != "" {
 			detail = mutedStyle.Render(elapsed)
 		}
-		return renderItemLine(indent, activeStyle.Render(activeIcon), idTag, activeText(t, maxTextLen), detail)
+		return renderItemLine(indent, activeStyle.Render(activeIcon), idTag, tint(lipgloss.NewStyle()).Render(activeText(t, maxTextLen)), detail)
 
 	default:
 		detail := ""
@@ -210,8 +227,22 @@ func renderItem(t *todo.Item, phase itemPhase, width, idWidth int, blockers func
 				detail = blockedStyle.Render("← " + strings.Join(blockerRefs, ", "))
 			}
 		}
-		return renderItemLine(indent, trackerPendingStyle.Render("○"), idTag, subject, detail)
+		return renderItemLine(indent, tint(trackerPendingStyle).Render("○"), idTag, tint(lipgloss.NewStyle()).Render(subject), detail)
 	}
+}
+
+// agentForeground returns the owning agent's display color for an item, and
+// whether the item is owned by a colored agent at all — a plain user todo has no
+// owner, and an owner with no configured color resolves to nothing.
+func agentForeground(t *todo.Item, agentColors map[string]string) (kit.AdaptiveColor, bool) {
+	if t.Owner == "" || len(agentColors) == 0 {
+		return kit.AdaptiveColor{}, false
+	}
+	color, ok := agentColors[strings.ToLower(t.Owner)]
+	if !ok || color == "" {
+		return kit.AdaptiveColor{}, false
+	}
+	return agentColor(color), true
 }
 
 func renderItemLine(indent, icon, id, subject, detail string) string {

--- a/internal/app/conv/tracker_view_test.go
+++ b/internal/app/conv/tracker_view_test.go
@@ -71,7 +71,7 @@ func TestRenderTaskAnimatesInProgressItem(t *testing.T) {
 	// both the solid (●) and dim (◌) phases.
 	var hasSolid, hasDim bool
 	for blink := range 4 * trackerPulseTicks {
-		frame := stripANSI(renderItem(task, itemRunning, 80, 2, nil, blink))
+		frame := stripANSI(renderItem(task, itemRunning, 80, 2, nil, blink, nil))
 		if strings.Contains(frame, "●") {
 			hasSolid = true
 		}
@@ -123,9 +123,9 @@ func TestRenderTrackerListOrdersByID(t *testing.T) {
 func TestRenderTaskHoldsStillWhenStalled(t *testing.T) {
 	task := &todo.Item{ID: "1", Subject: "Fix auth module", Status: todo.StatusInProgress}
 
-	first := stripANSI(renderItem(task, itemStalled, 80, 2, nil, 0))
+	first := stripANSI(renderItem(task, itemStalled, 80, 2, nil, 0, nil))
 	for blink := range 4 * trackerPulseTicks {
-		if frame := stripANSI(renderItem(task, itemStalled, 80, 2, nil, blink)); frame != first {
+		if frame := stripANSI(renderItem(task, itemStalled, 80, 2, nil, blink, nil)); frame != first {
 			t.Fatalf("stalled task animated across frames:\n%q\n%q", first, frame)
 		}
 	}
@@ -201,6 +201,40 @@ func TestRenderTrackerListFoldsLeadingFinished(t *testing.T) {
 	}
 	if !strings.Contains(plain, "3 completed") {
 		t.Fatalf("folded finished items should be summarized, not dropped silently:\n%s", plain)
+	}
+}
+
+// A row owned by a background agent is tinted with that agent's color; a plain
+// todo keeps the status palette. The tint changes only color, never the text.
+func TestRenderItemTintsAgentOwnedRows(t *testing.T) {
+	item := &todo.Item{ID: "1", Subject: "Audit deps", Status: todo.StatusInProgress, Owner: "explorer"}
+	colors := map[string]string{"explorer": "yellow"}
+
+	plain := renderItem(item, itemRunning, 80, 2, nil, 0, nil)
+	tinted := renderItem(item, itemRunning, 80, 2, nil, 0, colors)
+
+	if stripANSI(plain) != stripANSI(tinted) {
+		t.Fatalf("agent tint changed the row text, not just its color:\n  %q\n  %q", stripANSI(plain), stripANSI(tinted))
+	}
+	if plain == tinted {
+		t.Fatalf("agent-owned row should be tinted with the agent color, got identical output:\n%q", tinted)
+	}
+}
+
+func TestAgentForeground(t *testing.T) {
+	colors := map[string]string{"explorer": "yellow"}
+
+	if _, ok := agentForeground(&todo.Item{Owner: "explorer"}, colors); !ok {
+		t.Fatal("agent-owned item should resolve its color")
+	}
+	if _, ok := agentForeground(&todo.Item{Owner: "Explorer"}, colors); !ok {
+		t.Fatal("owner lookup should be case-insensitive")
+	}
+	if _, ok := agentForeground(&todo.Item{Owner: ""}, colors); ok {
+		t.Fatal("a plain todo (no owner) must not resolve a color")
+	}
+	if _, ok := agentForeground(&todo.Item{Owner: "ghost"}, colors); ok {
+		t.Fatal("an owner with no configured color must not resolve one")
 	}
 }
 

--- a/internal/app/conv/view.go
+++ b/internal/app/conv/view.go
@@ -44,7 +44,8 @@ type RenderContext struct {
 	InputTokens  int
 	OutputTokens int
 
-	// ── Decorations (activity / ownership maps) ─────────────────
+	// ── Decorations (color / activity maps) ─────────────────────
+	AgentColors  map[string]string
 	TaskActivity map[int][]string
 	TaskOwnerMap map[string]string
 
@@ -264,6 +265,7 @@ func renderAssistantWithTools(p RenderContext, msg core.ChatMessage, idx int, is
 		InputTokens:       p.InputTokens,
 		OutputTokens:      p.OutputTokens,
 		Blink:             p.Blink,
+		AgentColors:       p.AgentColors,
 		SpinnerView:       p.SpinnerView,
 		TaskOwnerMap:      p.TaskOwnerMap,
 		MDRenderer:        p.MDRenderer,
@@ -327,6 +329,7 @@ func renderPendingToolSpinnerFromParams(p RenderContext, suppressAgentLabel bool
 		TaskActivity:            p.TaskActivity,
 		SpinnerView:             p.SpinnerView,
 		Blink:                   p.Blink,
+		AgentColors:             p.AgentColors,
 		Width:                   p.Width,
 		SuppressAgentLabel:      suppressAgentLabel,
 	})

--- a/internal/app/init.go
+++ b/internal/app/init.go
@@ -23,6 +23,7 @@ import (
 	"github.com/genai-io/san/internal/session"
 	"github.com/genai-io/san/internal/setting"
 	"github.com/genai-io/san/internal/skill"
+	"github.com/genai-io/san/internal/subagent"
 	"github.com/genai-io/san/internal/task"
 	"github.com/genai-io/san/internal/todo"
 	"github.com/genai-io/san/internal/tool"
@@ -92,15 +93,18 @@ func initExtensions(cwd string) {
 		DynamicProviders:   []func() []command.Info{skillCommandInfos},
 		PluginCommandPaths: pluginCommandPaths,
 	})
+	if err := subagent.Initialize(subagent.Options{CWD: cwd, PluginAgentPaths: pluginAgentPaths}); err != nil {
+		log.Logger().Warn("Failed to initialize subagent", zap.Error(err))
+	}
 	if err := mcp.Initialize(mcp.Options{CWD: cwd, PluginServers: pluginMCPServers}); err != nil {
 		log.Logger().Warn("Failed to initialize mcp", zap.Error(err))
 	}
 }
 
 // discoverPlugins scans the working directory for plugins. Run on a cwd change
-// so the new project's plugins (and their command / MCP / hook contributions)
-// replace the previous project's before reloadProjectServices rebuilds the
-// project's feature services.
+// so the new project's plugins (and their command / agent / MCP / hook
+// contributions) replace the previous project's before reloadProjectServices
+// rebuilds the project's feature services.
 func discoverPlugins(cwd string) {
 	if err := plugin.Initialize(context.Background(), plugin.Options{CWD: cwd}); err != nil {
 		log.Logger().Warn("Failed to initialize plugin", zap.Error(err))
@@ -111,7 +115,8 @@ func discoverPlugins(cwd string) {
 // current project — its config dirs plus the active plugins' contributions —
 // and re-points the services struct at the fresh instances. Both halves live
 // here so the Initialize set and the Default()-regrab set cannot drift. The
-// five: settings, skills, commands, MCP servers, personas. Plugins themselves are not rebuilt here — discoverPlugins does that on a cwd change,
+// six: settings, skills, commands, subagents, MCP servers, personas. Plugins
+// themselves are not rebuilt here — discoverPlugins does that on a cwd change,
 // and a plugin load (--plugin-dir or /plugin install) has already done it.
 func (m *model) reloadProjectServices(cwd string) {
 	setting.Initialize(setting.Options{CWD: cwd})
@@ -128,6 +133,11 @@ func (m *model) reloadProjectServices(cwd string) {
 	})
 	m.services.Command = command.Default()
 
+	if err := subagent.Initialize(subagent.Options{CWD: cwd, PluginAgentPaths: pluginAgentPaths}); err != nil {
+		log.Logger().Warn("Failed to initialize subagent", zap.Error(err))
+	}
+	m.services.Subagent = subagent.Default()
+
 	if err := mcp.Initialize(mcp.Options{CWD: cwd, PluginServers: pluginMCPServers}); err != nil {
 		log.Logger().Warn("Failed to initialize mcp", zap.Error(err))
 	}
@@ -142,6 +152,19 @@ func pluginCommandPaths() []command.PluginCommandPath {
 	paths := make([]command.PluginCommandPath, len(pPaths))
 	for i, p := range pPaths {
 		paths[i] = command.PluginCommandPath{
+			Path:      p.Path,
+			Namespace: p.Namespace,
+			IsProject: p.Scope == plugin.ScopeProject || p.Scope == plugin.ScopeLocal,
+		}
+	}
+	return paths
+}
+
+func pluginAgentPaths() []subagent.PluginAgentPath {
+	pPaths := plugin.GetPluginAgentPaths()
+	paths := make([]subagent.PluginAgentPath, len(pPaths))
+	for i, p := range pPaths {
+		paths[i] = subagent.PluginAgentPath{
 			Path:      p.Path,
 			Namespace: p.Namespace,
 			IsProject: p.Scope == plugin.ScopeProject || p.Scope == plugin.ScopeLocal,
@@ -190,6 +213,27 @@ func commandSuggestionMatcher(cmdSvc *command.Registry) func(string) []suggest.S
 		}
 		return result
 	}
+}
+
+type agentRegistryAdapter struct {
+	reg *subagent.Registry
+}
+
+func (a *agentRegistryAdapter) ListConfigs() []tool.AgentConfigInfo {
+	configs := a.reg.ListConfigs()
+	out := make([]tool.AgentConfigInfo, len(configs))
+	for i, cfg := range configs {
+		out[i] = subagent.ToAgentConfigInfo(cfg)
+	}
+	return out
+}
+
+func (a *agentRegistryAdapter) GetDisabledAt(userLevel bool) map[string]bool {
+	return a.reg.GetDisabledAt(userLevel)
+}
+
+func (a *agentRegistryAdapter) SetEnabled(name string, enabled bool, userLevel bool) error {
+	return a.reg.SetEnabled(name, enabled, userLevel)
 }
 
 func skillCommandInfos() []command.Info {

--- a/internal/app/input/model.go
+++ b/internal/app/input/model.go
@@ -56,6 +56,7 @@ type Model struct {
 	Secret   SecretPromptModel
 
 	// Self-contained selectors.
+	Agent     AgentSelector
 	Persona   PersonaSelector
 	Search    SearchSelector
 	Plugin    PluginSelector
@@ -108,6 +109,7 @@ func (img *ImageState) RemoveAt(idx int) {
 }
 
 type SelectorDeps struct {
+	AgentRegistry   func() AgentRegistry
 	PersonaRegistry *corepersona.Registry
 	SkillRegistry   *coreskill.Registry
 	MCPRegistry     *coremcp.Registry
@@ -132,6 +134,7 @@ func New(cwd string, width int, matchFunc suggest.Matcher, deps SelectorDeps) Mo
 
 		Approval:  NewApproval(),
 		Secret:    NewSecretPrompt(),
+		Agent:     NewAgentSelector(deps.AgentRegistry),
 		Persona:   NewPersonaSelector(deps.PersonaRegistry, deps.Setting),
 		Search:    NewSearchSelector(deps.Setting),
 		Skill:     SkillState{Selector: NewSkillSelector(deps.SkillRegistry)},

--- a/internal/app/input/on_agent.go
+++ b/internal/app/input/on_agent.go
@@ -1,0 +1,292 @@
+package input
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/genai-io/san/internal/app/kit"
+	"github.com/genai-io/san/internal/tool"
+)
+
+// AgentRegistry provides agent display and management for the selector UI.
+type AgentRegistry interface {
+	ListConfigs() []tool.AgentConfigInfo
+	GetDisabledAt(userLevel bool) map[string]bool
+	SetEnabled(name string, enabled bool, userLevel bool) error
+}
+
+// agentTab identifies a category tab in the agent selector. The values double
+// as indices into the selector's tabbedList tab order.
+type agentTab int
+
+const (
+	agentTabProject agentTab = iota
+	agentTabUser
+)
+
+type agentItem struct {
+	Name           string
+	Description    string
+	Model          string
+	PermissionMode string
+	Tools          string
+	Source         string // "user", "project", or plugin scope
+	PluginName     string // populated when Source == "plugin" or name has "ns:" prefix
+	Enabled        bool
+}
+
+// AgentToggleMsg is sent when an agent's enabled state is toggled.
+type AgentToggleMsg struct {
+	AgentName string
+	Enabled   bool
+	Err       error
+}
+
+// AgentSelector holds the state for the agent selector overlay. The tab/filter/
+// keypress/frame mechanics live in the embedded tabbedList; this type owns
+// agent loading, the row layout, and the enable/disable action.
+type AgentSelector struct {
+	registry func() AgentRegistry
+	list     tabbedList[agentItem]
+}
+
+func NewAgentSelector(reg func() AgentRegistry) AgentSelector {
+	return AgentSelector{
+		registry: reg,
+		list: tabbedList[agentItem]{
+			tabs: []tabSpec{
+				{name: "Project"},
+				{name: "User"},
+			},
+			preferred:   []int{int(agentTabProject), int(agentTabUser)},
+			noun:        "agents",
+			placeholder: "Type to filter agents...",
+			hints:       []string{"↑/↓ navigate", "Enter toggle", "←/→/Tab switch tab", "Esc cancel"},
+			matchesTab:  agentMatchesTab,
+			searchKeys:  func(a agentItem) []string { return []string{a.Name, a.Description} },
+			nav:         kit.ListNav{MaxVisible: 10},
+		},
+	}
+}
+
+// EnterSelect activates the selector and loads agents from the registry.
+func (s *AgentSelector) EnterSelect(width, height int) error {
+	registry := s.registry()
+	allConfigs := registry.ListConfigs()
+	disabledByLevel := map[bool]map[string]bool{
+		false: registry.GetDisabledAt(false),
+		true:  registry.GetDisabledAt(true),
+	}
+
+	agents := make([]agentItem, 0, len(allConfigs))
+	for _, cfg := range allConfigs {
+		lowerName := strings.ToLower(cfg.Name)
+		var pluginName string
+		if idx := strings.Index(cfg.Name, ":"); idx > 0 {
+			pluginName = cfg.Name[:idx]
+		}
+		source := cfg.Source
+		// Disabled state lookup uses the user-level map for user agents and the
+		// project-level map for project and plugin agents.
+		userLevel := source == "user" || source == "user-plugin"
+		agents = append(agents, agentItem{
+			Name:           cfg.Name,
+			Description:    cfg.Description,
+			Model:          cfg.Model,
+			PermissionMode: formatAgentPermMode(cfg.PermissionMode),
+			Tools:          formatAgentTools(cfg.Tools),
+			Source:         source,
+			PluginName:     pluginName,
+			Enabled:        !disabledByLevel[userLevel][lowerName],
+		})
+	}
+
+	s.list.load(agents, width, height)
+	return nil
+}
+
+func formatAgentPermMode(mode string) string {
+	switch mode {
+	case "explore":
+		return "explore"
+	case "edit":
+		return "edit"
+	case "default", "":
+		return "default"
+	default:
+		return mode
+	}
+}
+
+func formatAgentTools(tools []string) string {
+	if tools == nil {
+		return "all tools"
+	}
+	if len(tools) == 0 {
+		return "none"
+	}
+	return strings.Join(tools, ", ")
+}
+
+func (s *AgentSelector) IsActive() bool { return s.list.active }
+
+// agentMatchesTab returns true when an agent belongs to the given tab.
+// Plugin agents are folded into Project or User tab depending on install path
+// (a "user-plugin" source is treated as User; bare "plugin" defaults to Project).
+func agentMatchesTab(a agentItem, tab int) bool {
+	switch agentTab(tab) {
+	case agentTabProject:
+		return a.Source == "project" || a.Source == "plugin" || a.Source == "project-plugin"
+	case agentTabUser:
+		return a.Source == "user" || a.Source == "user-plugin"
+	}
+	return false
+}
+
+func (s *AgentSelector) saveLevelForActiveTab() bool {
+	// User agents persist at user level; Project agents persist at project level.
+	return s.list.activeTab == int(agentTabUser)
+}
+
+func (s *AgentSelector) Toggle() tea.Cmd {
+	if len(s.list.filtered) == 0 || s.list.nav.Selected >= len(s.list.filtered) {
+		return nil
+	}
+	selected := &s.list.filtered[s.list.nav.Selected]
+	enabled := !selected.Enabled
+	if err := s.registry().SetEnabled(selected.Name, enabled, s.saveLevelForActiveTab()); err != nil {
+		return func() tea.Msg {
+			return AgentToggleMsg{AgentName: selected.Name, Enabled: selected.Enabled, Err: err}
+		}
+	}
+	selected.Enabled = enabled
+	for i := range s.list.items {
+		if s.list.items[i].Name == selected.Name {
+			s.list.items[i].Enabled = enabled
+			break
+		}
+	}
+	return func() tea.Msg {
+		return AgentToggleMsg{AgentName: selected.Name, Enabled: enabled}
+	}
+}
+
+func (s *AgentSelector) HandleKeypress(key tea.KeyMsg) tea.Cmd {
+	return s.list.handleKey(key, s.Toggle)
+}
+
+// ── Rendering ──────────────────────────────────────────────────────────────────
+
+func (s *AgentSelector) Render() string {
+	return s.list.render(s.renderItemList)
+}
+
+func (s *AgentSelector) renderItemList(sb *strings.Builder, panel kit.Panel) {
+	startIdx, endIdx := s.list.nav.VisibleRange()
+
+	if startIdx > 0 {
+		sb.WriteString(kit.MoreAbove())
+		sb.WriteString("\n")
+	}
+
+	// Compute name column width based on visible items so the model/mode
+	// columns align nicely while still adapting to long names.
+	maxNameLen := 12
+	for i := startIdx; i < endIdx; i++ {
+		if w := lipgloss.Width(s.list.filtered[i].Name); w > maxNameLen {
+			maxNameLen = w
+		}
+	}
+	maxNameLen = min(maxNameLen, 28)
+
+	descStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
+	badge := kit.BadgeStyle()
+
+	for i := startIdx; i < endIdx; i++ {
+		a := s.list.filtered[i]
+
+		var statusIcon string
+		var statusStyle lipgloss.Style
+		if a.Enabled {
+			statusIcon = "●"
+			statusStyle = kit.SelectorStatusConnected()
+		} else {
+			statusIcon = "○"
+			statusStyle = kit.SelectorStatusNone()
+		}
+
+		// Pad by display width, not bytes: one CJK agent name would otherwise
+		// shift the model, mode and badge columns on that row only.
+		name := kit.TruncateText(a.Name, maxNameLen)
+		paddedName := name + strings.Repeat(" ", max(0, maxNameLen-lipgloss.Width(name)))
+
+		model := kit.TruncateText(a.Model, 14)
+		paddedModel := model + strings.Repeat(" ", max(0, 14-lipgloss.Width(model)))
+
+		mode := kit.TruncateText(a.PermissionMode, 8)
+		paddedMode := mode + strings.Repeat(" ", max(0, 8-lipgloss.Width(mode)))
+
+		// Reserve room for an inline source badge on the right.
+		badgeText := ""
+		if a.PluginName != "" {
+			badgeText = "[Plugin: " + a.PluginName + "]"
+		}
+
+		// Width budget for one row, accounting for the panel's Padding(1, 2)
+		// (4 cols total) plus the row's own decoration:
+		//   2 ("> ") + 1 (icon) + 1 (space) + name + 2 (sep) +
+		//   14 (model) + 2 (sep) + 8 (mode) + 2 (sep) + tools
+		//   [+ 1 space + badge]
+		// The trailing -4 is a right-margin safety buffer.
+		rowFixed := 2 + 1 + 1 + maxNameLen + 2 + 14 + 2 + 8 + 2
+		if badgeText != "" {
+			rowFixed += 1 + len(badgeText)
+		}
+		toolsWidth := max(8, panel.ContentWidth()-4-rowFixed-4)
+		tools := kit.TruncateText(a.Tools, toolsWidth)
+
+		line := fmt.Sprintf("%s %s  %s  %s  %s",
+			statusStyle.Render(statusIcon),
+			paddedName,
+			paddedModel,
+			paddedMode,
+			descStyle.Render(tools),
+		)
+		if badgeText != "" {
+			line += " " + badge.Render(badgeText)
+		}
+
+		// Render the row without the selector row styles' PaddingLeft(2) so
+		// the row's left edge lines up with tabs/search/
+		// separator. Width(...) right-pads each row to the full inner content
+		// area so the right edge also matches the separator line.
+		rowWidth := max(20, panel.ContentWidth()-4)
+		sb.WriteString(kit.RenderPanelRow(line, i == s.list.nav.Selected, rowWidth))
+		sb.WriteString("\n")
+
+		// Description sub-line aligned under the agent name (4 cols in:
+		// 2 cursor + 1 icon + 1 space).
+		if i == s.list.nav.Selected && a.Description != "" {
+			subStyle := lipgloss.NewStyle().
+				Foreground(kit.CurrentTheme.Muted).
+				PaddingLeft(4)
+			descLineWidth := max(10, panel.ContentWidth()-8)
+			sb.WriteString(subStyle.Render(kit.TruncateText(a.Description, descLineWidth)))
+			sb.WriteString("\n")
+		}
+
+		// Spacer for breathing room between rows (skip after the last item;
+		// PadViewport will handle the trailing blank lines).
+		if i < endIdx-1 {
+			sb.WriteString("\n")
+		}
+	}
+
+	if endIdx < len(s.list.filtered) {
+		sb.WriteString(kit.MoreBelow())
+		sb.WriteString("\n")
+	}
+}

--- a/internal/app/input/on_agent_test.go
+++ b/internal/app/input/on_agent_test.go
@@ -1,0 +1,128 @@
+package input
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/genai-io/san/internal/subagent"
+	"github.com/genai-io/san/internal/tool"
+)
+
+type agentRegistryStub struct {
+	configs  []tool.AgentConfigInfo
+	disabled map[bool]map[string]bool
+	setName  string
+	setState bool
+	setUser  bool
+	setErr   error
+}
+
+func (s *agentRegistryStub) ListConfigs() []tool.AgentConfigInfo { return s.configs }
+func (s *agentRegistryStub) GetDisabledAt(user bool) map[string]bool {
+	return s.disabled[user]
+}
+func (s *agentRegistryStub) SetEnabled(name string, enabled, user bool) error {
+	s.setName, s.setState, s.setUser = name, enabled, user
+	return s.setErr
+}
+
+func TestAgentSelectorListsCustomAgentsAndTogglesTheirScope(t *testing.T) {
+	reg := &agentRegistryStub{
+		configs: []tool.AgentConfigInfo{
+			{Name: "project-reviewer", Source: "project"},
+			{Name: "user-researcher", Source: "user"},
+		},
+		disabled: map[bool]map[string]bool{false: {}, true: {}},
+	}
+	selector := NewAgentSelector(func() AgentRegistry { return reg })
+	if err := selector.EnterSelect(100, 40); err != nil {
+		t.Fatal(err)
+	}
+	if len(selector.list.items) != 2 {
+		t.Fatalf("listed agents = %d, want 2", len(selector.list.items))
+	}
+	if selector.list.activeTab != int(agentTabProject) {
+		t.Fatalf("active tab = %d, want project", selector.list.activeTab)
+	}
+
+	cmd := selector.Toggle()
+	if cmd == nil {
+		t.Fatal("toggle returned no command")
+	}
+	msg, ok := cmd().(AgentToggleMsg)
+	if !ok || msg.AgentName != "project-reviewer" || msg.Enabled {
+		t.Fatalf("toggle message = %#v, want disabled project-reviewer", msg)
+	}
+	if reg.setName != "project-reviewer" || reg.setState || reg.setUser {
+		t.Fatalf("SetEnabled args = %q, %v, %v", reg.setName, reg.setState, reg.setUser)
+	}
+
+	selector.list.activeTab = int(agentTabUser)
+	selector.list.filtered = []agentItem{{Name: "user-researcher", Source: "user", Enabled: true}}
+	selector.list.nav.Selected = 0
+	selector.Toggle()
+	if reg.setName != "user-researcher" || !reg.setUser {
+		t.Fatalf("user SetEnabled args = %q, user=%v", reg.setName, reg.setUser)
+	}
+}
+
+func TestAgentSelectorToggleFailureLeavesStateUnchanged(t *testing.T) {
+	reg := &agentRegistryStub{
+		configs:  []tool.AgentConfigInfo{{Name: "reviewer", Source: "project"}},
+		disabled: map[bool]map[string]bool{false: {}, true: {}},
+		setErr:   errors.New("read-only filesystem"),
+	}
+	selector := NewAgentSelector(func() AgentRegistry { return reg })
+	if err := selector.EnterSelect(100, 40); err != nil {
+		t.Fatal(err)
+	}
+
+	msg, ok := selector.Toggle()().(AgentToggleMsg)
+	if !ok || msg.Err == nil {
+		t.Fatalf("toggle message = %#v, want persistence error", msg)
+	}
+	if !selector.list.filtered[0].Enabled || !selector.list.items[0].Enabled {
+		t.Fatal("failed toggle changed the displayed state")
+	}
+}
+
+func TestAgentSelectorTogglePersistsThroughRegistryStore(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cwd := t.TempDir()
+
+	reg := subagent.NewRegistry()
+	reg.Register(&subagent.AgentConfig{Name: "project-reviewer", Source: "project"})
+	if err := reg.InitStores(cwd); err != nil {
+		t.Fatal(err)
+	}
+	adapter := &agentRegistryAdapterForTest{reg: reg}
+	selector := NewAgentSelector(func() AgentRegistry { return adapter })
+	if err := selector.EnterSelect(100, 40); err != nil {
+		t.Fatal(err)
+	}
+	selector.Toggle()
+
+	reloaded := subagent.NewAgentStore(filepath.Join(cwd, ".san", "agents.json"))
+	if !reloaded.IsDisabled("project-reviewer") {
+		t.Fatal("project agent disabled state was not persisted")
+	}
+}
+
+type agentRegistryAdapterForTest struct{ reg *subagent.Registry }
+
+func (a *agentRegistryAdapterForTest) ListConfigs() []tool.AgentConfigInfo {
+	configs := a.reg.ListConfigs()
+	out := make([]tool.AgentConfigInfo, len(configs))
+	for i, config := range configs {
+		out[i] = subagent.ToAgentConfigInfo(config)
+	}
+	return out
+}
+func (a *agentRegistryAdapterForTest) GetDisabledAt(user bool) map[string]bool {
+	return a.reg.GetDisabledAt(user)
+}
+func (a *agentRegistryAdapterForTest) SetEnabled(name string, enabled, user bool) error {
+	return a.reg.SetEnabled(name, enabled, user)
+}

--- a/internal/app/input/on_plugin.go
+++ b/internal/app/input/on_plugin.go
@@ -483,6 +483,7 @@ func (s *PluginSelector) refreshInstalledPlugins() {
 			Enabled:     p.Enabled,
 			Path:        p.Path,
 			Skills:      len(p.Components.Skills),
+			Agents:      len(p.Components.Agents),
 			Commands:    len(p.Components.Commands),
 			MCP:         len(p.Components.MCP),
 			LSP:         len(p.Components.LSP),

--- a/internal/app/input/on_plugin_command.go
+++ b/internal/app/input/on_plugin_command.go
@@ -109,6 +109,9 @@ func pluginFormatComponentCounts(p *coreplugin.Plugin) []string {
 	if n := len(p.Components.Skills); n > 0 {
 		components = append(components, fmt.Sprintf("%d skills", n))
 	}
+	if n := len(p.Components.Agents); n > 0 {
+		components = append(components, fmt.Sprintf("%d agents", n))
+	}
 	if n := len(p.Components.Commands); n > 0 {
 		components = append(components, fmt.Sprintf("%d commands", n))
 	}
@@ -179,6 +182,7 @@ func pluginHandleInfo(reg *coreplugin.Registry, name string) (string, error) {
 	sb.WriteString("\nComponents:\n")
 	pluginWriteComponentCount(&sb, "Commands", len(p.Components.Commands))
 	pluginWriteComponentCount(&sb, "Skills", len(p.Components.Skills))
+	pluginWriteComponentCount(&sb, "Agents", len(p.Components.Agents))
 	if p.Components.Hooks != nil {
 		pluginWriteComponentCount(&sb, "Hook events", len(p.Components.Hooks.Hooks))
 	}
@@ -258,7 +262,7 @@ func pluginHandleInstall(reg *coreplugin.Registry, ctx context.Context, cwd stri
 	}
 
 	return fmt.Sprintf(
-		"Installed plugin '%s' to %s scope.\n\nRun /reload-plugins to refresh skills, commands, MCP servers, and hooks.",
+		"Installed plugin '%s' to %s scope.\n\nRun /reload-plugins to refresh skills, agents, MCP servers, and hooks.",
 		ref,
 		scope,
 	), nil

--- a/internal/app/input/on_plugin_model.go
+++ b/internal/app/input/on_plugin_model.go
@@ -41,6 +41,7 @@ type pluginItem struct {
 	Enabled     bool
 	Path        string
 	Skills      int
+	Agents      int
 	Commands    int
 	Hooks       int
 	MCP         int

--- a/internal/app/input/on_plugin_test.go
+++ b/internal/app/input/on_plugin_test.go
@@ -192,6 +192,7 @@ func TestRenderInstalledDetailShowsStructuredSections(t *testing.T) {
 		Enabled:     true,
 		Scope:       coreplugin.ScopeProject,
 		Skills:      1,
+		Agents:      2,
 		Hooks:       1,
 	}
 	m.actions = []pluginAction{{Label: "Disable plugin", Action: "disable"}, {Label: "Back", Action: "back"}}

--- a/internal/app/input/on_plugin_view.go
+++ b/internal/app/input/on_plugin_view.go
@@ -787,6 +787,7 @@ func pluginBuildComponentList(p *pluginItem) []string {
 	}
 	counts := []componentCount{
 		{"✦", "Skills", p.Skills},
+		{"⚑", "Agents", p.Agents},
 		{"⌘", "Commands", p.Commands},
 		{"↪", "Hooks", p.Hooks},
 		{"☉", "MCP Servers", p.MCP},

--- a/internal/app/input/slash_command.go
+++ b/internal/app/input/slash_command.go
@@ -110,6 +110,7 @@ func builtinCommandHandlers() map[string]slashCommandHandler {
 		"help":           (*SlashCommandController).handleHelpCommand,
 		"tools":          (*SlashCommandController).handleToolCommand,
 		"skills":         (*SlashCommandController).handleSkillCommand,
+		"agents":         (*SlashCommandController).handleAgentCommand,
 		"tokenlimit":     (*SlashCommandController).handleTokenLimitCommand,
 		"compact":        (*SlashCommandController).handleCompactCommand,
 		"init":           (*SlashCommandController).handleInitCommand,
@@ -507,6 +508,13 @@ func (c *SlashCommandController) handleToolCommand(_ context.Context, _ string) 
 
 func (c *SlashCommandController) handleSkillCommand(_ context.Context, _ string) (string, tea.Cmd, error) {
 	if err := c.env.Input.Skill.Selector.EnterSelect(c.env.Width, c.env.Height); err != nil {
+		return "", nil, err
+	}
+	return "", nil, nil
+}
+
+func (c *SlashCommandController) handleAgentCommand(_ context.Context, _ string) (string, tea.Cmd, error) {
+	if err := c.env.Input.Agent.EnterSelect(c.env.Width, c.env.Height); err != nil {
 		return "", nil, err
 	}
 	return "", nil, nil

--- a/internal/app/kit/panel_test.go
+++ b/internal/app/kit/panel_test.go
@@ -9,7 +9,7 @@ import (
 
 // TestRenderPanelTabsCount confirms a tab's count is rendered only when it is
 // greater than zero — so count-less tabs (e.g. /config) show just their name
-// instead of a stray "0", while count-bearing tabs (e.g. skills) keep it.
+// instead of a stray "0", while count-bearing tabs (skills/agents) keep it.
 func TestRenderPanelTabsCount(t *testing.T) {
 	tabs := []PanelTab{
 		{Name: "withcount", Count: 7, Show: true},

--- a/internal/app/model_actions.go
+++ b/internal/app/model_actions.go
@@ -48,6 +48,7 @@ func (m *model) setActivePersona(name string) error {
 	// Skills (immediate): swap the in-memory persona skill set, then re-emit
 	// the skills-directory reminder so the model sees it on the next turn.
 	m.applyPersonaSkills()
+	m.applyPersonaAgents()
 	m.services.Reminder.RequeueSystemReminders()
 
 	// Prompt (immediate): hot-patch the running main agent's parts.
@@ -119,5 +120,6 @@ func (m *model) deletePersona(name string) error {
 	}
 	m.services.Persona.Reload()
 	m.applyPersonaSkills()
+	m.applyPersonaAgents()
 	return nil
 }

--- a/internal/app/model_lifecycle.go
+++ b/internal/app/model_lifecycle.go
@@ -16,6 +16,7 @@ import (
 	"github.com/genai-io/san/internal/broker"
 	"github.com/genai-io/san/internal/hook"
 	"github.com/genai-io/san/internal/setting"
+	"github.com/genai-io/san/internal/subagent"
 	"github.com/genai-io/san/internal/task"
 	"github.com/genai-io/san/internal/todo"
 )
@@ -38,6 +39,7 @@ func newModel(opts setting.RunOptions) (*model, error) {
 	m.ensureMemoryContextLoaded()
 	m.ReconfigureAgentTool()
 	m.applyPersonaSkills()
+	m.applyPersonaAgents()
 	m.wireReminderProviders()
 	m.InitTaskStorage()
 	m.userInput.Autopilot.SetMissionRefiner(m.missionRefine)
@@ -55,6 +57,9 @@ func newBaseModel() model {
 	applyStartupSettings(&environment, svc.Setting.Snapshot(), appCwd, svc.Setting.AllowBypass(), svc.Hook)
 	return model{
 		userInput: input.New(appCwd, defaultWidth, commandSuggestionMatcher(svc.Command), input.SelectorDeps{
+			AgentRegistry: func() input.AgentRegistry {
+				return &agentRegistryAdapter{reg: subagent.Default()}
+			},
 			PersonaRegistry: svc.Persona,
 			SkillRegistry:   svc.Skill,
 			MCPRegistry:     svc.MCP,
@@ -145,6 +150,7 @@ func (m *model) ReloadAfterPluginChange() error {
 	m.syncSettingsToHookEngine()
 	m.ReconfigureAgentTool()
 	m.applyPersonaSkills()
+	m.applyPersonaAgents()
 
 	// Refresh skills/memory reminders so the LLM sees the updated skill set
 	// in the next user message instead of waiting for SessionStart/PostCompact.

--- a/internal/app/model_scrollback_test.go
+++ b/internal/app/model_scrollback_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/genai-io/san/internal/app/input"
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/subagent"
 	"github.com/genai-io/san/internal/todo"
 	"github.com/genai-io/san/internal/tool/toolresult"
 )
@@ -232,7 +233,8 @@ func TestConsecutiveToolCommitsStayOutOfManagedFrameAndPrintOnceInOrder(t *testi
 		conv:      conv.NewModel(100),
 		userInput: input.New("", 100, nil, input.SelectorDeps{}),
 		services: services{
-			Tracker: todo.NewStore(),
+			Subagent: subagent.NewRegistry(),
+			Tracker:  todo.NewStore(),
 		},
 	}
 

--- a/internal/app/model_workspace.go
+++ b/internal/app/model_workspace.go
@@ -38,6 +38,9 @@ func (m *model) ReloadProjectContext(cwd string) {
 	// feature services that depend on them and re-point at them.
 	discoverPlugins(cwd)
 	m.reloadProjectServices(cwd)
+	m.applyPersonaSkills()
+	m.applyPersonaAgents()
+	m.services.Reminder.RequeueSystemReminders()
 	m.syncSettingsToHookEngine()
 }
 
@@ -47,6 +50,7 @@ func (m *model) reloadPersonasIfChanged(filePath string) {
 	}
 	m.services.Persona.Reload()
 	m.applyPersonaSkills()
+	m.applyPersonaAgents()
 	m.ReconfigureAgentTool()
 }
 

--- a/internal/app/run_agent.go
+++ b/internal/app/run_agent.go
@@ -11,12 +11,16 @@ import (
 	"syscall"
 
 	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/plugin"
+	"github.com/genai-io/san/internal/skill"
 	"github.com/genai-io/san/internal/subagent"
 	"github.com/genai-io/san/internal/tool"
+	"github.com/genai-io/san/internal/tool/fs"
 )
 
 // AgentRunOptions configures a one-shot headless agent run.
 type AgentRunOptions struct {
+	Name     string // optional custom agent name; empty uses the default agent
 	Prompt   string // task prompt (required)
 	Model    string // model override; empty uses the connected provider's model
 	MaxSteps int    // maximum LLM inference steps
@@ -46,18 +50,33 @@ func RunAgent(opts AgentRunOptions) error {
 
 	cwd, _ := os.Getwd()
 
+	if err := plugin.Initialize(ctx, plugin.Options{CWD: cwd}); err != nil {
+		return fmt.Errorf("failed to initialize plugins: %w", err)
+	}
+	skill.Initialize(skill.Options{CWD: cwd, PluginSkillPaths: pluginSkillPaths})
+	if err := subagent.Initialize(subagent.Options{CWD: cwd, PluginAgentPaths: pluginAgentPaths}); err != nil {
+		return fmt.Errorf("failed to initialize subagent registry: %w", err)
+	}
+	fs.SetEnvProvider(plugin.PluginEnv)
+
 	// Run through the full subagent pipeline so headless invocations get the
-	// same fixed permission gate and runtime mode policy as TUI-spawned
-	// subagents.
+	// same permission gate (deny_tools / confirmation floor / allow_tools / mode)
+	// as TUI-spawned subagents.
 	executor := subagent.NewExecutor(resolved.Provider, cwd, resolved.ModelID, nil)
 	executor.SetResolver(llm.NewProviderPool(store))
 	executor.SetModelStore(store, resolved.ProviderName, resolved.AuthMethod)
+	executor.SetSkillsDirectory(skill.Default().PromptSection())
 
-	fmt.Println("Agent: subagent")
+	name := opts.Name
+	if name == "" {
+		name = "subagent"
+	}
+	fmt.Printf("Agent: %s\n", name)
 	fmt.Printf("Prompt: %s\n", opts.Prompt)
 	fmt.Println("---")
 
 	req := tool.AgentExecRequest{
+		Agent:    opts.Name,
 		Prompt:   opts.Prompt,
 		Model:    opts.Model,
 		MaxSteps: opts.MaxSteps,

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -17,6 +17,7 @@ import (
 	"github.com/genai-io/san/internal/session"
 	"github.com/genai-io/san/internal/setting"
 	"github.com/genai-io/san/internal/skill"
+	"github.com/genai-io/san/internal/subagent"
 	"github.com/genai-io/san/internal/task"
 	"github.com/genai-io/san/internal/todo"
 	"github.com/genai-io/san/internal/tool"
@@ -32,6 +33,7 @@ type services struct {
 	Hook     *hook.Engine
 	Session  *session.Setup
 	Skill    *skill.Registry
+	Subagent *subagent.Registry
 	Command  *command.Registry
 	Task     *task.Manager
 	Tracker  todo.Service
@@ -98,6 +100,7 @@ func newServices() services {
 		Hook:      hook.DefaultEngine(),
 		Session:   session.Default(),
 		Skill:     skill.Default(),
+		Subagent:  subagent.Default(),
 		Command:   command.Default(),
 		Task:      task.Default(),
 		Tracker:   todo.Default(),

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -68,6 +68,7 @@ func (m *model) overlayPanels() []overlayPanel {
 		&m.userInput.Provider.Selector, // fullscreen slash-command pickers
 		&m.userInput.Tool,
 		&m.userInput.Skill.Selector,
+		&m.userInput.Agent,
 		&m.userInput.Persona,
 		&m.userInput.MCP.Selector,
 		&m.userInput.Plugin,
@@ -250,6 +251,22 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// PostCompact. Without this nudge the LLM sees stale state until
 		// one of those fires.
 		m.services.Reminder.RequeueSystemReminders()
+		return m, nil
+	case input.AgentToggleMsg:
+		if msg.Err != nil {
+			m.conv.AddNotice("Failed to update agent: " + msg.Err.Error())
+			return m, nil
+		}
+		// Why stop on toggle: the agents directory lives in the Agent tool's
+		// description, which is frozen at agent build time. Stopping forces
+		// ensureAgentSession to rebuild on the next user turn with the new
+		// directory. Why guard on Stream.Active: stopping mid-stream would
+		// orphan in-flight tool calls and the partial assistant turn —
+		// leave the toggle pending; ensureAgentSession will see the updated
+		// store the next time it actually rebuilds.
+		if m.services.Agent.Active() && !m.conv.Stream.Active {
+			m.StopAgentSession()
+		}
 		return m, nil
 	case persistSessionDoneMsg:
 		if msg.err != nil {

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -11,6 +11,7 @@ import (
 	"github.com/genai-io/san/internal/app/input"
 	"github.com/genai-io/san/internal/app/kit"
 	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/subagent"
 	"github.com/genai-io/san/internal/todo"
 )
 
@@ -266,6 +267,7 @@ func (m *model) renderTrackerList() string {
 		Blockers:     m.services.Tracker.OpenBlockers,
 		Executing:    m.executingTrackerItem,
 		Blink:        m.conv.Spinner.Frame(),
+		AgentColors:  m.agentColors(),
 	})
 }
 
@@ -349,12 +351,31 @@ func (m model) messageRenderParams() conv.RenderContext {
 		OutputTokens: m.env.OutputTokens,
 
 		// Decorations
+		AgentColors:  m.agentColors(),
 		TaskActivity: m.conv.TaskActivity,
 		TaskOwnerMap: buildTaskOwnerMap(m.services.Tracker.List()),
 
 		// Modal interlock
 		InteractivePromptActive: m.conv.Modal.Question != nil && m.conv.Modal.Question.IsActive(),
 	}
+}
+
+func (m model) agentColors() map[string]string {
+	return buildAgentColors(m.services.Subagent.ListConfigs())
+}
+
+func buildAgentColors(configs []*subagent.AgentConfig) map[string]string {
+	if len(configs) == 0 {
+		return nil
+	}
+	colors := make(map[string]string, len(configs))
+	for _, cfg := range configs {
+		if cfg == nil || cfg.Color == "" {
+			continue
+		}
+		colors[strings.ToLower(cfg.Name)] = cfg.Color
+	}
+	return colors
 }
 
 func buildTaskOwnerMap(tasks []*todo.Item) map[string]string {

--- a/internal/core/tool.go
+++ b/internal/core/tool.go
@@ -29,8 +29,8 @@ type ToolSchema struct {
 
 // Tools is a mutable, queryable collection of tools.
 //
-// Can change dynamically: hooks add/remove tools, MCP servers connect or
-// disconnect, and parent agents filter child tool sets.
+// Can change dynamically: hooks add/remove tools, agent definitions
+// restrict to read-only, parent agents filter child tool sets.
 type Tools interface {
 	Get(name string) Tool
 	All() []Tool

--- a/internal/inspector/ui/assets/app.js
+++ b/internal/inspector/ui/assets/app.js
@@ -125,7 +125,7 @@ function permInputSummary(tool, input) {
     case "Skill":
       return input.skill ? "/" + input.skill : "";
     case "Agent":
-      return input.description ? "→ " + truncate(input.description, 64) : "";
+      return input.name ? "→ " + input.name : "";
     case "Glob":
     case "Grep":
       return input.pattern ? truncate(input.pattern, 48) : "";

--- a/internal/persona/persona_test.go
+++ b/internal/persona/persona_test.go
@@ -51,16 +51,17 @@ func TestParseDir_LoadsParts(t *testing.T) {
 	}
 }
 
-func TestParseDir_IgnoresRemovedAgentAllowList(t *testing.T) {
+func TestParseDir_ParsesAgentAllowList(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "p")
 	writeFile(t, filepath.Join(dir, "settings.json"),
-		`{"description":"x","agents":["explorer","code-reviewer"]}`)
+		`{"description":"x","agents":["explorer","project-reviewer"]}`)
 	p, ok := parseDir(dir)
 	if !ok {
 		t.Fatal("expected persona to load")
 	}
-	if p.Settings == nil || p.Settings.Description != "x" {
-		t.Errorf("settings not parsed after ignoring legacy agents field: %+v", p.Settings)
+	if p.Settings == nil || len(p.Settings.Agents) != 2 ||
+		p.Settings.Agents[0] != "explorer" || p.Settings.Agents[1] != "project-reviewer" {
+		t.Errorf("agents allow-list not parsed: %+v", p.Settings)
 	}
 }
 

--- a/internal/persona/settings.go
+++ b/internal/persona/settings.go
@@ -17,9 +17,15 @@ import (
 // Skills maps a skill name to "active" / "enable" / "disable". These states
 // apply in-memory while the persona is selected and are never written to
 // skills.json.
+//
+// Agents is an allow-list of subagent names: when non-empty, only those agent
+// types are visible (spawnable + shown in the agents directory) while the
+// persona is selected. Empty/omitted = all subagents visible. Like Skills, it
+// is applied in-memory and never written to the agent enable/disable stores.
 type Settings struct {
 	Description string            `json:"description,omitempty"`
 	Skills      map[string]string `json:"skills,omitempty"`
+	Agents      []string          `json:"agents,omitempty"`
 
 	// Embedded so the overlay fields (permissions, disabledTools, model, …)
 	// sit at the top level of settings.json, e.g. {"disabledTools": {...}}.

--- a/internal/plugin/integration.go
+++ b/internal/plugin/integration.go
@@ -1,5 +1,5 @@
 // Package plugin provides integration helpers for loading plugin components
-// into the skill, hooks, command, and MCP registries.
+// into the skill, agent, hooks, and MCP registries.
 package plugin
 
 import (
@@ -13,6 +13,11 @@ import (
 // GetPluginSkillPaths returns all skill directory paths from enabled plugins.
 func GetPluginSkillPaths() []PluginPath {
 	return collectPluginPaths(func(p *Plugin) []string { return p.Components.Skills })
+}
+
+// GetPluginAgentPaths returns all agent file paths from enabled plugins.
+func GetPluginAgentPaths() []PluginPath {
+	return collectPluginPaths(func(p *Plugin) []string { return p.Components.Agents })
 }
 
 // GetPluginCommandPaths returns all command file paths from enabled plugins.

--- a/internal/plugin/loader.go
+++ b/internal/plugin/loader.go
@@ -85,6 +85,7 @@ func resolveComponents(manifest *Manifest, pluginPath string) Components {
 	return Components{
 		Commands: ResolveCommands(manifest, pluginPath),
 		Skills:   ResolveSkills(manifest, pluginPath),
+		Agents:   ResolveAgents(manifest, pluginPath),
 		Hooks:    ResolveHooksConfig(manifest.Hooks, pluginPath),
 		MCP:      ResolveMCPServers(manifest.MCPServers, pluginPath),
 		LSP:      ResolveLSPServers(manifest.LSPServers, pluginPath),

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -119,6 +119,21 @@ Say hello!
 		t.Fatal(err)
 	}
 
+	// Create agents directory
+	agentsDir := filepath.Join(tmpDir, "agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	agentContent := `---
+name: test-agent
+description: A test agent
+---
+You are a test agent.
+`
+	if err := os.WriteFile(filepath.Join(agentsDir, "test-agent.md"), []byte(agentContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
 	// Load the plugin
 	plugin, err := LoadPlugin(tmpDir, ScopeUser, "test-plugin@test")
 	if err != nil {
@@ -144,6 +159,9 @@ Say hello!
 	// Verify components were resolved
 	if len(plugin.Components.Skills) != 1 {
 		t.Errorf("Plugin skills count = %d, want 1", len(plugin.Components.Skills))
+	}
+	if len(plugin.Components.Agents) != 1 {
+		t.Errorf("Plugin agents count = %d, want 1", len(plugin.Components.Agents))
 	}
 }
 

--- a/internal/plugin/resolver.go
+++ b/internal/plugin/resolver.go
@@ -112,6 +112,12 @@ func ResolveSkills(manifest *Manifest, pluginPath string) []string {
 	return skills
 }
 
+// ResolveAgents resolves agent file paths from the plugin.
+func ResolveAgents(manifest *Manifest, pluginPath string) []string {
+	paths := ResolvePaths(manifest.Agents, pluginPath, []string{"agents"})
+	return collectMarkdownFiles(paths)
+}
+
 // collectMarkdownFiles collects markdown files from a list of paths.
 // Each path can be a file or directory.
 func collectMarkdownFiles(paths []string) []string {

--- a/internal/plugin/service.go
+++ b/internal/plugin/service.go
@@ -1,12 +1,13 @@
 // Package plugin loads, installs, and enables plugin bundles that
-// contribute skills, slash commands, MCP servers, hooks, and env vars to the
-// host application.
+// contribute skills, subagent definitions, slash commands, MCP servers,
+// hooks, and env vars to the host application.
 //
-// The package exposes *Registry directly. Plugin's cross-domain outputs (skill
-// paths, command paths, MCP servers, hooks, and env vars) are consumed via the
-// package-level free functions in integration.go — each downstream consumer
-// pulls what it needs. There is no shared narrow surface for a producer-side
-// role interface.
+// The package exposes *Registry directly. Plugin's many cross-domain
+// outputs (agent paths, skill paths, command paths, MCP servers, hooks,
+// env vars) are consumed via the package-level free functions in
+// integration.go — each downstream consumer (skill / subagent / command
+// / mcp / setting) pulls what it needs. There is no shared narrow
+// surface for a producer-side role interface.
 package plugin
 
 import "context"

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -95,6 +95,9 @@ type Components struct {
 	// Skills are paths to skill directories (containing SKILL.md)
 	Skills []string
 
+	// Agents are paths to agent markdown files
+	Agents []string
+
 	// Hooks is the parsed hooks configuration
 	Hooks *HooksConfig
 
@@ -156,6 +159,7 @@ type Manifest struct {
 	// Component path fields - can be string, []string, or inline object
 	// Use any type and resolve during loading
 	Commands   any `json:"commands,omitempty"`
+	Agents     any `json:"agents,omitempty"`
 	Skills     any `json:"skills,omitempty"`
 	Hooks      any `json:"hooks,omitempty"`
 	MCPServers any `json:"mcpServers,omitempty"`

--- a/internal/subagent/executor_test.go
+++ b/internal/subagent/executor_test.go
@@ -752,6 +752,24 @@ func TestResolveAgentConfigUsesDefaultAndCustomDefinitions(t *testing.T) {
 	}
 }
 
+func TestResolveAgentConfigRejectsDisabledDefinition(t *testing.T) {
+	old := Default()
+	SetDefaultRegistry(NewRegistry())
+	t.Cleanup(func() { SetDefaultRegistry(old) })
+
+	registry := Default()
+	registry.Register(&AgentConfig{Name: "reviewer"})
+	if err := registry.InitStores(t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.SetEnabled("reviewer", false, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := resolveAgentConfig("reviewer"); ok {
+		t.Fatal("disabled custom agent should not resolve")
+	}
+}
+
 func TestExecutorUsesRegistryCapturedAtConstruction(t *testing.T) {
 	old := Default()
 	projectA := NewRegistry()

--- a/internal/subagent/lazy_loading_test.go
+++ b/internal/subagent/lazy_loading_test.go
@@ -1,0 +1,72 @@
+package subagent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAgentLazyLoading(t *testing.T) {
+	// Create a temporary agent file
+	tmpDir := t.TempDir()
+	agentFile := filepath.Join(tmpDir, "test-agent.md")
+
+	agentContent := `---
+name: test-lazy-agent
+description: A test agent for lazy loading verification
+model: opus
+---
+
+This is the full system prompt content that should NOT be loaded at startup.
+It contains detailed instructions for the agent.
+
+## Instructions
+1. Do something
+2. Do something else
+`
+	if err := os.WriteFile(agentFile, []byte(agentContent), 0o644); err != nil {
+		t.Fatalf("Failed to create test agent file: %v", err)
+	}
+
+	// Parse the agent file (simulating startup)
+	config, err := parseAgentFile(agentFile)
+	if err != nil {
+		t.Fatalf("Failed to parse agent file: %v", err)
+	}
+
+	// Verify metadata is loaded
+	if config.Name != "test-lazy-agent" {
+		t.Errorf("Name not loaded: got %q", config.Name)
+	}
+	if config.Description != "A test agent for lazy loading verification" {
+		t.Errorf("Description not loaded: got %q", config.Description)
+	}
+	if config.Model != "opus" {
+		t.Errorf("Model not loaded: got %q", config.Model)
+	}
+
+	// Verify SystemPrompt is NOT loaded at parse time (lazy loading)
+	if config.SystemPrompt != "" {
+		t.Errorf("SystemPrompt should be empty at parse time, got: %q", config.SystemPrompt)
+	}
+
+	// Now call GetSystemPrompt() to trigger lazy loading
+	prompt := config.GetSystemPrompt()
+
+	// Verify the full content is now loaded
+	if prompt == "" {
+		t.Error("GetSystemPrompt() should return the full content")
+	}
+	if config.SystemPrompt == "" {
+		t.Error("SystemPrompt should be populated after GetSystemPrompt()")
+	}
+
+	// Verify it contains the expected content
+	if len(prompt) < 50 {
+		t.Errorf("System prompt seems too short: %d chars", len(prompt))
+	}
+
+	t.Logf("✓ Metadata loaded at startup (name=%s, desc=%s, model=%s)",
+		config.Name, config.Description[:20]+"...", config.Model)
+	t.Logf("✓ SystemPrompt loaded lazily (%d chars)", len(prompt))
+}

--- a/internal/subagent/loader.go
+++ b/internal/subagent/loader.go
@@ -1,12 +1,211 @@
 package subagent
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/genai-io/san/internal/confdir"
 	"github.com/genai-io/san/internal/log"
 	"github.com/genai-io/san/internal/markdown"
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
 )
 
-// LoadAgentSystemPrompt loads just the system prompt body from an Agent file.
+// PluginAgentPath represents a plugin agent path with namespace metadata.
+type PluginAgentPath struct {
+	Path      string
+	Namespace string
+	IsProject bool
+}
+
+// agentSearchPath represents an agent search location with optional namespace.
+type agentSearchPath struct {
+	path      string
+	namespace string // Default namespace for agents in this path (from plugin)
+	source    string
+}
+
+// LoadCustomAgents replaces the package registry with custom definitions from
+// the standard locations. Production initialization uses loadCustomAgents so it
+// can include plugin paths and install the complete registry atomically.
+func LoadCustomAgents(cwd string) {
+	registry := NewRegistry()
+	loadCustomAgents(cwd, registry, nil)
+	setDefaultRegistry(registry)
+}
+
+func loadCustomAgents(cwd string, registry *Registry, pluginPaths func() []PluginAgentPath) {
+	homeDir, _ := os.UserHomeDir()
+
+	priorityOrdered := []agentSearchPath{
+		{path: filepath.Join(confdir.Dir(cwd), "agents")},
+		{path: filepath.Join(confdir.Dir(homeDir), "agents")},
+		{path: filepath.Join(cwd, ".claude", "agents")},
+		{path: filepath.Join(homeDir, ".claude", "agents")},
+	}
+	if pluginPaths != nil {
+		for _, plugin := range pluginPaths() {
+			source := "user-plugin"
+			if plugin.IsProject {
+				source = "project-plugin"
+			}
+			priorityOrdered = append(priorityOrdered, agentSearchPath{path: plugin.Path, namespace: plugin.Namespace, source: source})
+		}
+	}
+
+	for i := len(priorityOrdered) - 1; i >= 0; i-- {
+		sp := priorityOrdered[i]
+		loadAgentsFromDirWithNamespace(registry, sp.path, sp.namespace, sp.source)
+	}
+}
+
+// loadAgentsFromDirWithNamespace loads agents with an optional namespace prefix.
+// The path can be either a directory (scanned for .md files) or a direct file path.
+func loadAgentsFromDirWithNamespace(registry *Registry, path string, namespace string, source ...string) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return
+	}
+
+	// If path is a file, load it directly
+	if !info.IsDir() {
+		if strings.HasSuffix(path, ".md") {
+			loadAgentFromFileWithNamespace(registry, path, namespace, source...)
+		}
+		return
+	}
+
+	// Path is a directory, scan for .md files
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".md") {
+			continue
+		}
+
+		filePath := filepath.Join(path, name)
+		loadAgentFromFileWithNamespace(registry, filePath, namespace, source...)
+	}
+}
+
+// loadAgentFromFileWithNamespace loads an agent with optional namespace.
+func loadAgentFromFileWithNamespace(registry *Registry, filePath string, namespace string, source ...string) {
+	config, err := parseAgentFile(filePath)
+	if err != nil {
+		log.Logger().Debug("Failed to parse agent file",
+			zap.String("path", filePath),
+			zap.Error(err))
+		return
+	}
+
+	if config != nil {
+		if namespace != "" {
+			localName := config.Name
+			if _, suffix, ok := strings.Cut(localName, ":"); ok {
+				localName = suffix
+			}
+			config.Name = namespace + ":" + localName
+		}
+		if len(source) > 0 && source[0] != "" {
+			config.Source = source[0]
+		}
+
+		registry.Register(config)
+		log.Logger().Info("Loaded custom agent",
+			zap.String("name", config.Name),
+			zap.String("source", filePath))
+	}
+}
+
+// frontmatterAliases are alternate key spellings accepted in agent
+// frontmatter: `tools` is Claude Code's key, the hyphenated forms are the
+// spellings docs/guides/writing-a-subagent.md documents. Canonical keys on
+// AgentConfig win when both are present.
+type frontmatterAliases struct {
+	Tools          ToolList       `yaml:"tools"`
+	AllowedTools   ToolList       `yaml:"allowed-tools"`
+	PermissionMode PermissionMode `yaml:"permission-mode"`
+	MaxSteps       int            `yaml:"max_steps"`
+}
+
+func (a frontmatterAliases) applyTo(config *AgentConfig) {
+	if config.AllowTools == nil {
+		if a.AllowedTools != nil {
+			config.AllowTools = a.AllowedTools
+		} else if a.Tools != nil {
+			config.AllowTools = a.Tools
+		}
+	}
+	if config.PermissionMode == "" && a.PermissionMode != "" {
+		config.PermissionMode = a.PermissionMode
+	}
+	if config.MaxSteps <= 0 && a.MaxSteps > 0 {
+		config.MaxSteps = a.MaxSteps
+	}
+}
+
+// parseAgentFile parses an AGENT.md file with YAML frontmatter.
+func parseAgentFile(filePath string) (*AgentConfig, error) {
+	frontmatter, _, err := markdown.ParseFrontmatterFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	if frontmatter == "" {
+		return nil, nil
+	}
+
+	var config AgentConfig
+	if err := yaml.Unmarshal([]byte(frontmatter), &config); err != nil {
+		return nil, err
+	}
+	var aliases frontmatterAliases
+	if err := yaml.Unmarshal([]byte(frontmatter), &aliases); err == nil {
+		aliases.applyTo(&config)
+	}
+
+	config.PermissionMode = NormalizePermissionMode(string(config.PermissionMode))
+
+	config.Name = strings.TrimSpace(config.Name)
+	if config.Name == "" {
+		config.Name = strings.TrimSuffix(filepath.Base(filePath), ".md")
+	}
+	if config.Model == "" {
+		config.Model = "inherit"
+	}
+	if config.MaxSteps <= 0 {
+		config.MaxSteps = defaultMaxSteps
+	}
+	if config.PermissionMode == "" {
+		config.PermissionMode = PermissionDefault
+	}
+
+	// Body is lazily loaded via GetSystemPrompt()
+	config.SourceFile = filePath
+
+	if config.Source == "" {
+		homeDir, _ := os.UserHomeDir()
+		switch {
+		case strings.HasPrefix(filePath, filepath.Join(confdir.Dir(homeDir), "agents")),
+			strings.HasPrefix(filePath, filepath.Join(homeDir, ".claude", "agents")):
+			config.Source = "user"
+		default:
+			config.Source = "project"
+		}
+	}
+
+	return &config, nil
+}
+
+// LoadAgentSystemPrompt loads just the system prompt (body) from an agent file.
 func LoadAgentSystemPrompt(filePath string) string {
 	_, body, err := markdown.ParseFrontmatterFile(filePath)
 	if err != nil {

--- a/internal/subagent/loader_priority_test.go
+++ b/internal/subagent/loader_priority_test.go
@@ -1,0 +1,139 @@
+package subagent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeAgentFile(t *testing.T, dir, name, frontmatter string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "---\n" + frontmatter + "\n---\n\nBody.\n"
+	if err := os.WriteFile(filepath.Join(dir, name+".md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadCustomAgentsProjectOverridesClaudeCompat(t *testing.T) {
+	SetDefaultRegistry(NewRegistry())
+	t.Cleanup(ResetDefaultRegistry)
+
+	cwd := t.TempDir()
+	writeAgentFile(t, filepath.Join(cwd, ".san", "agents"), "reviewer",
+		"name: reviewer\ndescription: san project reviewer")
+	writeAgentFile(t, filepath.Join(cwd, ".claude", "agents"), "reviewer",
+		"name: reviewer\ndescription: claude compat reviewer")
+
+	LoadCustomAgents(cwd)
+
+	config, ok := Default().Get("reviewer")
+	if !ok {
+		t.Fatal("reviewer not registered")
+	}
+	if config.Description != "san project reviewer" {
+		t.Fatalf("description = %q, want the .san definition to win", config.Description)
+	}
+}
+
+func TestParseAgentFileTrimsFrontmatterName(t *testing.T) {
+	dir := t.TempDir()
+	writeAgentFile(t, dir, "trimmed", "name: '  reviewer  '\ndescription: trims names")
+
+	config, err := parseAgentFile(filepath.Join(dir, "trimmed.md"))
+	if err != nil {
+		t.Fatalf("parseAgentFile: %v", err)
+	}
+	if config.Name != "reviewer" {
+		t.Fatalf("name = %q, want reviewer", config.Name)
+	}
+}
+
+func TestPluginAgentSourceTracksScope(t *testing.T) {
+	dir := t.TempDir()
+	writeAgentFile(t, dir, "reviewer", "name: reviewer\ndescription: plugin reviewer")
+
+	registry := NewRegistry()
+	loadCustomAgents(t.TempDir(), registry, func() []PluginAgentPath {
+		return []PluginAgentPath{{Path: filepath.Join(dir, "reviewer.md"), Namespace: "example", IsProject: false}}
+	})
+	config, ok := registry.Get("example:reviewer")
+	if !ok || config.Source != "user-plugin" {
+		t.Fatalf("user plugin config = %#v, %v; want user-plugin source", config, ok)
+	}
+
+	registry = NewRegistry()
+	loadCustomAgents(t.TempDir(), registry, func() []PluginAgentPath {
+		return []PluginAgentPath{{Path: filepath.Join(dir, "reviewer.md"), Namespace: "example", IsProject: true}}
+	})
+	config, ok = registry.Get("example:reviewer")
+	if !ok || config.Source != "project-plugin" {
+		t.Fatalf("project plugin config = %#v, %v; want project-plugin source", config, ok)
+	}
+}
+
+func TestPluginAgentCannotEscapeContributingNamespace(t *testing.T) {
+	dir := t.TempDir()
+	writeAgentFile(t, dir, "reviewer", "name: other:reviewer\ndescription: plugin reviewer")
+
+	registry := NewRegistry()
+	loadCustomAgents(t.TempDir(), registry, func() []PluginAgentPath {
+		return []PluginAgentPath{{Path: filepath.Join(dir, "reviewer.md"), Namespace: "example", IsProject: true}}
+	})
+	if _, ok := registry.Get("other:reviewer"); ok {
+		t.Fatal("plugin agent escaped its contributing namespace")
+	}
+	if _, ok := registry.Get("example:reviewer"); !ok {
+		t.Fatal("plugin agent was not forced into its contributing namespace")
+	}
+}
+
+func TestParseAgentFileAcceptsFrontmatterAliases(t *testing.T) {
+	dir := t.TempDir()
+	writeAgentFile(t, dir, "test-runner",
+		"name: test-runner\ndescription: runs tests\nallowed-tools: [Bash, Read, Grep]\npermission-mode: bypass")
+
+	config, err := parseAgentFile(filepath.Join(dir, "test-runner.md"))
+	if err != nil {
+		t.Fatalf("parseAgentFile: %v", err)
+	}
+	if got := config.AllowTools.Names(); len(got) != 3 || got[0] != "Bash" {
+		t.Fatalf("allowed-tools alias not applied: %#v", got)
+	}
+	if config.PermissionMode != PermissionBypass {
+		t.Fatalf("permission-mode alias = %q, want bypass", config.PermissionMode)
+	}
+}
+
+func TestParseAgentFileAcceptsClaudeCodeToolsKey(t *testing.T) {
+	dir := t.TempDir()
+	writeAgentFile(t, dir, "cc-agent",
+		"name: cc-agent\ndescription: cc compat\ntools: Read, Grep")
+
+	config, err := parseAgentFile(filepath.Join(dir, "cc-agent.md"))
+	if err != nil {
+		t.Fatalf("parseAgentFile: %v", err)
+	}
+	if got := config.AllowTools.Names(); len(got) != 2 || got[0] != "Read" || got[1] != "Grep" {
+		t.Fatalf("tools alias not applied: %#v", got)
+	}
+}
+
+func TestParseAgentFileCanonicalKeysWinOverAliases(t *testing.T) {
+	dir := t.TempDir()
+	writeAgentFile(t, dir, "mixed",
+		"name: mixed\ndescription: both spellings\nallow_tools: [Read]\ntools: [Bash]\nmode: explore\npermission-mode: bypass")
+
+	config, err := parseAgentFile(filepath.Join(dir, "mixed.md"))
+	if err != nil {
+		t.Fatalf("parseAgentFile: %v", err)
+	}
+	if got := config.AllowTools.Names(); len(got) != 1 || got[0] != "Read" {
+		t.Fatalf("canonical allow_tools should win: %#v", got)
+	}
+	if config.PermissionMode != PermissionExplore {
+		t.Fatalf("canonical mode should win, got %q", config.PermissionMode)
+	}
+}

--- a/internal/subagent/registry.go
+++ b/internal/subagent/registry.go
@@ -1,22 +1,27 @@
 package subagent
 
 import (
+	"sort"
 	"strings"
 	"sync"
 )
 
-// Registry manages custom agent definitions in memory.
+// Registry manages custom agent definitions.
 type Registry struct {
-	mu     sync.RWMutex
-	agents map[string]*AgentConfig
+	mu           sync.RWMutex
+	agents       map[string]*AgentConfig
+	userStore    *AgentStore     // User-level enabled/disabled states
+	projectStore *AgentStore     // Project-level enabled/disabled states
+	personaAllow map[string]bool // active persona's visible-agent allow-list (nil = no restriction)
+	cwd          string          // Current working directory
 }
 
-// NewRegistry creates an empty registry.
+// NewRegistry creates an empty registry for user, project, and plugin-defined agents.
 func NewRegistry() *Registry {
 	return &Registry{agents: make(map[string]*AgentConfig)}
 }
 
-// Register adds an agent configuration to the registry.
+// Register adds an agent configuration to the registry
 func (r *Registry) Register(config *AgentConfig) {
 	config.Name = strings.TrimSpace(config.Name)
 	if config.Name == "" {
@@ -27,26 +32,217 @@ func (r *Registry) Register(config *AgentConfig) {
 	r.agents[strings.ToLower(config.Name)] = config
 }
 
-// Get retrieves an agent configuration by name.
+// Get retrieves an agent configuration by name
 func (r *Registry) Get(name string) (*AgentConfig, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	config, ok := r.agents[strings.ToLower(strings.TrimSpace(name))]
+	config, ok := r.agents[strings.ToLower(name)]
 	return config, ok
 }
 
-// Resolve returns a custom agent configuration by exact name.
+// Resolve returns an enabled custom agent configuration by exact name.
 func (r *Registry) Resolve(name string) (*AgentConfig, bool) {
-	return r.Get(name)
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	lowerName := strings.ToLower(strings.TrimSpace(name))
+	config, ok := r.agents[lowerName]
+	if !ok || r.isDisabledInternal(lowerName) {
+		return nil, false
+	}
+	return config, true
 }
 
-// ListConfigs returns all registered agent configurations.
+// ListConfigs returns all registered agent configurations that are visible
+// under the active persona allow-list.
 func (r *Registry) ListConfigs() []*AgentConfig {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	configs := make([]*AgentConfig, 0, len(r.agents))
-	for _, config := range r.agents {
+	for name, config := range r.agents {
+		if r.personaAllow != nil && !r.personaAllow[name] {
+			continue
+		}
 		configs = append(configs, config)
 	}
 	return configs
+}
+
+// InitStores initializes the user and project stores for enabled/disabled state
+func (r *Registry) InitStores(cwd string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.cwd = cwd
+	r.userStore = NewUserAgentStore()
+	r.projectStore = NewProjectAgentStore(cwd)
+	return nil
+}
+
+// IsEnabled returns whether an agent is enabled
+// An agent is enabled unless explicitly disabled in either store
+// Project-level settings take priority over user-level
+func (r *Registry) IsEnabled(name string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	lowerName := strings.ToLower(name)
+
+	// The active persona's allow-list restricts the visible set: an agent not
+	// on it is treated as disabled while that persona is selected.
+	if r.personaAllow != nil && !r.personaAllow[lowerName] {
+		return false
+	}
+
+	// Check project store first (higher priority)
+	if r.projectStore != nil && r.projectStore.IsDisabled(lowerName) {
+		return false
+	}
+
+	// Check user store
+	if r.userStore != nil && r.userStore.IsDisabled(lowerName) {
+		return false
+	}
+
+	return true
+}
+
+// SetEnabled sets the enabled state for an agent at the specified level.
+// Used by internal/app's agentRegistryAdapter.
+func (r *Registry) SetEnabled(name string, enabled bool, userLevel bool) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	lowerName := strings.ToLower(name)
+
+	if userLevel {
+		if r.userStore != nil {
+			return r.userStore.SetDisabled(lowerName, !enabled)
+		}
+	} else {
+		if r.projectStore != nil {
+			return r.projectStore.SetDisabled(lowerName, !enabled)
+		}
+	}
+	return nil
+}
+
+// GetDisabledAt returns the disabled agents from the specified level.
+// Used by internal/app's agentRegistryAdapter.
+func (r *Registry) GetDisabledAt(userLevel bool) map[string]bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if userLevel {
+		if r.userStore != nil {
+			return r.userStore.GetDisabled()
+		}
+	} else {
+		if r.projectStore != nil {
+			return r.projectStore.GetDisabled()
+		}
+	}
+	return make(map[string]bool)
+}
+
+// LoadPersona restricts the visible agent set to an allow-list while a persona
+// is active: only the named agents are spawnable and shown in the agents
+// directory. An empty/blank list clears the restriction (all agents visible).
+// In-memory only — never written to the user/project enable-disable stores, so
+// it composes with them and disappears when the persona is cleared.
+func (r *Registry) LoadPersona(allow []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	m := make(map[string]bool, len(allow))
+	for _, n := range allow {
+		if n = strings.ToLower(strings.TrimSpace(n)); n != "" {
+			m[n] = true
+		}
+	}
+	if len(m) == 0 {
+		r.personaAllow = nil
+		return
+	}
+	r.personaAllow = m
+}
+
+// ClearPersona removes any persona allow-list, making all agents visible again
+// (subject to the user/project enable-disable stores).
+func (r *Registry) ClearPersona() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.personaAllow = nil
+}
+
+// isDisabledInternal checks if an agent is disabled (must be called with lock held)
+func (r *Registry) isDisabledInternal(name string) bool {
+	if r.personaAllow != nil && !r.personaAllow[name] {
+		return true
+	}
+	if r.projectStore != nil && r.projectStore.IsDisabled(name) {
+		return true
+	}
+	if r.userStore != nil && r.userStore.IsDisabled(name) {
+		return true
+	}
+	return false
+}
+
+// GetAgentsSection returns the body of the agents directory for the system
+// prompt. Only enabled agents, sorted by name (deterministic output).
+//
+// Returns plain body text without the outer XML tag; the system catalog
+// wraps it in <agents>…</agents>.
+func (r *Registry) GetAgentsSection() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	type entry struct {
+		name, desc, whenToUse, tools string
+	}
+
+	var entries []entry
+	for name, config := range r.agents {
+		if r.isDisabledInternal(name) {
+			continue
+		}
+		toolsDesc := "*"
+		if config.AllowTools != nil {
+			toolsDesc = strings.Join(config.AllowTools.DisplayNames(), ", ")
+		}
+		entries = append(entries, entry{
+			name:      config.Name,
+			desc:      config.Description,
+			whenToUse: config.WhenToUse,
+			tools:     toolsDesc,
+		})
+	}
+
+	if len(entries) == 0 {
+		return ""
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].name < entries[j].name
+	})
+
+	var sb strings.Builder
+	sb.WriteString("Available custom agents for the Agent tool:\n\n")
+	for i, e := range entries {
+		sb.WriteString("- " + e.name + ": " + e.desc)
+		if e.whenToUse != "" {
+			sb.WriteString("\n  Use when: " + e.whenToUse)
+		}
+		sb.WriteString("\n  Tools: " + e.tools)
+		if i < len(entries)-1 {
+			sb.WriteString("\n")
+		}
+	}
+	return sb.String()
+}
+
+// PromptSection returns the rendered prompt section for available agents.
+func (r *Registry) PromptSection() string {
+	return r.GetAgentsSection()
 }

--- a/internal/subagent/registry_persona_test.go
+++ b/internal/subagent/registry_persona_test.go
@@ -1,0 +1,67 @@
+package subagent
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLoadPersona_AllowListRestrictsVisibility checks that a persona allow-list
+// hides every agent not on it (spawn gate + agents directory), is
+// case-insensitive, and is fully reversible.
+func TestLoadPersona_AllowListRestrictsVisibility(t *testing.T) {
+	r := NewRegistry()
+	r.Register(&AgentConfig{Name: "reviewer", Description: "Reviews changes"})
+	r.Register(&AgentConfig{Name: "implementer", Description: "Implements changes"})
+
+	if !r.IsEnabled("reviewer") || !r.IsEnabled("implementer") {
+		t.Fatal("custom agents should be enabled with no persona allow-list")
+	}
+
+	// One-agent allow-list: only it stays visible.
+	r.LoadPersona([]string{"reviewer"})
+	if !r.IsEnabled("reviewer") {
+		t.Error("an allowed agent should stay enabled")
+	}
+	if r.IsEnabled("implementer") {
+		t.Error("agents off the allow-list should be hidden")
+	}
+	section := r.GetAgentsSection()
+	if !strings.Contains(section, "reviewer") {
+		t.Error("agents directory should list the allowed agent")
+	}
+	if strings.Contains(section, "implementer") {
+		t.Error("agents directory should omit non-allowed agents")
+	}
+	configs := r.ListConfigs()
+	if len(configs) != 1 || configs[0].Name != "reviewer" {
+		t.Fatalf("selector configs = %#v, want only reviewer", configs)
+	}
+
+	// The implicit default is not a registered custom agent and remains
+	// available when a persona restricts the custom catalog.
+	old := Default()
+	SetDefaultRegistry(r)
+	t.Cleanup(func() { SetDefaultRegistry(old) })
+	if config, ok := resolveAgentConfig(""); !ok || config.Name != defaultAgentName {
+		t.Fatalf("implicit default config = %#v, %v", config, ok)
+	}
+
+	// Case-insensitive + whitespace-trimmed.
+	r.LoadPersona([]string{" Reviewer "})
+	if !r.IsEnabled("reviewer") {
+		t.Error("allow-list match should be case-insensitive and trimmed")
+	}
+
+	// A blank/empty list is treated as no restriction.
+	r.LoadPersona([]string{"", "  "})
+	if !r.IsEnabled("implementer") {
+		t.Error("a blank allow-list should impose no restriction")
+	}
+
+	// ClearPersona restores everything.
+	r.LoadPersona([]string{"reviewer"})
+	r.ClearPersona()
+	if !r.IsEnabled("reviewer") || !r.IsEnabled("implementer") {
+		t.Error("ClearPersona should make all custom agents visible again")
+	}
+}

--- a/internal/subagent/service.go
+++ b/internal/subagent/service.go
@@ -1,17 +1,52 @@
-// Package subagent owns custom Agent runtime configuration and execution.
+// Package subagent owns the registry of custom agent definitions (markdown
+// files under ~/.san/agents/ and <project>/.san/agents/) plus the
+// *Executor that spawns one of them as a background core.Agent for a
+// single invocation.
+//
+// The package exposes the concrete *Registry directly — no Service
+// interface. The four production caller sites use four different
+// subsets of *Registry's surface (Get from cmd; ListConfigs from
+// view; PromptSection from agent.go; the whole registry from the TUI
+// selector via an adapter). No shared narrow surface → no role
+// interface earns its keep. TEMPLATE Rule 3.
+//
+// Executor construction goes through the package-level NewExecutor
+// free function (in executor.go), not through any method on *Registry.
 package subagent
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+)
 
-// Default returns the package-level registry.
+// Options holds all dependencies for initialization.
+type Options struct {
+	CWD              string
+	PluginAgentPaths func() []PluginAgentPath
+}
+
+// Initialize loads custom agents from all sources and initializes state stores.
+func Initialize(opts Options) error {
+	registry := NewRegistry()
+	loadCustomAgents(opts.CWD, registry, opts.PluginAgentPaths)
+	if err := registry.InitStores(opts.CWD); err != nil {
+		return fmt.Errorf("failed to initialize agent stores: %w", err)
+	}
+	setDefaultRegistry(registry)
+	return nil
+}
+
+// Default returns the package-level *Registry. The registry is
+// initialized to an empty state at package load and populated by
+// Initialize().
 func Default() *Registry {
 	registryMu.RLock()
 	defer registryMu.RUnlock()
 	return defaultRegistry
 }
 
-// SetDefaultRegistry replaces the package-level registry. Intended for tests.
-// A nil argument restores a fresh empty registry.
+// SetDefaultRegistry replaces the package-level registry. Intended for
+// tests. A nil argument restores a fresh empty *Registry.
 func SetDefaultRegistry(r *Registry) {
 	if r == nil {
 		r = NewRegistry()
@@ -19,7 +54,8 @@ func SetDefaultRegistry(r *Registry) {
 	setDefaultRegistry(r)
 }
 
-// ResetDefaultRegistry restores a fresh empty registry. Intended for tests.
+// ResetDefaultRegistry restores a fresh empty *Registry. Intended for
+// tests.
 func ResetDefaultRegistry() {
 	setDefaultRegistry(NewRegistry())
 }

--- a/internal/subagent/store.go
+++ b/internal/subagent/store.go
@@ -1,0 +1,119 @@
+package subagent
+
+import (
+	"encoding/json"
+	"maps"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/genai-io/san/internal/atomicfile"
+	"github.com/genai-io/san/internal/confdir"
+)
+
+// AgentStoreData is the JSON structure for agents.json
+type AgentStoreData struct {
+	Disabled []string `json:"disabled"`
+}
+
+// AgentStore handles persistence of agent enabled/disabled states
+type AgentStore struct {
+	mu       sync.RWMutex
+	path     string
+	disabled map[string]bool
+}
+
+// NewAgentStore creates a new store at the given path
+func NewAgentStore(path string) *AgentStore {
+	store := &AgentStore{
+		path:     path,
+		disabled: make(map[string]bool),
+	}
+	store.load()
+	return store
+}
+
+// NewUserAgentStore creates a store for user-level (~/.san/agents.json)
+func NewUserAgentStore() *AgentStore {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return &AgentStore{disabled: make(map[string]bool)}
+	}
+	return NewAgentStore(filepath.Join(confdir.Dir(home), "agents.json"))
+}
+
+// NewProjectAgentStore creates a store for project-level (.san/agents.json)
+func NewProjectAgentStore(cwd string) *AgentStore {
+	return NewAgentStore(filepath.Join(confdir.Dir(cwd), "agents.json"))
+}
+
+// load reads disabled agents from disk
+func (s *AgentStore) load() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		return
+	}
+
+	var storeData AgentStoreData
+	if err := json.Unmarshal(data, &storeData); err != nil {
+		return
+	}
+
+	s.disabled = make(map[string]bool)
+	for _, name := range storeData.Disabled {
+		s.disabled[name] = true
+	}
+}
+
+// persistDisabled writes the disabled agent list to disk. Lock-free — operates
+// only on the provided snapshot.
+func persistDisabled(path string, disabled []string) error {
+	return atomicfile.WriteJSON(path, AgentStoreData{Disabled: disabled}, 0o644)
+}
+
+// IsDisabled returns whether an agent is disabled
+func (s *AgentStore) IsDisabled(name string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.disabled[name]
+}
+
+// SetDisabled sets the disabled state for an agent and persists to disk.
+func (s *AgentStore) SetDisabled(name string, disabled bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	wasDisabled := s.disabled[name]
+	if disabled {
+		s.disabled[name] = true
+	} else {
+		delete(s.disabled, name)
+	}
+
+	snapshot := make([]string, 0, len(s.disabled))
+	for n := range s.disabled {
+		snapshot = append(snapshot, n)
+	}
+	if err := persistDisabled(s.path, snapshot); err != nil {
+		if wasDisabled {
+			s.disabled[name] = true
+		} else {
+			delete(s.disabled, name)
+		}
+		return err
+	}
+	return nil
+}
+
+// GetDisabled returns a copy of the disabled agents map
+func (s *AgentStore) GetDisabled() map[string]bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make(map[string]bool, len(s.disabled))
+	maps.Copy(result, s.disabled)
+	return result
+}

--- a/internal/subagent/types.go
+++ b/internal/subagent/types.go
@@ -327,7 +327,6 @@ type AgentConfig struct {
 	SystemPrompt string   `yaml:"system-prompt,omitempty" json:"system_prompt,omitempty"`
 	MaxSteps     int      `yaml:"max-steps" json:"max_steps"`
 	Source       string   `yaml:"-" json:"source,omitempty"`
-	McpServers   []string `yaml:"mcp-servers,omitempty" json:"mcp_servers,omitempty"`
 	SourceFile   string   `yaml:"-" json:"-"`
 
 	systemPromptOnce sync.Once `yaml:"-" json:"-"`

--- a/internal/tool/agent/schema.go
+++ b/internal/tool/agent/schema.go
@@ -4,17 +4,44 @@ import (
 	"strings"
 
 	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/tool"
 )
 
-// Schema returns the model-facing tool definition for Agent.
+// AgentTool describes itself with the available-agents directory embedded when
+// one is supplied at build time.
+var _ tool.AgentDirectoryAwareTool = (*AgentTool)(nil)
+
+// Schema returns the model-facing tool definition for Agent, without an
+// available-agents directory. GetToolSchemasWith injects the directory via
+// SchemaWithAgentDirectory when one is available.
 func (t *AgentTool) Schema() core.ToolSchema {
-	return agentSchema()
+	return agentSchema("")
 }
 
-func agentSchema() core.ToolSchema {
+// SchemaWithAgentDirectory returns the Agent schema with the available-agents
+// directory embedded in the description. It satisfies tool.AgentDirectoryAwareTool
+// so the schema follows the live agent catalog on each rebuild. An empty
+// directory yields the same result as Schema.
+func (t *AgentTool) SchemaWithAgentDirectory(agentDirectory string) core.ToolSchema {
+	return agentSchema(agentDirectory)
+}
+
+// agentSchema builds the Agent tool schema with the given agent-directory body
+// embedded directly in the description. The directory is rendered before the
+// usage notes so the LLM sees the available custom agent names right after the
+// opening line.
+func agentSchema(agentDirectory string) core.ToolSchema {
+	agentDirectory = strings.TrimSpace(agentDirectory)
+
 	var sb strings.Builder
 	sb.WriteString("Launch a subagent for complex work that benefits from separate context or parallel execution.\n\n")
-	sb.WriteString("Omit name to use the default agent.\n\n")
+	if agentDirectory != "" {
+		sb.WriteString("Optional custom subagent definitions:\n\n")
+		sb.WriteString(agentDirectory)
+		sb.WriteString("\n\nSet name only when selecting one of these custom agents; otherwise omit it to use the default agent.\n\n")
+	} else {
+		sb.WriteString("Omit name to use the default agent.\n\n")
+	}
 	sb.WriteString("Use the lightest option that fits: a single Bash or Read call → that tool directly; 3+ non-mutating searches with decisions between them → mode=explore; code changes or multi-file edits → mode=edit.\n\n")
 	sb.WriteString("Brief the agent like a colleague who just walked in — it has not seen this conversation. Write a self-contained prompt: the goal and why, what you've ruled out, relevant paths and constraints; for lookups the exact command, for investigations the question. Never delegate understanding: \"based on your findings, fix the bug\" pushes synthesis onto the agent.\n\n")
 	sb.WriteString("Notes:\n")

--- a/internal/tool/agent/schema_test.go
+++ b/internal/tool/agent/schema_test.go
@@ -5,10 +5,41 @@ import (
 	"testing"
 )
 
-func TestAgentSchemaUsesDefaultGuidance(t *testing.T) {
-	schema := agentSchema()
+func TestAgentSchemaEmbedsDirectory(t *testing.T) {
+	directory := "Available custom agents for the Agent tool:\n\n- project-reviewer: General multi-step review agent\n  Tools: Read, Bash(git diff*)\n- plugin:browser-user: Uses a browser\n  Tools: WebFetch"
+
+	schema := agentSchema(directory)
+	if !strings.Contains(schema.Description, "project-reviewer") {
+		t.Error("Agent description should embed the directory body when supplied")
+	}
+	if !strings.Contains(schema.Description, "plugin:browser-user") {
+		t.Error("Agent description should list every custom directory entry")
+	}
+	if !strings.Contains(schema.Description, "Set name only when selecting one of these custom agents") {
+		t.Error("Agent description should retain custom-agent guidance after the directory")
+	}
+}
+
+func TestAgentSchemaOmitsDirectoryWhenEmpty(t *testing.T) {
+	schema := agentSchema("")
+	if strings.Contains(schema.Description, "Available custom agents") {
+		t.Error("empty directory should not produce an Available-agents block")
+	}
 	if !strings.Contains(schema.Description, "Omit name to use the default agent") {
-		t.Error("default-agent guidance must remain in the Agent schema")
+		t.Error("default-agent guidance must remain without a directory")
+	}
+}
+
+// TestAgentToolSchemaMatchesEmptyDirectory verifies the tool.Tool method and
+// the directory-less builder agree, so the Agent's default self-description
+// (Schema) and its zero-directory form (SchemaWithAgentDirectory) can't drift.
+func TestAgentToolSchemaMatchesEmptyDirectory(t *testing.T) {
+	at := &AgentTool{}
+	if at.Schema().Description != agentSchema("").Description {
+		t.Error("AgentTool.Schema must equal the directory-less agentSchema")
+	}
+	if at.SchemaWithAgentDirectory("").Description != agentSchema("").Description {
+		t.Error("SchemaWithAgentDirectory(\"\") must equal the directory-less agentSchema")
 	}
 }
 

--- a/internal/tool/schema.go
+++ b/internal/tool/schema.go
@@ -32,10 +32,14 @@ func IsAgentToolName(name string) bool {
 
 // SchemaOptions configures dynamic content embedded in tool schemas.
 //
-// MCPTools is a getter called at schema build time so tool descriptions stay
-// in sync with the harness. It may be nil.
+// Both fields are getters (called at schema build time) so tool descriptions
+// stay in sync with whatever the harness has loaded most recently. Either may
+// be nil — a nil MCPTools yields no MCP tools, and a nil AgentDirectory yields
+// an Agent tool whose description omits the available-types listing (useful
+// for subagent contexts where recursive spawning is discouraged).
 type SchemaOptions struct {
-	MCPTools func() []core.ToolSchema
+	MCPTools       func() []core.ToolSchema
+	AgentDirectory func() string
 
 	// ExtraTools are caller-supplied schemas appended to the registered set —
 	// the hook for conditionally-present tools whose schema the caller builds
@@ -63,15 +67,22 @@ var builtinToolOrder = []string{
 }
 
 // GetToolSchemas returns core.ToolSchema definitions for all registered tools
-// with no dynamic content. For MCP-aware schemas use GetToolSchemasWith.
+// with no dynamic content (no MCP tools, no agent directory). For
+// directory-aware schemas use GetToolSchemasWith.
 func GetToolSchemas() []core.ToolSchema {
 	return GetToolSchemasWith(SchemaOptions{})
 }
 
 // GetToolSchemasWith returns tool schemas with dynamic content from opts.
 // Built-in schemas are sourced from each registered tool's Schema (the single
-// source of truth), in builtinToolOrder.
+// source of truth), in builtinToolOrder; the Agent tool's description embeds
+// the available-agents directory when one is supplied.
 func GetToolSchemasWith(opts SchemaOptions) []core.ToolSchema {
+	var agentDirectory string
+	if opts.AgentDirectory != nil {
+		agentDirectory = opts.AgentDirectory()
+	}
+
 	tools := make([]core.ToolSchema, 0, len(builtinToolOrder)+len(opts.ExtraTools)+8)
 	for _, name := range builtinToolOrder {
 		t, ok := Get(name)
@@ -81,6 +92,12 @@ func GetToolSchemasWith(opts SchemaOptions) []core.ToolSchema {
 			// TestBuiltinToolsAllRegistered). Skip defensively rather than
 			// nil-panic should a build ever drop one.
 			continue
+		}
+		if agentDirectory != "" {
+			if da, ok := t.(AgentDirectoryAwareTool); ok {
+				tools = append(tools, da.SchemaWithAgentDirectory(agentDirectory))
+				continue
+			}
 		}
 		tools = append(tools, t.Schema())
 	}

--- a/internal/tool/schema_registry_test.go
+++ b/internal/tool/schema_registry_test.go
@@ -1,6 +1,7 @@
 package tool_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/genai-io/san/internal/core"
@@ -73,6 +74,44 @@ func TestBuiltinOrderCoversEveryRegisteredTool(t *testing.T) {
 		if !presented[canonical] {
 			t.Errorf("registered tool %q (canonical %q) is absent from the model-facing schema list; add it to builtinToolOrder (or exempt it deliberately)", name, canonical)
 		}
+	}
+}
+
+func TestGetToolSchemasUsesDirectoryGetter(t *testing.T) {
+	schemas := tool.GetToolSchemasWith(tool.SchemaOptions{
+		AgentDirectory: func() string {
+			return "Available custom agents for the Agent tool:\n\n- explorer: Read-only research"
+		},
+	})
+
+	agent, ok := findSchema(schemas, tool.ToolAgent)
+	if !ok {
+		t.Fatal("Agent schema not found in GetToolSchemasWith output")
+	}
+	if !strings.Contains(agent.Description, "explorer: Read-only research") {
+		t.Errorf("Agent schema description missing directory entry, got: %s", agent.Description)
+	}
+}
+
+// TestAgentDirectoryReevaluatedPerCall verifies the AgentDirectory getter is
+// invoked on each schema build, so toggling /agents produces an updated
+// description on the next rebuild.
+func TestAgentDirectoryReevaluatedPerCall(t *testing.T) {
+	directory := "v1"
+	getter := func() string { return directory }
+
+	first, _ := findSchema(tool.GetToolSchemasWith(tool.SchemaOptions{AgentDirectory: getter}), tool.ToolAgent)
+	directory = "v2"
+	second, _ := findSchema(tool.GetToolSchemasWith(tool.SchemaOptions{AgentDirectory: getter}), tool.ToolAgent)
+
+	if !strings.Contains(first.Description, "v1") {
+		t.Error("first build should embed directory v1")
+	}
+	if !strings.Contains(second.Description, "v2") {
+		t.Error("second build should embed directory v2 (getter must run each call)")
+	}
+	if strings.Contains(second.Description, "v1") {
+		t.Error("second build should NOT contain stale v1 directory")
 	}
 }
 

--- a/internal/tool/set.go
+++ b/internal/tool/set.go
@@ -38,14 +38,15 @@ func IsParentOnlyTool(name string) bool {
 // If Static is non-nil, it is returned directly (for custom agents).
 // Otherwise, tools are resolved dynamically using the config fields.
 type Set struct {
-	Static      []core.ToolSchema        // fixed tool list (overrides dynamic)
-	Disabled    map[string]bool          // excluded tools
-	MCP         func() []core.ToolSchema // MCP tools getter
-	Allow       []string                 // agent allow list (nil = all tools, non-nil = only these)
-	Disallow    []string                 // agent deny list (excluded after allow filtering)
-	IsAgent     bool                     // true for subagent tool sets (excludes parent-only tools)
-	ExtraTools  []core.ToolSchema        // caller-built conditional tools (e.g. Evolve; main agent only)
-	disallowSet map[string]bool          // eagerly-initialized normalized lookup cache for Disallow
+	Static         []core.ToolSchema        // fixed tool list (overrides dynamic)
+	Disabled       map[string]bool          // excluded tools
+	MCP            func() []core.ToolSchema // MCP tools getter
+	AgentDirectory func() string            // available-agents listing for the Agent tool description
+	Allow          []string                 // agent allow list (nil = all tools, non-nil = only these)
+	Disallow       []string                 // agent deny list (excluded after allow filtering)
+	IsAgent        bool                     // true for subagent tool sets (excludes parent-only tools)
+	ExtraTools     []core.ToolSchema        // caller-built conditional tools (e.g. Evolve; main agent only)
+	disallowSet    map[string]bool          // eagerly-initialized normalized lookup cache for Disallow
 }
 
 // Tools returns the resolved tool set for a turn.
@@ -72,8 +73,9 @@ func (s *Set) Tools() []core.ToolSchema {
 // defaultTools returns the full tool set filtered by disabled tools.
 func (s *Set) defaultTools() []core.ToolSchema {
 	tools := GetToolSchemasWith(SchemaOptions{
-		MCPTools:   s.MCP,
-		ExtraTools: s.ExtraTools,
+		MCPTools:       s.MCP,
+		AgentDirectory: s.AgentDirectory,
+		ExtraTools:     s.ExtraTools,
 	})
 
 	filtered := make([]core.ToolSchema, 0, len(tools))
@@ -90,7 +92,8 @@ func (s *Set) defaultTools() []core.ToolSchema {
 // Used for agents with nil Allow (= all tools).
 func (s *Set) agentAllTools() []core.ToolSchema {
 	allTools := GetToolSchemasWith(SchemaOptions{
-		MCPTools: s.MCP,
+		MCPTools:       s.MCP,
+		AgentDirectory: s.AgentDirectory,
 	})
 	filtered := make([]core.ToolSchema, 0, len(allTools))
 	for _, t := range allTools {

--- a/internal/tool/types.go
+++ b/internal/tool/types.go
@@ -28,6 +28,20 @@ type Tool interface {
 	Execute(ctx context.Context, params map[string]any, cwd string) toolresult.ToolResult
 }
 
+// AgentDirectoryAwareTool is an optional interface for a tool whose schema
+// embeds the available-agents directory supplied at build time. The Agent tool
+// implements it so its description follows the live agent catalog. Tools that
+// do not implement it are described solely by Schema. The name mirrors the
+// SchemaOptions.AgentDirectory it consumes, and the …AwareTool shape follows
+// the existing PermissionAwareTool / InteractiveTool optional interfaces.
+type AgentDirectoryAwareTool interface {
+	Tool
+
+	// SchemaWithAgentDirectory returns the schema with the given agent-directory
+	// body embedded in the description. An empty directory must match Schema.
+	SchemaWithAgentDirectory(agentDirectory string) core.ToolSchema
+}
+
 // PermissionAwareTool is a tool that requires user permission before execution
 type PermissionAwareTool interface {
 	Tool

--- a/notes/tech-debt.md
+++ b/notes/tech-debt.md
@@ -45,7 +45,8 @@ This file tracks structural follow-ups that are not tied to a single feature.
 ### Documentation gaps (resolved 2026-05-18 in the docs/restructure branch)
 
 - ~~`docs/guides/` only contains `explore-mode.md`.~~ Added
-  `getting-started.md`, `writing-a-skill.md`, and `writing-a-plugin.md`.
+  `getting-started.md`, `writing-a-skill.md`, `writing-a-subagent.md`,
+  `writing-a-plugin.md`.
 - ~~`docs/design/decisions/` is empty.~~ Added
   `0001-layered-package-architecture.md`.
 - ~~Infrastructure packages (`log`, `secret`, `filecache`, `markdown`)

--- a/site/docs.html
+++ b/site/docs.html
@@ -63,6 +63,7 @@
         <h3><span class="ico">📘</span> Guides</h3>
         <ul>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/guides/writing-a-skill.md">Writing a skill</a></li>
+          <li><a href="https://github.com/genai-io/san/blob/main/docs/guides/writing-a-subagent.md">Writing a subagent</a></li>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/guides/writing-a-plugin.md">Writing a plugin</a></li>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/guides/explore-mode.md">Explore mode</a></li>
         </ul>

--- a/site/docs.zh.html
+++ b/site/docs.zh.html
@@ -63,6 +63,7 @@
         <h3><span class="ico">📘</span> 指南</h3>
         <ul>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/guides/writing-a-skill.md">编写技能</a></li>
+          <li><a href="https://github.com/genai-io/san/blob/main/docs/guides/writing-a-subagent.md">编写子智能体</a></li>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/guides/writing-a-plugin.md">编写插件</a></li>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/guides/explore-mode.md">探索模式</a></li>
         </ul>

--- a/tests/integration/plugin/plugin_test.go
+++ b/tests/integration/plugin/plugin_test.go
@@ -63,6 +63,11 @@ func TestPluginComponents(t *testing.T) {
 		t.Errorf("Skills count = %d, want 1", len(p.Components.Skills))
 	}
 
+	// Check agents
+	if len(p.Components.Agents) != 1 {
+		t.Errorf("Agents count = %d, want 1", len(p.Components.Agents))
+	}
+
 	// Check commands
 	if len(p.Components.Commands) != 1 {
 		t.Errorf("Commands count = %d, want 1", len(p.Components.Commands))
@@ -307,5 +312,42 @@ func TestMarketplaceManager(t *testing.T) {
 	ids = manager.List()
 	if len(ids) != 0 {
 		t.Errorf("After remove, List() length = %d, want 0", len(ids))
+	}
+}
+
+func TestPluginAgentPaths(t *testing.T) {
+	if testPluginDir == "" {
+		t.Skip("Test plugin directory not found")
+	}
+
+	// Create a fresh registry
+	registry := plugin.NewRegistry()
+	ctx := context.Background()
+
+	// Load plugin
+	err := registry.LoadFromPath(ctx, testPluginDir)
+	if err != nil {
+		t.Fatalf("LoadFromPath() error = %v", err)
+	}
+
+	// Get enabled plugins
+	enabled := registry.GetEnabled()
+	if len(enabled) != 1 {
+		t.Fatalf("Expected 1 enabled plugin, got %d", len(enabled))
+	}
+
+	// Check that agent paths are resolved
+	p := enabled[0]
+	if len(p.Components.Agents) != 1 {
+		t.Errorf("Expected 1 agent path, got %d", len(p.Components.Agents))
+	}
+
+	// Verify the agent file exists
+	if len(p.Components.Agents) > 0 {
+		agentPath := p.Components.Agents[0]
+		if _, err := os.Stat(agentPath); os.IsNotExist(err) {
+			t.Errorf("Agent file does not exist: %s", agentPath)
+		}
+		t.Logf("Agent path: %s", agentPath)
 	}
 }

--- a/tests/integration/plugin/testdata/test-plugin/agents/test-agent.md
+++ b/tests/integration/plugin/testdata/test-plugin/agents/test-agent.md
@@ -1,0 +1,18 @@
+---
+name: test-agent
+description: A test agent for plugin UI/UX comparison
+model: haiku
+permission-mode: explore
+max-steps: 5
+---
+
+# Test Agent
+
+You are a test agent from the test-plugin. Your purpose is to verify that the plugin agent system is working correctly.
+
+When invoked:
+1. Acknowledge that you are the test-agent from test-plugin
+2. Describe what tools you have access to
+3. Confirm the plugin system integration is working
+
+Keep responses brief and informative.

--- a/tests/integration/plugin/testdata/test-plugin/commands/status.md
+++ b/tests/integration/plugin/testdata/test-plugin/commands/status.md
@@ -12,6 +12,7 @@ Display the status of the test-plugin:
 3. Status: Active
 4. Components loaded:
    - Skills: hello
+   - Agents: test-agent
    - Commands: status
 
 Report that all plugin components are functioning normally.


### PR DESCRIPTION
Add custom Agent discovery, management, and product integrations on top of the runtime contract.

- Load project, user, Claude-compatible, and plugin Agent definitions.
- Add persistence, persona filtering, `/agents`, headless execution, and Agent UI rendering.
- Document custom Agents and plugin Agent contributions.

Stack: #407 → **2/3** → #409