### PR TITLE
fix(mcp): manage per-agent server lifecycles

### DIFF
--- a/docs/reference/claude-permission-compat.md
+++ b/docs/reference/claude-permission-compat.md
@@ -216,6 +216,7 @@ max-steps: 500
 color: blue                  # UI display color
 when-to-use: "When to use this agent"
 skills: []                   # Additional skills to load
+mcp-servers: []              # MCP servers for this agent
 ---
 
 System prompt content goes here in the markdown body...

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -654,7 +654,7 @@ func (m *model) ReconfigureAgentTool() {
 	}
 	executor.SetProjectInstructions(m.env.CachedProjectInstructions)
 	executor.SetSkillsDirectory(m.services.Skill.PromptSection())
-	executor.SetMCP(m.services.MCP)
+	executor.SetMCP(m.services.MCP, m.services.MCP)
 
 	adapter := subagent.NewExecutorAdapter(executor)
 	type executorSetter interface{ SetExecutor(tool.AgentExecutor) }

--- a/internal/app/run_agent.go
+++ b/internal/app/run_agent.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 
 	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/mcp"
 	"github.com/genai-io/san/internal/plugin"
 	"github.com/genai-io/san/internal/skill"
 	"github.com/genai-io/san/internal/subagent"
@@ -57,6 +58,9 @@ func RunAgent(opts AgentRunOptions) error {
 	if err := subagent.Initialize(subagent.Options{CWD: cwd, PluginAgentPaths: pluginAgentPaths}); err != nil {
 		return fmt.Errorf("failed to initialize subagent registry: %w", err)
 	}
+	if err := mcp.Initialize(mcp.Options{CWD: cwd, PluginServers: pluginMCPServers}); err != nil {
+		return fmt.Errorf("failed to initialize MCP registry: %w", err)
+	}
 	fs.SetEnvProvider(plugin.PluginEnv)
 
 	// Run through the full subagent pipeline so headless invocations get the
@@ -66,6 +70,7 @@ func RunAgent(opts AgentRunOptions) error {
 	executor.SetResolver(llm.NewProviderPool(store))
 	executor.SetModelStore(store, resolved.ProviderName, resolved.AuthMethod)
 	executor.SetSkillsDirectory(skill.Default().PromptSection())
+	executor.SetMCP(mcp.DefaultRegistry(), mcp.DefaultRegistry())
 
 	name := opts.Name
 	if name == "" {

--- a/internal/mcp/adopt_clients_test.go
+++ b/internal/mcp/adopt_clients_test.go
@@ -60,6 +60,7 @@ func registryWith(configs map[string]ServerConfig, clients map[string]*Client) *
 	}
 	for name, c := range clients {
 		r.clients[name] = c
+		r.persistent[name] = true
 	}
 	return r
 }
@@ -128,6 +129,51 @@ func TestAdoptLiveClientsRejectsAChangedConfig(t *testing.T) {
 		t.Error("adopted a connection whose configuration no longer matches")
 	}
 	waitFor(t, "the stale server's transport to close", tr.isClosed)
+}
+
+func TestAdoptLiveClientsRebindsToolsChangedCallback(t *testing.T) {
+	cfg := ServerConfig{Name: "docs", Type: "stdio", Command: "docs-server"}
+	tr := &liveTransport{}
+	client := connectedClient(t, cfg, tr)
+	old := registryWith(map[string]ServerConfig{"docs": cfg}, map[string]*Client{"docs": client})
+	fresh := registryWith(map[string]ServerConfig{"docs": cfg}, nil)
+
+	var oldCalls, freshCalls int
+	old.SetOnToolsChanged(func() { oldCalls++ })
+	fresh.SetOnToolsChanged(func() { freshCalls++ })
+	client.SetOnToolsChanged(old.notifyToolsChanged)
+	fresh.adoptLiveClients(old)
+
+	client.mu.RLock()
+	callback := client.onToolsChanged
+	client.mu.RUnlock()
+	callback()
+	if oldCalls != 0 || freshCalls != 1 {
+		t.Fatalf("tools-changed callbacks = old:%d fresh:%d, want old:0 fresh:1", oldCalls, freshCalls)
+	}
+}
+
+func TestAdoptLiveClientsLeavesTemporaryConnectionWithLeaseOwner(t *testing.T) {
+	cfg := ServerConfig{Name: "docs", Type: "stdio", Command: "docs-server"}
+	tr := &liveTransport{}
+	client := connectedClient(t, cfg, tr)
+	old := registryWith(map[string]ServerConfig{"docs": cfg}, map[string]*Client{"docs": client})
+	old.temporary["docs"] = true
+	delete(old.persistent, "docs")
+	old.leasing["docs"] = map[uint64]int{0: 1}
+
+	fresh := registryWith(map[string]ServerConfig{"docs": cfg}, nil)
+	fresh.adoptLiveClients(old)
+
+	if _, ok := fresh.clients["docs"]; ok {
+		t.Fatal("new registry adopted a temporary connection still owned by an active Agent")
+	}
+	if got := old.clients["docs"]; got != client {
+		t.Fatal("old registry lost the temporary connection before its lease cleanup")
+	}
+	if tr.isClosed() {
+		t.Fatal("reload closed a temporary connection still used by an active Agent")
+	}
 }
 
 // waitFor polls cond, since the teardown of servers that did not survive runs

--- a/internal/mcp/caller.go
+++ b/internal/mcp/caller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 )
 
 // Caller adapts the mcp.Tools surface into the (content, isError, err)
@@ -46,27 +47,31 @@ func ExtractContent(contents []ToolResultContent) string {
 	return strings.Join(parts, "\n")
 }
 
-// ConnectServers connects to a specific set of MCP servers via the
-// supplied Servers handle. Returns a cleanup function that disconnects
-// them.
-func ConnectServers(ctx context.Context, servers Servers, serverNames []string) (cleanup func(), errs []error) {
-	var connected []string
+// ConnectServers acquires a connection lease for each configured MCP server.
+// Concurrent custom-Agent runs share one connection; cleanup releases only this
+// invocation's leases, and a connection that existed beforehand stays connected.
+func ConnectServers(ctx context.Context, servers *Registry, serverNames []string) (cleanup func(), errs []error) {
+	type lease struct {
+		name       string
+		generation uint64
+	}
+	var acquired []lease
 	for _, name := range serverNames {
-		if _, ok := servers.GetConfig(name); !ok {
-			errs = append(errs, fmt.Errorf("MCP server not configured: %s", name))
-			continue
-		}
-		if err := servers.Connect(ctx, name); err != nil {
+		generation, err := servers.acquireServer(ctx, name)
+		if err != nil {
 			errs = append(errs, fmt.Errorf("MCP server %s: %w", name, err))
 			continue
 		}
-		connected = append(connected, name)
+		acquired = append(acquired, lease{name: name, generation: generation})
 	}
 
+	var once sync.Once
 	cleanup = func() {
-		for _, name := range connected {
-			servers.Disconnect(name)
-		}
+		once.Do(func() {
+			for _, lease := range acquired {
+				servers.releaseServer(lease.name, lease.generation)
+			}
+		})
 	}
 	return cleanup, errs
 }

--- a/internal/mcp/caller_test.go
+++ b/internal/mcp/caller_test.go
@@ -1,0 +1,293 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/genai-io/san/internal/mcp/transport"
+)
+
+func TestConnectServersLeavesExistingConnectionOwned(t *testing.T) {
+	tr := newSlowTransport(0)
+	registry := connectedRegistry(t, map[string]transport.Transport{"shared": tr})
+
+	cleanup, errs := ConnectServers(context.Background(), registry, []string{"shared"})
+	if len(errs) != 0 {
+		t.Fatalf("ConnectServers() errors = %v", errs)
+	}
+	cleanup()
+
+	if _, ok := registry.GetClient("shared"); !ok {
+		t.Fatal("cleanup disconnected a connection owned by another caller")
+	}
+}
+
+type leaseTransport struct {
+	mu     sync.Mutex
+	alive  bool
+	closed int
+}
+
+func (t *leaseTransport) Start(context.Context) error {
+	t.mu.Lock()
+	t.alive = true
+	t.mu.Unlock()
+	return nil
+}
+
+func (t *leaseTransport) Send(_ context.Context, req *transport.JSONRPCRequest) (*transport.JSONRPCResponse, error) {
+	result := json.RawMessage(`{}`)
+	return &transport.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: result}, nil
+}
+
+func (t *leaseTransport) SendNotification(context.Context, *transport.JSONRPCNotification) error {
+	return nil
+}
+
+func (t *leaseTransport) Close() error {
+	t.mu.Lock()
+	t.alive = false
+	t.closed++
+	t.mu.Unlock()
+	return nil
+}
+
+func (t *leaseTransport) IsAlive() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.alive
+}
+
+func (t *leaseTransport) SetNotificationHandler(transport.NotificationHandler) {}
+
+func (t *leaseTransport) closeCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.closed
+}
+
+func TestConnectServersSharesConcurrentLeases(t *testing.T) {
+	registry := NewRegistryForTest(map[string]ServerConfig{
+		"shared": {Name: "shared", Type: TransportSTDIO, Command: "shared"},
+	})
+	tr := &leaseTransport{}
+	var factoryCalls int
+	registry.clientFactory = func(cfg ServerConfig) *Client {
+		factoryCalls++
+		client := NewClient(cfg)
+		client.TransportFactory = func() (transport.Transport, error) { return tr, nil }
+		return client
+	}
+
+	start := make(chan struct{})
+	cleanups := make(chan func(), 2)
+	errors := make(chan []error, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			cleanup, errs := ConnectServers(context.Background(), registry, []string{"shared"})
+			cleanups <- cleanup
+			errors <- errs
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	for range 2 {
+		if errs := <-errors; len(errs) != 0 {
+			t.Fatalf("ConnectServers() errors = %v", errs)
+		}
+	}
+	if factoryCalls != 1 {
+		t.Fatalf("client factory calls = %d, want 1", factoryCalls)
+	}
+
+	firstCleanup := <-cleanups
+	secondCleanup := <-cleanups
+	firstCleanup()
+	if _, ok := registry.GetClient("shared"); !ok {
+		t.Fatal("first cleanup disconnected a connection still leased by another caller")
+	}
+	if tr.closeCount() != 0 {
+		t.Fatal("first cleanup closed the shared transport")
+	}
+
+	secondCleanup()
+	if _, ok := registry.GetClient("shared"); ok {
+		t.Fatal("last cleanup left its temporary connection in the registry")
+	}
+	deadline := time.Now().Add(time.Second)
+	for tr.closeCount() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if tr.closeCount() != 1 {
+		t.Fatalf("transport close count = %d, want 1", tr.closeCount())
+	}
+}
+
+func TestConnectPromotesLeasedConnectionToPersistent(t *testing.T) {
+	registry := NewRegistryForTest(map[string]ServerConfig{
+		"shared": {Name: "shared", Type: TransportSTDIO, Command: "shared"},
+	})
+	tr := &leaseTransport{}
+	registry.clientFactory = func(cfg ServerConfig) *Client {
+		client := NewClient(cfg)
+		client.TransportFactory = func() (transport.Transport, error) { return tr, nil }
+		return client
+	}
+
+	cleanup, errs := ConnectServers(context.Background(), registry, []string{"shared"})
+	if len(errs) != 0 {
+		t.Fatalf("ConnectServers() errors = %v", errs)
+	}
+	if err := registry.Connect(context.Background(), "shared"); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+	cleanup()
+
+	if _, ok := registry.GetClient("shared"); !ok {
+		t.Fatal("lease cleanup disconnected a connection promoted by an explicit Connect")
+	}
+	if tr.closeCount() != 0 {
+		t.Fatal("lease cleanup closed a connection promoted by an explicit Connect")
+	}
+}
+
+func TestConnectServersCleanupIsIdempotent(t *testing.T) {
+	registry := NewRegistryForTest(map[string]ServerConfig{
+		"shared": {Name: "shared", Type: TransportSTDIO, Command: "shared"},
+	})
+	tr := &leaseTransport{}
+	registry.clientFactory = func(cfg ServerConfig) *Client {
+		client := NewClient(cfg)
+		client.TransportFactory = func() (transport.Transport, error) { return tr, nil }
+		return client
+	}
+
+	first, errs := ConnectServers(context.Background(), registry, []string{"shared"})
+	if len(errs) != 0 {
+		t.Fatalf("first ConnectServers() errors = %v", errs)
+	}
+	second, errs := ConnectServers(context.Background(), registry, []string{"shared"})
+	if len(errs) != 0 {
+		t.Fatalf("second ConnectServers() errors = %v", errs)
+	}
+
+	first()
+	first()
+	if _, ok := registry.GetClient("shared"); !ok {
+		t.Fatal("repeated cleanup released another caller's lease")
+	}
+	second()
+	waitFor(t, "the final lease cleanup to close the transport", func() bool { return tr.closeCount() == 1 })
+}
+
+func TestLeaseReconnectAfterTransportDeathTracksGenerations(t *testing.T) {
+	registry := NewRegistryForTest(map[string]ServerConfig{
+		"shared": {Name: "shared", Type: TransportSTDIO, Command: "shared"},
+	})
+	firstTransport := &leaseTransport{}
+	secondTransport := &leaseTransport{}
+	transports := []transport.Transport{firstTransport, secondTransport}
+	registry.clientFactory = func(cfg ServerConfig) *Client {
+		tr := transports[0]
+		transports = transports[1:]
+		client := NewClient(cfg)
+		client.TransportFactory = func() (transport.Transport, error) { return tr, nil }
+		return client
+	}
+
+	first, errs := ConnectServers(context.Background(), registry, []string{"shared"})
+	if len(errs) != 0 {
+		t.Fatalf("first ConnectServers() errors = %v", errs)
+	}
+	firstTransport.mu.Lock()
+	firstTransport.alive = false
+	firstTransport.mu.Unlock()
+	second, errs := ConnectServers(context.Background(), registry, []string{"shared"})
+	if len(errs) != 0 {
+		t.Fatalf("replacement ConnectServers() errors = %v", errs)
+	}
+
+	first()
+	second()
+	if _, ok := registry.GetClient("shared"); ok {
+		t.Fatal("generation-specific lease cleanup leaked the replacement connection")
+	}
+	waitFor(t, "the replacement transport to close", func() bool { return secondTransport.closeCount() == 1 })
+}
+
+func TestPersistentIntentSurvivesLeaseReconnect(t *testing.T) {
+	registry := NewRegistryForTest(map[string]ServerConfig{
+		"shared": {Name: "shared", Type: TransportSTDIO, Command: "shared"},
+	})
+	firstTransport := &leaseTransport{}
+	secondTransport := &leaseTransport{}
+	transports := []transport.Transport{firstTransport, secondTransport}
+	registry.clientFactory = func(cfg ServerConfig) *Client {
+		tr := transports[0]
+		transports = transports[1:]
+		client := NewClient(cfg)
+		client.TransportFactory = func() (transport.Transport, error) { return tr, nil }
+		return client
+	}
+
+	if err := registry.Connect(context.Background(), "shared"); err != nil {
+		t.Fatalf("persistent Connect() error = %v", err)
+	}
+	firstTransport.mu.Lock()
+	firstTransport.alive = false
+	firstTransport.mu.Unlock()
+	cleanup, errs := ConnectServers(context.Background(), registry, []string{"shared"})
+	if len(errs) != 0 {
+		t.Fatalf("ConnectServers() errors = %v", errs)
+	}
+	cleanup()
+
+	if _, ok := registry.GetClient("shared"); !ok {
+		t.Fatal("lease cleanup disconnected a replacement with persistent ownership")
+	}
+	if secondTransport.closeCount() != 0 {
+		t.Fatal("lease cleanup closed a persistently owned replacement")
+	}
+}
+
+func TestStaleLeaseCleanupDoesNotDisconnectReplacement(t *testing.T) {
+	registry := NewRegistryForTest(map[string]ServerConfig{
+		"shared": {Name: "shared", Type: TransportSTDIO, Command: "shared"},
+	})
+	first := &leaseTransport{}
+	second := &leaseTransport{}
+	transports := []transport.Transport{first, second}
+	registry.clientFactory = func(cfg ServerConfig) *Client {
+		tr := transports[0]
+		transports = transports[1:]
+		client := NewClient(cfg)
+		client.TransportFactory = func() (transport.Transport, error) { return tr, nil }
+		return client
+	}
+
+	cleanup, errs := ConnectServers(context.Background(), registry, []string{"shared"})
+	if len(errs) != 0 {
+		t.Fatalf("ConnectServers() errors = %v", errs)
+	}
+	registry.Disconnect("shared")
+	if err := registry.Connect(context.Background(), "shared"); err != nil {
+		t.Fatalf("replacement Connect() error = %v", err)
+	}
+	cleanup()
+
+	client, ok := registry.GetClient("shared")
+	if !ok || client == nil {
+		t.Fatal("stale lease cleanup removed the replacement connection")
+	}
+	if !second.IsAlive() {
+		t.Fatal("stale lease cleanup closed the replacement transport")
+	}
+}

--- a/internal/mcp/disconnect_test.go
+++ b/internal/mcp/disconnect_test.go
@@ -49,6 +49,7 @@ func connectedRegistry(t *testing.T, servers map[string]transport.Transport) *Re
 		c.mu.Unlock()
 		r.configs[name] = cfg
 		r.clients[name] = c
+		r.persistent[name] = true
 	}
 	return r
 }
@@ -112,6 +113,37 @@ func TestDisconnectAllDoesNotBlockPerServer(t *testing.T) {
 		case <-time.After(2 * time.Second):
 			t.Errorf("transport %d was never torn down", i)
 		}
+	}
+}
+
+func TestDisconnectAllNotifiesToolsChanged(t *testing.T) {
+	tr := newSlowTransport(0)
+	r := connectedRegistry(t, map[string]transport.Transport{"shared": tr})
+	notified := make(chan struct{}, 1)
+	r.SetOnToolsChanged(func() { notified <- struct{}{} })
+
+	r.DisconnectAll()
+	select {
+	case <-notified:
+	case <-time.After(time.Second):
+		t.Fatal("DisconnectAll did not notify tool-schema subscribers")
+	}
+}
+
+func TestLifecycleCallbackMayReenterRegistry(t *testing.T) {
+	tr := newSlowTransport(0)
+	r := connectedRegistry(t, map[string]transport.Transport{"shared": tr})
+	done := make(chan struct{})
+	r.SetOnToolsChanged(func() {
+		r.DisconnectAll()
+		close(done)
+	})
+
+	r.Disconnect("shared")
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("tools-changed callback deadlocked reentering the lifecycle API")
 	}
 }
 

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -32,18 +32,25 @@ type PluginServer struct {
 
 // Registry manages multiple MCP server connections
 type Registry struct {
-	mu         sync.RWMutex
-	clients    map[string]*Client
-	configs    map[string]ServerConfig
-	disabled   map[string]bool   // servers explicitly disabled by the user
-	connecting map[string]bool   // servers currently being connected (async)
-	connectErr map[string]string // last connection error for servers without a client
-	loader     *ConfigLoader
-	cwd        string
+	mu           sync.RWMutex
+	connectionMu sync.Mutex
+	clients      map[string]*Client
+	configs      map[string]ServerConfig
+	disabled     map[string]bool           // servers explicitly disabled by the user
+	connecting   map[string]bool           // servers currently being connected (async)
+	connectErr   map[string]string         // last connection error for servers without a client
+	leasing      map[string]map[uint64]int // active per-agent users grouped by connection generation
+	temporary    map[string]bool           // connections created solely for active leases
+	persistent   map[string]bool           // explicit connection intent, retained across reconnects
+	generation   map[string]uint64         // changes whenever a connection is replaced
+	loader       *ConfigLoader
+	cwd          string
 
 	// PluginServers returns MCP servers contributed by plugins. Injected by
 	// the app layer to avoid mcp importing plugin (same-layer dependency).
 	PluginServers func() []PluginServer
+
+	clientFactory func(ServerConfig) *Client // test seam; nil uses NewClient
 
 	// Callback when tool schemas change
 	onToolsChanged func()
@@ -60,6 +67,7 @@ type mcpState struct {
 // (reloadProjectServices) while DefaultRegistry() is read elsewhere.
 var (
 	registryMu      sync.RWMutex
+	registryAdoptMu sync.Mutex
 	defaultRegistry = newEmptyRegistry()
 )
 
@@ -79,22 +87,43 @@ func (r *Registry) adoptLiveClients(old *Registry) {
 		return
 	}
 
+	registryAdoptMu.Lock()
+	defer registryAdoptMu.Unlock()
+	old.connectionMu.Lock()
+	defer old.connectionMu.Unlock()
+	r.connectionMu.Lock()
+	defer r.connectionMu.Unlock()
+
 	old.mu.Lock()
 	adopted := make(map[string]*Client)
-	var stale []*Client
+	stale := make(map[string]*Client)
 	for name, client := range old.clients {
 		cfg, stillConfigured := r.configs[name]
+		if !old.persistent[name] {
+			continue
+		}
 		if stillConfigured && reflect.DeepEqual(cfg, old.configs[name]) && client.IsConnected() {
 			adopted[name] = client
 			continue
 		}
-		stale = append(stale, client)
+		stale[name] = client
 	}
-	old.clients = make(map[string]*Client)
+	for name, client := range adopted {
+		delete(old.clients, name)
+		delete(old.persistent, name)
+		client.SetOnToolsChanged(r.notifyToolsChanged)
+	}
+	for name := range stale {
+		delete(old.clients, name)
+		delete(old.persistent, name)
+	}
 	old.mu.Unlock()
 
 	r.mu.Lock()
 	maps.Copy(r.clients, adopted)
+	for name := range adopted {
+		r.persistent[name] = true
+	}
 	r.mu.Unlock()
 
 	if len(stale) > 0 {
@@ -113,6 +142,10 @@ func newEmptyRegistry() *Registry {
 		disabled:   make(map[string]bool),
 		connecting: make(map[string]bool),
 		connectErr: make(map[string]string),
+		leasing:    make(map[string]map[uint64]int),
+		temporary:  make(map[string]bool),
+		persistent: make(map[string]bool),
+		generation: make(map[string]uint64),
 	}
 }
 
@@ -125,6 +158,10 @@ func NewRegistryForTest(configs map[string]ServerConfig) *Registry {
 		disabled:   make(map[string]bool),
 		connecting: make(map[string]bool),
 		connectErr: make(map[string]string),
+		leasing:    make(map[string]map[uint64]int),
+		temporary:  make(map[string]bool),
+		persistent: make(map[string]bool),
+		generation: make(map[string]uint64),
 	}
 }
 
@@ -142,6 +179,10 @@ func NewRegistry(cwd string) (*Registry, error) {
 		disabled:   make(map[string]bool),
 		connecting: make(map[string]bool),
 		connectErr: make(map[string]string),
+		leasing:    make(map[string]map[uint64]int),
+		temporary:  make(map[string]bool),
+		persistent: make(map[string]bool),
+		generation: make(map[string]uint64),
 		loader:     loader,
 		cwd:        cwd,
 	}
@@ -160,18 +201,36 @@ func (r *Registry) Reload() error {
 	}
 	configs = r.mergePluginMCPConfigs(configs)
 
+	r.connectionMu.Lock()
+	var stale = make(map[string]*Client)
 	r.mu.Lock()
-	// Disconnect clients whose config was removed.
+	// Disconnect clients whose config was removed or changed. Active temporary
+	// lease-owned clients stay with their current registry until their owner
+	// releases them; reload must not invalidate an in-flight Agent run.
 	for name, client := range r.clients {
-		if _, ok := configs[name]; !ok {
-			_ = client.Disconnect()
-			delete(r.clients, name)
-			delete(r.connecting, name)
-			delete(r.connectErr, name)
+		config, ok := configs[name]
+		if !r.persistent[name] || ok && reflect.DeepEqual(config, r.configs[name]) {
+			continue
 		}
+		stale[name] = client
+		delete(r.clients, name)
+		delete(r.connecting, name)
+		delete(r.connectErr, name)
+		delete(r.leasing, name)
+		delete(r.temporary, name)
+		delete(r.persistent, name)
+		r.generation[name]++
 	}
 	r.configs = configs
 	r.mu.Unlock()
+	r.connectionMu.Unlock()
+
+	for name, client := range stale {
+		closeInBackground(name, client)
+	}
+	if len(stale) > 0 {
+		r.notifyToolsChanged()
+	}
 	return nil
 }
 
@@ -213,6 +272,8 @@ func (r *Registry) AddServer(name string, config ServerConfig, scope Scope) erro
 
 // RemoveServer removes a server configuration
 func (r *Registry) RemoveServer(name string) error {
+	r.connectionMu.Lock()
+	defer r.connectionMu.Unlock()
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -220,6 +281,7 @@ func (r *Registry) RemoveServer(name string) error {
 	if client, ok := r.clients[name]; ok {
 		_ = client.Disconnect()
 		delete(r.clients, name)
+		r.generation[name]++
 	}
 
 	// Remove from all configs
@@ -230,40 +292,136 @@ func (r *Registry) RemoveServer(name string) error {
 	delete(r.configs, name)
 	delete(r.connecting, name)
 	delete(r.connectErr, name)
+	delete(r.leasing, name)
+	delete(r.temporary, name)
+	delete(r.persistent, name)
 	return nil
 }
 
-// Connect connects to an MCP server
+// Connect connects to an MCP server and keeps the connection persistent until
+// an explicit disconnect, even if a custom Agent originally created it.
 func (r *Registry) Connect(ctx context.Context, name string) error {
+	r.connectionMu.Lock()
+	connected, err := r.connectLocked(ctx, name)
+	if err == nil {
+		r.mu.Lock()
+		r.persistent[name] = true
+		delete(r.temporary, name)
+		r.mu.Unlock()
+	}
+	r.connectionMu.Unlock()
+
+	if connected {
+		r.notifyToolsChanged()
+	}
+	return err
+}
+
+// connectLocked establishes one connection and reports whether it installed
+// the registry's current client. The caller must hold connectionMu so duplicate
+// transports cannot be created and ownership changes stay atomic.
+func (r *Registry) connectLocked(ctx context.Context, name string) (bool, error) {
 	r.mu.Lock()
 	config, ok := r.configs[name]
 	if !ok {
 		r.mu.Unlock()
-		return fmt.Errorf("server not found: %s", name)
+		return false, fmt.Errorf("server not found: %s", name)
 	}
-
-	// Already connected?
 	if client, ok := r.clients[name]; ok && client.IsConnected() {
 		r.mu.Unlock()
-		return nil
+		return false, nil
 	}
+	factory := r.clientFactory
 	r.mu.Unlock()
 
-	// Create and connect client
 	client := NewClient(config)
-	if err := client.Connect(ctx); err != nil {
-		return fmt.Errorf("failed to connect to %s: %w", name, err)
+	if factory != nil {
+		client = factory(config)
 	}
-
-	// Set up tools changed callback
+	if err := client.Connect(ctx); err != nil {
+		return false, fmt.Errorf("failed to connect to %s: %w", name, err)
+	}
 	client.SetOnToolsChanged(r.notifyToolsChanged)
 
 	r.mu.Lock()
 	r.clients[name] = client
+	if r.generation == nil {
+		r.generation = make(map[string]uint64)
+	}
+	r.generation[name]++
 	r.mu.Unlock()
+	return true, nil
+}
 
-	r.notifyToolsChanged()
-	return nil
+// acquireServer keeps a configured server connected for one custom-Agent run.
+// The first lease owns a newly-created temporary connection; later leases share
+// it. A connection that predated all leases remains persistent after release.
+func (r *Registry) acquireServer(ctx context.Context, name string) (uint64, error) {
+	r.connectionMu.Lock()
+	connected, err := r.connectLocked(ctx, name)
+	if err != nil {
+		r.connectionMu.Unlock()
+		return 0, err
+	}
+
+	r.mu.Lock()
+	if r.leasing == nil {
+		r.leasing = make(map[string]map[uint64]int)
+	}
+	generation := r.generation[name]
+	if r.leasing[name] == nil {
+		r.leasing[name] = make(map[uint64]int)
+	}
+	r.leasing[name][generation]++
+	if connected && !r.persistent[name] {
+		r.temporary[name] = true
+	}
+	r.mu.Unlock()
+	r.connectionMu.Unlock()
+
+	if connected {
+		r.notifyToolsChanged()
+	}
+	return generation, nil
+}
+
+// releaseServer drops one custom-Agent lease and disconnects only a temporary
+// connection whose final lease ended. A stale cleanup from an older connection
+// generation cannot affect a replacement connection with the same name.
+func (r *Registry) releaseServer(name string, generation uint64) {
+	r.connectionMu.Lock()
+
+	var client *Client
+
+	r.mu.Lock()
+	generationLeases := r.leasing[name]
+	if generationLeases == nil || generationLeases[generation] == 0 {
+		r.mu.Unlock()
+		r.connectionMu.Unlock()
+		return
+	}
+	if generationLeases[generation] > 1 {
+		generationLeases[generation]--
+		r.mu.Unlock()
+		r.connectionMu.Unlock()
+		return
+	}
+	delete(generationLeases, generation)
+	if len(generationLeases) == 0 {
+		delete(r.leasing, name)
+	}
+	if r.generation[name] == generation && r.temporary[name] && !r.persistent[name] {
+		client = r.clients[name]
+		delete(r.clients, name)
+		delete(r.temporary, name)
+	}
+	r.mu.Unlock()
+	r.connectionMu.Unlock()
+
+	if client != nil {
+		closeInBackground(name, client)
+		r.notifyToolsChanged()
+	}
 }
 
 // ConnectAll connects to all configured MCP servers.
@@ -296,12 +454,19 @@ func (r *Registry) ConnectAll(ctx context.Context) []error {
 // inline froze the UI for that whole time, and doing it under r.mu froze the
 // agent goroutine with it, since CallTool takes the read lock.
 func (r *Registry) Disconnect(name string) {
+	r.connectionMu.Lock()
+
 	r.mu.Lock()
 	client, ok := r.clients[name]
 	if ok {
 		delete(r.clients, name)
+		r.generation[name]++
 	}
+	delete(r.leasing, name)
+	delete(r.temporary, name)
+	delete(r.persistent, name)
 	r.mu.Unlock()
+	r.connectionMu.Unlock()
 	if !ok {
 		return
 	}
@@ -312,13 +477,25 @@ func (r *Registry) Disconnect(name string) {
 
 // DisconnectAll disconnects from all MCP servers
 func (r *Registry) DisconnectAll() {
+	r.connectionMu.Lock()
+
 	r.mu.Lock()
 	clients := r.clients
 	r.clients = make(map[string]*Client)
+	for name := range clients {
+		r.generation[name]++
+	}
+	r.leasing = make(map[string]map[uint64]int)
+	r.temporary = make(map[string]bool)
+	r.persistent = make(map[string]bool)
 	r.mu.Unlock()
+	r.connectionMu.Unlock()
 
 	for name, client := range clients {
 		closeInBackground(name, client)
+	}
+	if len(clients) > 0 {
+		r.notifyToolsChanged()
 	}
 }
 

--- a/internal/subagent/executor.go
+++ b/internal/subagent/executor.go
@@ -11,12 +11,14 @@ import (
 	"github.com/genai-io/san/internal/core/system"
 	"github.com/genai-io/san/internal/hook"
 	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/log"
 	"github.com/genai-io/san/internal/mcp"
 	"github.com/genai-io/san/internal/reminder"
 	"github.com/genai-io/san/internal/setting"
 	"github.com/genai-io/san/internal/task"
 	"github.com/genai-io/san/internal/tool"
 	"github.com/genai-io/san/internal/tool/perm"
+	"go.uber.org/zap"
 )
 
 // ProviderResolver turns a vendor name into a live provider so a subagent can
@@ -43,6 +45,7 @@ type Executor struct {
 	projectInstructions  string               // project memory (CLAUDE.md/AGENTS.md) for edit-capable subagents
 	skillsPrompt         string               // available skills section for capable subagents
 	mcpTools             mcp.Tools            // tool schemas + execution
+	mcpServers           *mcp.Registry        // connect/disconnect for per-subagent server sets
 }
 
 type SubagentSessionStore interface {
@@ -135,9 +138,12 @@ func (e *Executor) SetSkillsDirectory(skillsPrompt string) {
 	e.skillsPrompt = skillsPrompt
 }
 
-// SetMCP wires the parent's MCP tools for the subagent.
-func (e *Executor) SetMCP(tools mcp.Tools) {
+// SetMCP wires the parent's MCP access for the subagent. Tool schemas
+// and execution flow through tools; connection lifecycle for any
+// per-subagent server set flows through servers.
+func (e *Executor) SetMCP(tools mcp.Tools, servers *mcp.Registry) {
 	e.mcpTools = tools
+	e.mcpServers = servers
 }
 
 // SetSessionStore configures session persistence for subagent conversations.
@@ -362,6 +368,16 @@ func (e *Executor) buildAgent(ctx context.Context, run *preparedRun, onToolExec 
 	rc := run.cfg
 	agentCwd := run.cwd
 	cleanup := func() {}
+
+	if len(rc.config.McpServers) > 0 && e.mcpServers != nil {
+		mcpCleanup, errs := mcp.ConnectServers(ctx, e.mcpServers, rc.config.McpServers)
+		if mcpCleanup != nil {
+			cleanup = mcpCleanup
+		}
+		for _, err := range errs {
+			log.Logger().Warn("Agent MCP server connection failed", zap.Error(err))
+		}
+	}
 
 	// Subagent system prompt deliberately omits skills and memory — those
 	// ride on the first user message as <system-reminder> blocks built by

--- a/internal/subagent/types.go
+++ b/internal/subagent/types.go
@@ -327,6 +327,7 @@ type AgentConfig struct {
 	SystemPrompt string   `yaml:"system-prompt,omitempty" json:"system_prompt,omitempty"`
 	MaxSteps     int      `yaml:"max-steps" json:"max_steps"`
 	Source       string   `yaml:"-" json:"source,omitempty"`
+	McpServers   []string `yaml:"mcp-servers,omitempty" json:"mcp_servers,omitempty"`
 	SourceFile   string   `yaml:"-" json:"-"`
 
 	systemPromptOnce sync.Once `yaml:"-" json:"-"`


### PR DESCRIPTION
Make MCP connections safe for concurrent per-Agent use.

- Add lease- and generation-aware connection ownership and cleanup.
- Preserve intent and callbacks across reconnect, adoption, and reload.
- Connect configured MCP servers for TUI and headless Agent runs.

Stack: #407 → #408 → **3/3**