### PR TITLE
fix(mcp): manage per-agent server lifecycles

### DIFF
--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -655,7 +655,7 @@ func (m *model) ReconfigureAgentTool() {
 	}
 	executor.SetProjectInstructions(m.env.CachedProjectInstructions)
 	executor.SetSkillsDirectory(m.services.Skill.PromptSection())
-	executor.SetMCP(m.services.MCP, m.services.MCP)
+	executor.SetMCPDependencies(m.services.MCP, m.services.MCP)
 
 	adapter := subagent.NewExecutorAdapter(executor)
 	type executorSetter interface{ SetExecutor(tool.AgentExecutor) }

--- a/internal/mcp/adopt_clients_test.go
+++ b/internal/mcp/adopt_clients_test.go
@@ -53,13 +53,14 @@ func connectedClient(t *testing.T, cfg ServerConfig, tr transport.Transport) *Cl
 	return c
 }
 
-func registryWith(configs map[string]ServerConfig, clients map[string]*Client) *Registry {
+func registryWithRetainedClients(configs map[string]ServerConfig, clients map[string]*Client) *Registry {
 	r := newEmptyRegistry()
 	for name, cfg := range configs {
 		r.configs[name] = cfg
 	}
 	for name, c := range clients {
 		r.clients[name] = c
+		r.retainWithoutLeases[name] = true
 	}
 	return r
 }
@@ -68,17 +69,17 @@ func registryWith(configs map[string]ServerConfig, clients map[string]*Client) *
 // one. Replacing the registry on a cwd change used to drop its connection, so
 // every mcp__* tool disappeared from the agent for the rest of the session with
 // nothing to reconnect it — AutoConnect only runs at startup.
-func TestAdoptLiveClientsKeepsUnchangedServersConnected(t *testing.T) {
+func TestRegistryReplacementTransfersMatchingRetainedConnection(t *testing.T) {
 	cfg := ServerConfig{Name: "docs", Type: "stdio", Command: "docs-server", Args: []string{"--stdio"}}
 	tr := &liveTransport{}
-	old := registryWith(
+	old := registryWithRetainedClients(
 		map[string]ServerConfig{"docs": cfg},
 		map[string]*Client{"docs": connectedClient(t, cfg, tr)},
 	)
 
 	// Same server still configured after the cwd change.
-	fresh := registryWith(map[string]ServerConfig{"docs": cfg}, nil)
-	fresh.adoptLiveClients(old)
+	fresh := registryWithRetainedClients(map[string]ServerConfig{"docs": cfg}, nil)
+	fresh.transferRetainedConnectionsFrom(old)
 
 	if _, ok := fresh.clients["docs"]; !ok {
 		t.Fatal("the live connection was not carried across; mcp__docs__* tools would vanish")
@@ -93,16 +94,16 @@ func TestAdoptLiveClientsKeepsUnchangedServersConnected(t *testing.T) {
 
 // A project-scoped server that the new project does not configure must be torn
 // down — it was previously dropped still running, leaking the subprocess.
-func TestAdoptLiveClientsDisconnectsServersTheNewProjectDropped(t *testing.T) {
+func TestRegistryReplacementDisconnectsRetainedConnectionMissingFromIncomingConfig(t *testing.T) {
 	cfg := ServerConfig{Name: "old-proj", Type: "stdio", Command: "old-server"}
 	tr := &liveTransport{}
-	old := registryWith(
+	old := registryWithRetainedClients(
 		map[string]ServerConfig{"old-proj": cfg},
 		map[string]*Client{"old-proj": connectedClient(t, cfg, tr)},
 	)
 
-	fresh := registryWith(map[string]ServerConfig{}, nil) // new project configures nothing
-	fresh.adoptLiveClients(old)
+	fresh := registryWithRetainedClients(map[string]ServerConfig{}, nil) // new project configures nothing
+	fresh.transferRetainedConnectionsFrom(old)
 
 	if _, ok := fresh.clients["old-proj"]; ok {
 		t.Error("a server the new project does not configure was adopted")
@@ -112,22 +113,67 @@ func TestAdoptLiveClientsDisconnectsServersTheNewProjectDropped(t *testing.T) {
 
 // Same name, different command: the config changed, so the old process is not
 // the server the new project asked for.
-func TestAdoptLiveClientsRejectsAChangedConfig(t *testing.T) {
+func TestRegistryReplacementDisconnectsRetainedConnectionWhoseConfigChanged(t *testing.T) {
 	oldCfg := ServerConfig{Name: "docs", Type: "stdio", Command: "docs-server", Args: []string{"--v1"}}
 	newCfg := ServerConfig{Name: "docs", Type: "stdio", Command: "docs-server", Args: []string{"--v2"}}
 	tr := &liveTransport{}
-	old := registryWith(
+	old := registryWithRetainedClients(
 		map[string]ServerConfig{"docs": oldCfg},
 		map[string]*Client{"docs": connectedClient(t, oldCfg, tr)},
 	)
 
-	fresh := registryWith(map[string]ServerConfig{"docs": newCfg}, nil)
-	fresh.adoptLiveClients(old)
+	fresh := registryWithRetainedClients(map[string]ServerConfig{"docs": newCfg}, nil)
+	fresh.transferRetainedConnectionsFrom(old)
 
 	if _, ok := fresh.clients["docs"]; ok {
 		t.Error("adopted a connection whose configuration no longer matches")
 	}
 	waitFor(t, "the stale server's transport to close", tr.isClosed)
+}
+
+func TestTransferredConnectionNotifiesIncomingRegistryOnly(t *testing.T) {
+	cfg := ServerConfig{Name: "docs", Type: "stdio", Command: "docs-server"}
+	tr := &liveTransport{}
+	client := connectedClient(t, cfg, tr)
+	old := registryWithRetainedClients(map[string]ServerConfig{"docs": cfg}, map[string]*Client{"docs": client})
+	fresh := registryWithRetainedClients(map[string]ServerConfig{"docs": cfg}, nil)
+
+	var oldCalls, freshCalls int
+	old.SetOnToolsChanged(func() { oldCalls++ })
+	fresh.SetOnToolsChanged(func() { freshCalls++ })
+	client.SetOnToolsChanged(old.notifyToolsChanged)
+	fresh.transferRetainedConnectionsFrom(old)
+
+	client.mu.RLock()
+	callback := client.onToolsChanged
+	client.mu.RUnlock()
+	callback()
+	if oldCalls != 0 || freshCalls != 1 {
+		t.Fatalf("tools-changed callbacks = old:%d fresh:%d, want old:0 fresh:1", oldCalls, freshCalls)
+	}
+}
+
+func TestRegistryReplacementLeavesLeaseOwnedConnectionInOutgoingRegistry(t *testing.T) {
+	cfg := ServerConfig{Name: "docs", Type: "stdio", Command: "docs-server"}
+	tr := &liveTransport{}
+	client := connectedClient(t, cfg, tr)
+	old := registryWithRetainedClients(map[string]ServerConfig{"docs": cfg}, map[string]*Client{"docs": client})
+	old.disconnectAfterFinalLease["docs"] = true
+	delete(old.retainWithoutLeases, "docs")
+	old.leaseCountsByConnectionEpoch["docs"] = map[uint64]int{0: 1}
+
+	fresh := registryWithRetainedClients(map[string]ServerConfig{"docs": cfg}, nil)
+	fresh.transferRetainedConnectionsFrom(old)
+
+	if _, ok := fresh.clients["docs"]; ok {
+		t.Fatal("new registry adopted a temporary connection still owned by an active Agent")
+	}
+	if got := old.clients["docs"]; got != client {
+		t.Fatal("old registry lost the temporary connection before its lease cleanup")
+	}
+	if tr.isClosed() {
+		t.Fatal("reload closed a temporary connection still used by an active Agent")
+	}
 }
 
 // waitFor polls cond, since the teardown of servers that did not survive runs

--- a/internal/mcp/caller.go
+++ b/internal/mcp/caller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 )
 
 // Caller adapts the mcp.Tools surface into the (content, isError, err)
@@ -46,27 +47,35 @@ func ExtractContent(contents []ToolResultContent) string {
 	return strings.Join(parts, "\n")
 }
 
-// ConnectServers connects to a specific set of MCP servers via the
-// supplied Servers handle. Returns a cleanup function that disconnects
-// them.
-func ConnectServers(ctx context.Context, servers Servers, serverNames []string) (cleanup func(), errs []error) {
-	var connected []string
-	for _, name := range serverNames {
-		if _, ok := servers.GetConfig(name); !ok {
-			errs = append(errs, fmt.Errorf("MCP server not configured: %s", name))
-			continue
-		}
-		if err := servers.Connect(ctx, name); err != nil {
-			errs = append(errs, fmt.Errorf("MCP server %s: %w", name, err))
-			continue
-		}
-		connected = append(connected, name)
+// AcquireServerConnectionLeases acquires a connection lease for each configured
+// MCP server. Concurrent custom-Agent runs share one connection; releaseLeases
+// releases only this invocation's leases, and a preexisting connection remains.
+func AcquireServerConnectionLeases(ctx context.Context, registry *Registry, serverNames []string) (releaseLeases func(), acquireErrors []error) {
+	type connectionLeaseToken struct {
+		serverName      string
+		connectionEpoch uint64
 	}
 
-	cleanup = func() {
-		for _, name := range connected {
-			servers.Disconnect(name)
+	acquiredLeaseTokens := make([]connectionLeaseToken, 0, len(serverNames))
+	for _, serverName := range serverNames {
+		connectionEpoch, err := registry.acquireConnectionLease(ctx, serverName)
+		if err != nil {
+			acquireErrors = append(acquireErrors, fmt.Errorf("MCP server %s: %w", serverName, err))
+			continue
 		}
+		acquiredLeaseTokens = append(acquiredLeaseTokens, connectionLeaseToken{
+			serverName:      serverName,
+			connectionEpoch: connectionEpoch,
+		})
 	}
-	return cleanup, errs
+
+	var releaseOnce sync.Once
+	releaseLeases = func() {
+		releaseOnce.Do(func() {
+			for _, leaseToken := range acquiredLeaseTokens {
+				registry.releaseConnectionLease(leaseToken.serverName, leaseToken.connectionEpoch)
+			}
+		})
+	}
+	return releaseLeases, acquireErrors
 }

--- a/internal/mcp/caller_test.go
+++ b/internal/mcp/caller_test.go
@@ -1,0 +1,293 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/genai-io/san/internal/mcp/transport"
+)
+
+func TestLeaseReleaseDoesNotDisconnectPreexistingRetainedConnection(t *testing.T) {
+	tr := newSlowTransport(0)
+	registry := connectedRegistry(t, map[string]transport.Transport{"shared": tr})
+
+	cleanup, errs := AcquireServerConnectionLeases(context.Background(), registry, []string{"shared"})
+	if len(errs) != 0 {
+		t.Fatalf("AcquireServerConnectionLeases() errors = %v", errs)
+	}
+	cleanup()
+
+	if _, ok := registry.GetClient("shared"); !ok {
+		t.Fatal("cleanup disconnected a connection owned by another caller")
+	}
+}
+
+type connectionLifecycleTransport struct {
+	mu         sync.Mutex
+	alive      bool
+	closeCalls int
+}
+
+func (t *connectionLifecycleTransport) Start(context.Context) error {
+	t.mu.Lock()
+	t.alive = true
+	t.mu.Unlock()
+	return nil
+}
+
+func (t *connectionLifecycleTransport) Send(_ context.Context, req *transport.JSONRPCRequest) (*transport.JSONRPCResponse, error) {
+	result := json.RawMessage(`{}`)
+	return &transport.JSONRPCResponse{JSONRPC: "2.0", ID: req.ID, Result: result}, nil
+}
+
+func (t *connectionLifecycleTransport) SendNotification(context.Context, *transport.JSONRPCNotification) error {
+	return nil
+}
+
+func (t *connectionLifecycleTransport) Close() error {
+	t.mu.Lock()
+	t.alive = false
+	t.closeCalls++
+	t.mu.Unlock()
+	return nil
+}
+
+func (t *connectionLifecycleTransport) IsAlive() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.alive
+}
+
+func (t *connectionLifecycleTransport) SetNotificationHandler(transport.NotificationHandler) {}
+
+func (t *connectionLifecycleTransport) closeCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.closeCalls
+}
+
+func TestConcurrentLeaseAcquisitionSharesOneConnectionUntilFinalRelease(t *testing.T) {
+	registry := NewRegistryForTest(map[string]ServerConfig{
+		"shared": {Name: "shared", Type: TransportSTDIO, Command: "shared"},
+	})
+	tr := &connectionLifecycleTransport{}
+	var factoryCalls int
+	registry.newClientForConfig = func(cfg ServerConfig) *Client {
+		factoryCalls++
+		client := NewClient(cfg)
+		client.TransportFactory = func() (transport.Transport, error) { return tr, nil }
+		return client
+	}
+
+	start := make(chan struct{})
+	cleanups := make(chan func(), 2)
+	errors := make(chan []error, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			cleanup, errs := AcquireServerConnectionLeases(context.Background(), registry, []string{"shared"})
+			cleanups <- cleanup
+			errors <- errs
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	for range 2 {
+		if errs := <-errors; len(errs) != 0 {
+			t.Fatalf("AcquireServerConnectionLeases() errors = %v", errs)
+		}
+	}
+	if factoryCalls != 1 {
+		t.Fatalf("client factory calls = %d, want 1", factoryCalls)
+	}
+
+	firstCleanup := <-cleanups
+	secondCleanup := <-cleanups
+	firstCleanup()
+	if _, ok := registry.GetClient("shared"); !ok {
+		t.Fatal("first cleanup disconnected a connection still leased by another caller")
+	}
+	if tr.closeCount() != 0 {
+		t.Fatal("first cleanup closed the shared transport")
+	}
+
+	secondCleanup()
+	if _, ok := registry.GetClient("shared"); ok {
+		t.Fatal("last cleanup left its temporary connection in the registry")
+	}
+	deadline := time.Now().Add(time.Second)
+	for tr.closeCount() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if tr.closeCount() != 1 {
+		t.Fatalf("transport close count = %d, want 1", tr.closeCount())
+	}
+}
+
+func TestExplicitConnectRetainsLeaseCreatedConnectionAfterFinalRelease(t *testing.T) {
+	registry := NewRegistryForTest(map[string]ServerConfig{
+		"shared": {Name: "shared", Type: TransportSTDIO, Command: "shared"},
+	})
+	tr := &connectionLifecycleTransport{}
+	registry.newClientForConfig = func(cfg ServerConfig) *Client {
+		client := NewClient(cfg)
+		client.TransportFactory = func() (transport.Transport, error) { return tr, nil }
+		return client
+	}
+
+	cleanup, errs := AcquireServerConnectionLeases(context.Background(), registry, []string{"shared"})
+	if len(errs) != 0 {
+		t.Fatalf("AcquireServerConnectionLeases() errors = %v", errs)
+	}
+	if err := registry.Connect(context.Background(), "shared"); err != nil {
+		t.Fatalf("Connect() error = %v", err)
+	}
+	cleanup()
+
+	if _, ok := registry.GetClient("shared"); !ok {
+		t.Fatal("lease cleanup disconnected a connection promoted by an explicit Connect")
+	}
+	if tr.closeCount() != 0 {
+		t.Fatal("lease cleanup closed a connection promoted by an explicit Connect")
+	}
+}
+
+func TestLeaseSetReleaseIsIdempotent(t *testing.T) {
+	registry := NewRegistryForTest(map[string]ServerConfig{
+		"shared": {Name: "shared", Type: TransportSTDIO, Command: "shared"},
+	})
+	tr := &connectionLifecycleTransport{}
+	registry.newClientForConfig = func(cfg ServerConfig) *Client {
+		client := NewClient(cfg)
+		client.TransportFactory = func() (transport.Transport, error) { return tr, nil }
+		return client
+	}
+
+	first, errs := AcquireServerConnectionLeases(context.Background(), registry, []string{"shared"})
+	if len(errs) != 0 {
+		t.Fatalf("first AcquireServerConnectionLeases() errors = %v", errs)
+	}
+	second, errs := AcquireServerConnectionLeases(context.Background(), registry, []string{"shared"})
+	if len(errs) != 0 {
+		t.Fatalf("second AcquireServerConnectionLeases() errors = %v", errs)
+	}
+
+	first()
+	first()
+	if _, ok := registry.GetClient("shared"); !ok {
+		t.Fatal("repeated cleanup released another caller's lease")
+	}
+	second()
+	waitFor(t, "the final lease cleanup to close the transport", func() bool { return tr.closeCount() == 1 })
+}
+
+func TestDeadConnectionReplacementKeepsLeaseCountsSeparatedByConnectionEpoch(t *testing.T) {
+	registry := NewRegistryForTest(map[string]ServerConfig{
+		"shared": {Name: "shared", Type: TransportSTDIO, Command: "shared"},
+	})
+	firstTransport := &connectionLifecycleTransport{}
+	secondTransport := &connectionLifecycleTransport{}
+	transports := []transport.Transport{firstTransport, secondTransport}
+	registry.newClientForConfig = func(cfg ServerConfig) *Client {
+		tr := transports[0]
+		transports = transports[1:]
+		client := NewClient(cfg)
+		client.TransportFactory = func() (transport.Transport, error) { return tr, nil }
+		return client
+	}
+
+	first, errs := AcquireServerConnectionLeases(context.Background(), registry, []string{"shared"})
+	if len(errs) != 0 {
+		t.Fatalf("first AcquireServerConnectionLeases() errors = %v", errs)
+	}
+	firstTransport.mu.Lock()
+	firstTransport.alive = false
+	firstTransport.mu.Unlock()
+	second, errs := AcquireServerConnectionLeases(context.Background(), registry, []string{"shared"})
+	if len(errs) != 0 {
+		t.Fatalf("replacement AcquireServerConnectionLeases() errors = %v", errs)
+	}
+
+	first()
+	second()
+	if _, ok := registry.GetClient("shared"); ok {
+		t.Fatal("generation-specific lease cleanup leaked the replacement connection")
+	}
+	waitFor(t, "the replacement transport to close", func() bool { return secondTransport.closeCount() == 1 })
+}
+
+func TestExplicitRetentionIntentAppliesToLeaseTriggeredReplacement(t *testing.T) {
+	registry := NewRegistryForTest(map[string]ServerConfig{
+		"shared": {Name: "shared", Type: TransportSTDIO, Command: "shared"},
+	})
+	firstTransport := &connectionLifecycleTransport{}
+	secondTransport := &connectionLifecycleTransport{}
+	transports := []transport.Transport{firstTransport, secondTransport}
+	registry.newClientForConfig = func(cfg ServerConfig) *Client {
+		tr := transports[0]
+		transports = transports[1:]
+		client := NewClient(cfg)
+		client.TransportFactory = func() (transport.Transport, error) { return tr, nil }
+		return client
+	}
+
+	if err := registry.Connect(context.Background(), "shared"); err != nil {
+		t.Fatalf("persistent Connect() error = %v", err)
+	}
+	firstTransport.mu.Lock()
+	firstTransport.alive = false
+	firstTransport.mu.Unlock()
+	cleanup, errs := AcquireServerConnectionLeases(context.Background(), registry, []string{"shared"})
+	if len(errs) != 0 {
+		t.Fatalf("AcquireServerConnectionLeases() errors = %v", errs)
+	}
+	cleanup()
+
+	if _, ok := registry.GetClient("shared"); !ok {
+		t.Fatal("lease cleanup disconnected a replacement with persistent ownership")
+	}
+	if secondTransport.closeCount() != 0 {
+		t.Fatal("lease cleanup closed a persistently owned replacement")
+	}
+}
+
+func TestOldEpochLeaseReleaseCannotDisconnectCurrentConnection(t *testing.T) {
+	registry := NewRegistryForTest(map[string]ServerConfig{
+		"shared": {Name: "shared", Type: TransportSTDIO, Command: "shared"},
+	})
+	first := &connectionLifecycleTransport{}
+	second := &connectionLifecycleTransport{}
+	transports := []transport.Transport{first, second}
+	registry.newClientForConfig = func(cfg ServerConfig) *Client {
+		tr := transports[0]
+		transports = transports[1:]
+		client := NewClient(cfg)
+		client.TransportFactory = func() (transport.Transport, error) { return tr, nil }
+		return client
+	}
+
+	cleanup, errs := AcquireServerConnectionLeases(context.Background(), registry, []string{"shared"})
+	if len(errs) != 0 {
+		t.Fatalf("AcquireServerConnectionLeases() errors = %v", errs)
+	}
+	registry.Disconnect("shared")
+	if err := registry.Connect(context.Background(), "shared"); err != nil {
+		t.Fatalf("replacement Connect() error = %v", err)
+	}
+	cleanup()
+
+	client, ok := registry.GetClient("shared")
+	if !ok || client == nil {
+		t.Fatal("stale lease cleanup removed the replacement connection")
+	}
+	if !second.IsAlive() {
+		t.Fatal("stale lease cleanup closed the replacement transport")
+	}
+}

--- a/internal/mcp/disconnect_test.go
+++ b/internal/mcp/disconnect_test.go
@@ -49,6 +49,7 @@ func connectedRegistry(t *testing.T, servers map[string]transport.Transport) *Re
 		c.mu.Unlock()
 		r.configs[name] = cfg
 		r.clients[name] = c
+		r.retainWithoutLeases[name] = true
 	}
 	return r
 }
@@ -112,6 +113,37 @@ func TestDisconnectAllDoesNotBlockPerServer(t *testing.T) {
 		case <-time.After(2 * time.Second):
 			t.Errorf("transport %d was never torn down", i)
 		}
+	}
+}
+
+func TestDisconnectAllNotifiesToolsChanged(t *testing.T) {
+	tr := newSlowTransport(0)
+	r := connectedRegistry(t, map[string]transport.Transport{"shared": tr})
+	notified := make(chan struct{}, 1)
+	r.SetOnToolsChanged(func() { notified <- struct{}{} })
+
+	r.DisconnectAll()
+	select {
+	case <-notified:
+	case <-time.After(time.Second):
+		t.Fatal("DisconnectAll did not notify tool-schema subscribers")
+	}
+}
+
+func TestToolsChangedCallbackCanReenterConnectionLifecycle(t *testing.T) {
+	tr := newSlowTransport(0)
+	r := connectedRegistry(t, map[string]transport.Transport{"shared": tr})
+	done := make(chan struct{})
+	r.SetOnToolsChanged(func() {
+		r.DisconnectAll()
+		close(done)
+	})
+
+	r.Disconnect("shared")
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("tools-changed callback deadlocked reentering the lifecycle API")
 	}
 }
 

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -32,18 +32,25 @@ type PluginServer struct {
 
 // Registry manages multiple MCP server connections
 type Registry struct {
-	mu         sync.RWMutex
-	clients    map[string]*Client
-	configs    map[string]ServerConfig
-	disabled   map[string]bool   // servers explicitly disabled by the user
-	connecting map[string]bool   // servers currently being connected (async)
-	connectErr map[string]string // last connection error for servers without a client
-	loader     *ConfigLoader
-	cwd        string
+	mu                           sync.RWMutex
+	connectionLifecycleMu        sync.Mutex
+	clients                      map[string]*Client
+	configs                      map[string]ServerConfig
+	disabled                     map[string]bool           // servers explicitly disabled by the user
+	connecting                   map[string]bool           // servers currently being connected (async)
+	connectErr                   map[string]string         // last connection error for servers without a client
+	leaseCountsByConnectionEpoch map[string]map[uint64]int // active per-agent users grouped by connection generation
+	disconnectAfterFinalLease    map[string]bool           // connections created solely for active leases
+	retainWithoutLeases          map[string]bool           // explicit connection intent, retained across reconnects
+	connectionEpoch              map[string]uint64         // changes whenever a connection is replaced
+	loader                       *ConfigLoader
+	cwd                          string
 
 	// PluginServers returns MCP servers contributed by plugins. Injected by
 	// the app layer to avoid mcp importing plugin (same-layer dependency).
 	PluginServers func() []PluginServer
+
+	newClientForConfig func(ServerConfig) *Client // test seam; nil uses NewClient
 
 	// Callback when tool schemas change
 	onToolsChanged func()
@@ -59,11 +66,12 @@ type mcpState struct {
 // guarding is the swap, which Initialize performs on the bubbletea goroutine
 // (reloadProjectServices) while DefaultRegistry() is read elsewhere.
 var (
-	registryMu      sync.RWMutex
-	defaultRegistry = newEmptyRegistry()
+	registryMu         sync.RWMutex
+	registryTransferMu sync.Mutex
+	defaultRegistry    = newEmptyRegistry()
 )
 
-// adoptLiveClients moves connections from the outgoing registry into this one
+// transferRetainedConnectionsFrom moves connections from the outgoing registry into this one
 // for every server whose configuration is unchanged, and tears down the rest.
 //
 // Without it a cwd change replaced the registry with a fresh, zero-client one:
@@ -74,32 +82,53 @@ var (
 // The teardown of servers that did NOT survive runs detached: Client.Disconnect
 // waits on the child's read loop and exit, up to seven seconds per server, and
 // Initialize is called from the bubbletea goroutine.
-func (r *Registry) adoptLiveClients(old *Registry) {
-	if old == nil || old == r {
+func (incoming *Registry) transferRetainedConnectionsFrom(outgoing *Registry) {
+	if outgoing == nil || outgoing == incoming {
 		return
 	}
 
-	old.mu.Lock()
-	adopted := make(map[string]*Client)
-	var stale []*Client
-	for name, client := range old.clients {
-		cfg, stillConfigured := r.configs[name]
-		if stillConfigured && reflect.DeepEqual(cfg, old.configs[name]) && client.IsConnected() {
-			adopted[name] = client
+	registryTransferMu.Lock()
+	defer registryTransferMu.Unlock()
+	outgoing.connectionLifecycleMu.Lock()
+	defer outgoing.connectionLifecycleMu.Unlock()
+	incoming.connectionLifecycleMu.Lock()
+	defer incoming.connectionLifecycleMu.Unlock()
+
+	outgoing.mu.Lock()
+	connectionsToTransfer := make(map[string]*Client)
+	retainedConnectionsToDisconnect := make(map[string]*Client)
+	for name, client := range outgoing.clients {
+		cfg, stillConfigured := incoming.configs[name]
+		if !outgoing.retainWithoutLeases[name] {
 			continue
 		}
-		stale = append(stale, client)
+		if stillConfigured && reflect.DeepEqual(cfg, outgoing.configs[name]) && client.IsConnected() {
+			connectionsToTransfer[name] = client
+			continue
+		}
+		retainedConnectionsToDisconnect[name] = client
 	}
-	old.clients = make(map[string]*Client)
-	old.mu.Unlock()
+	for name, client := range connectionsToTransfer {
+		delete(outgoing.clients, name)
+		delete(outgoing.retainWithoutLeases, name)
+		client.SetOnToolsChanged(incoming.notifyToolsChanged)
+	}
+	for name := range retainedConnectionsToDisconnect {
+		delete(outgoing.clients, name)
+		delete(outgoing.retainWithoutLeases, name)
+	}
+	outgoing.mu.Unlock()
 
-	r.mu.Lock()
-	maps.Copy(r.clients, adopted)
-	r.mu.Unlock()
+	incoming.mu.Lock()
+	maps.Copy(incoming.clients, connectionsToTransfer)
+	for name := range connectionsToTransfer {
+		incoming.retainWithoutLeases[name] = true
+	}
+	incoming.mu.Unlock()
 
-	if len(stale) > 0 {
+	if len(retainedConnectionsToDisconnect) > 0 {
 		go func() {
-			for _, c := range stale {
+			for _, c := range retainedConnectionsToDisconnect {
 				_ = c.Disconnect()
 			}
 		}()
@@ -108,11 +137,15 @@ func (r *Registry) adoptLiveClients(old *Registry) {
 
 func newEmptyRegistry() *Registry {
 	return &Registry{
-		clients:    make(map[string]*Client),
-		configs:    make(map[string]ServerConfig),
-		disabled:   make(map[string]bool),
-		connecting: make(map[string]bool),
-		connectErr: make(map[string]string),
+		clients:                      make(map[string]*Client),
+		configs:                      make(map[string]ServerConfig),
+		disabled:                     make(map[string]bool),
+		connecting:                   make(map[string]bool),
+		connectErr:                   make(map[string]string),
+		leaseCountsByConnectionEpoch: make(map[string]map[uint64]int),
+		disconnectAfterFinalLease:    make(map[string]bool),
+		retainWithoutLeases:          make(map[string]bool),
+		connectionEpoch:              make(map[string]uint64),
 	}
 }
 
@@ -120,11 +153,15 @@ func newEmptyRegistry() *Registry {
 // It does not read from disk.
 func NewRegistryForTest(configs map[string]ServerConfig) *Registry {
 	return &Registry{
-		clients:    make(map[string]*Client),
-		configs:    configs,
-		disabled:   make(map[string]bool),
-		connecting: make(map[string]bool),
-		connectErr: make(map[string]string),
+		clients:                      make(map[string]*Client),
+		configs:                      configs,
+		disabled:                     make(map[string]bool),
+		connecting:                   make(map[string]bool),
+		connectErr:                   make(map[string]string),
+		leaseCountsByConnectionEpoch: make(map[string]map[uint64]int),
+		disconnectAfterFinalLease:    make(map[string]bool),
+		retainWithoutLeases:          make(map[string]bool),
+		connectionEpoch:              make(map[string]uint64),
 	}
 }
 
@@ -137,13 +174,17 @@ func NewRegistry(cwd string) (*Registry, error) {
 	}
 
 	reg := &Registry{
-		clients:    make(map[string]*Client),
-		configs:    configs,
-		disabled:   make(map[string]bool),
-		connecting: make(map[string]bool),
-		connectErr: make(map[string]string),
-		loader:     loader,
-		cwd:        cwd,
+		clients:                      make(map[string]*Client),
+		configs:                      configs,
+		disabled:                     make(map[string]bool),
+		connecting:                   make(map[string]bool),
+		connectErr:                   make(map[string]string),
+		leaseCountsByConnectionEpoch: make(map[string]map[uint64]int),
+		disconnectAfterFinalLease:    make(map[string]bool),
+		retainWithoutLeases:          make(map[string]bool),
+		connectionEpoch:              make(map[string]uint64),
+		loader:                       loader,
+		cwd:                          cwd,
 	}
 	reg.configs = reg.mergePluginMCPConfigs(configs)
 	reg.loadState()
@@ -160,18 +201,36 @@ func (r *Registry) Reload() error {
 	}
 	configs = r.mergePluginMCPConfigs(configs)
 
+	r.connectionLifecycleMu.Lock()
+	retainedConnectionsInvalidatedByReload := make(map[string]*Client)
 	r.mu.Lock()
-	// Disconnect clients whose config was removed.
+	// Disconnect clients whose config was removed or changed. Active temporary
+	// lease-owned clients stay with their current registry until their owner
+	// releases them; reload must not invalidate an in-flight Agent run.
 	for name, client := range r.clients {
-		if _, ok := configs[name]; !ok {
-			_ = client.Disconnect()
-			delete(r.clients, name)
-			delete(r.connecting, name)
-			delete(r.connectErr, name)
+		config, ok := configs[name]
+		if !r.retainWithoutLeases[name] || ok && reflect.DeepEqual(config, r.configs[name]) {
+			continue
 		}
+		retainedConnectionsInvalidatedByReload[name] = client
+		delete(r.clients, name)
+		delete(r.connecting, name)
+		delete(r.connectErr, name)
+		delete(r.leaseCountsByConnectionEpoch, name)
+		delete(r.disconnectAfterFinalLease, name)
+		delete(r.retainWithoutLeases, name)
+		r.connectionEpoch[name]++
 	}
 	r.configs = configs
 	r.mu.Unlock()
+	r.connectionLifecycleMu.Unlock()
+
+	for name, client := range retainedConnectionsInvalidatedByReload {
+		disconnectClientAsync(name, client)
+	}
+	if len(retainedConnectionsInvalidatedByReload) > 0 {
+		r.notifyToolsChanged()
+	}
 	return nil
 }
 
@@ -213,6 +272,8 @@ func (r *Registry) AddServer(name string, config ServerConfig, scope Scope) erro
 
 // RemoveServer removes a server configuration
 func (r *Registry) RemoveServer(name string) error {
+	r.connectionLifecycleMu.Lock()
+	defer r.connectionLifecycleMu.Unlock()
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -220,6 +281,7 @@ func (r *Registry) RemoveServer(name string) error {
 	if client, ok := r.clients[name]; ok {
 		_ = client.Disconnect()
 		delete(r.clients, name)
+		r.connectionEpoch[name]++
 	}
 
 	// Remove from all configs
@@ -230,40 +292,136 @@ func (r *Registry) RemoveServer(name string) error {
 	delete(r.configs, name)
 	delete(r.connecting, name)
 	delete(r.connectErr, name)
+	delete(r.leaseCountsByConnectionEpoch, name)
+	delete(r.disconnectAfterFinalLease, name)
+	delete(r.retainWithoutLeases, name)
 	return nil
 }
 
-// Connect connects to an MCP server
-func (r *Registry) Connect(ctx context.Context, name string) error {
+// Connect connects to an MCP server and keeps the connection persistent until
+// an explicit disconnect, even if an Agent definition originally created it.
+func (r *Registry) Connect(ctx context.Context, serverName string) error {
+	r.connectionLifecycleMu.Lock()
+	installedNewClient, err := r.ensureConnectedWhileLifecycleLocked(ctx, serverName)
+	if err == nil {
+		r.mu.Lock()
+		r.retainWithoutLeases[serverName] = true
+		delete(r.disconnectAfterFinalLease, serverName)
+		r.mu.Unlock()
+	}
+	r.connectionLifecycleMu.Unlock()
+
+	if installedNewClient {
+		r.notifyToolsChanged()
+	}
+	return err
+}
+
+// ensureConnectedWhileLifecycleLocked establishes one connection and reports whether it installed
+// the registry's current client. The caller must hold connectionLifecycleMu so duplicate
+// transports cannot be created and ownership changes stay atomic.
+func (r *Registry) ensureConnectedWhileLifecycleLocked(ctx context.Context, serverName string) (installedNewClient bool, err error) {
 	r.mu.Lock()
-	config, ok := r.configs[name]
+	config, ok := r.configs[serverName]
 	if !ok {
 		r.mu.Unlock()
-		return fmt.Errorf("server not found: %s", name)
+		return false, fmt.Errorf("server not found: %s", serverName)
 	}
-
-	// Already connected?
-	if client, ok := r.clients[name]; ok && client.IsConnected() {
+	if client, ok := r.clients[serverName]; ok && client.IsConnected() {
 		r.mu.Unlock()
-		return nil
+		return false, nil
 	}
+	factory := r.newClientForConfig
 	r.mu.Unlock()
 
-	// Create and connect client
 	client := NewClient(config)
-	if err := client.Connect(ctx); err != nil {
-		return fmt.Errorf("failed to connect to %s: %w", name, err)
+	if factory != nil {
+		client = factory(config)
 	}
-
-	// Set up tools changed callback
+	if err := client.Connect(ctx); err != nil {
+		return false, fmt.Errorf("failed to connect to %s: %w", serverName, err)
+	}
 	client.SetOnToolsChanged(r.notifyToolsChanged)
 
 	r.mu.Lock()
-	r.clients[name] = client
+	r.clients[serverName] = client
+	if r.connectionEpoch == nil {
+		r.connectionEpoch = make(map[string]uint64)
+	}
+	r.connectionEpoch[serverName]++
 	r.mu.Unlock()
+	return true, nil
+}
 
-	r.notifyToolsChanged()
-	return nil
+// acquireConnectionLease keeps a configured server connected for one custom-Agent run.
+// The first lease owns a newly-created temporary connection; later leases share
+// it. A connection that predated all leases remains persistent after release.
+func (r *Registry) acquireConnectionLease(ctx context.Context, serverName string) (connectionEpoch uint64, err error) {
+	r.connectionLifecycleMu.Lock()
+	installedNewClient, err := r.ensureConnectedWhileLifecycleLocked(ctx, serverName)
+	if err != nil {
+		r.connectionLifecycleMu.Unlock()
+		return 0, err
+	}
+
+	r.mu.Lock()
+	if r.leaseCountsByConnectionEpoch == nil {
+		r.leaseCountsByConnectionEpoch = make(map[string]map[uint64]int)
+	}
+	connectionEpoch = r.connectionEpoch[serverName]
+	if r.leaseCountsByConnectionEpoch[serverName] == nil {
+		r.leaseCountsByConnectionEpoch[serverName] = make(map[uint64]int)
+	}
+	r.leaseCountsByConnectionEpoch[serverName][connectionEpoch]++
+	if installedNewClient && !r.retainWithoutLeases[serverName] {
+		r.disconnectAfterFinalLease[serverName] = true
+	}
+	r.mu.Unlock()
+	r.connectionLifecycleMu.Unlock()
+
+	if installedNewClient {
+		r.notifyToolsChanged()
+	}
+	return connectionEpoch, nil
+}
+
+// releaseConnectionLease drops one custom-Agent lease and disconnects only a temporary
+// connection whose final lease ended. A stale cleanup from an older connection
+// generation cannot affect a replacement connection with the same name.
+func (r *Registry) releaseConnectionLease(serverName string, leasedConnectionEpoch uint64) {
+	r.connectionLifecycleMu.Lock()
+
+	var clientDetachedAfterFinalLease *Client
+
+	r.mu.Lock()
+	leaseCountsByEpoch := r.leaseCountsByConnectionEpoch[serverName]
+	if leaseCountsByEpoch == nil || leaseCountsByEpoch[leasedConnectionEpoch] == 0 {
+		r.mu.Unlock()
+		r.connectionLifecycleMu.Unlock()
+		return
+	}
+	if leaseCountsByEpoch[leasedConnectionEpoch] > 1 {
+		leaseCountsByEpoch[leasedConnectionEpoch]--
+		r.mu.Unlock()
+		r.connectionLifecycleMu.Unlock()
+		return
+	}
+	delete(leaseCountsByEpoch, leasedConnectionEpoch)
+	if len(leaseCountsByEpoch) == 0 {
+		delete(r.leaseCountsByConnectionEpoch, serverName)
+	}
+	if r.connectionEpoch[serverName] == leasedConnectionEpoch && r.disconnectAfterFinalLease[serverName] && !r.retainWithoutLeases[serverName] {
+		clientDetachedAfterFinalLease = r.clients[serverName]
+		delete(r.clients, serverName)
+		delete(r.disconnectAfterFinalLease, serverName)
+	}
+	r.mu.Unlock()
+	r.connectionLifecycleMu.Unlock()
+
+	if clientDetachedAfterFinalLease != nil {
+		disconnectClientAsync(serverName, clientDetachedAfterFinalLease)
+		r.notifyToolsChanged()
+	}
 }
 
 // ConnectAll connects to all configured MCP servers.
@@ -296,36 +454,55 @@ func (r *Registry) ConnectAll(ctx context.Context) []error {
 // inline froze the UI for that whole time, and doing it under r.mu froze the
 // agent goroutine with it, since CallTool takes the read lock.
 func (r *Registry) Disconnect(name string) {
+	r.connectionLifecycleMu.Lock()
+
 	r.mu.Lock()
 	client, ok := r.clients[name]
 	if ok {
 		delete(r.clients, name)
+		r.connectionEpoch[name]++
 	}
+	delete(r.leaseCountsByConnectionEpoch, name)
+	delete(r.disconnectAfterFinalLease, name)
+	delete(r.retainWithoutLeases, name)
 	r.mu.Unlock()
+	r.connectionLifecycleMu.Unlock()
 	if !ok {
 		return
 	}
 
-	closeInBackground(name, client)
+	disconnectClientAsync(name, client)
 	r.notifyToolsChanged()
 }
 
 // DisconnectAll disconnects from all MCP servers
 func (r *Registry) DisconnectAll() {
+	r.connectionLifecycleMu.Lock()
+
 	r.mu.Lock()
 	clients := r.clients
 	r.clients = make(map[string]*Client)
+	for name := range clients {
+		r.connectionEpoch[name]++
+	}
+	r.leaseCountsByConnectionEpoch = make(map[string]map[uint64]int)
+	r.disconnectAfterFinalLease = make(map[string]bool)
+	r.retainWithoutLeases = make(map[string]bool)
 	r.mu.Unlock()
+	r.connectionLifecycleMu.Unlock()
 
 	for name, client := range clients {
-		closeInBackground(name, client)
+		disconnectClientAsync(name, client)
+	}
+	if len(clients) > 0 {
+		r.notifyToolsChanged()
 	}
 }
 
-// closeInBackground tears a client down off the caller's goroutine, reporting
+// disconnectClientAsync tears a client down off the caller's goroutine, reporting
 // a failure to the log — the caller cannot act on it, and waiting for it is
 // what froze the UI.
-func closeInBackground(name string, client *Client) {
+func disconnectClientAsync(name string, client *Client) {
 	go func() {
 		if err := client.Disconnect(); err != nil {
 			log.Logger().Warn("mcp: disconnect failed",

--- a/internal/mcp/service.go
+++ b/internal/mcp/service.go
@@ -42,10 +42,9 @@ type Tools interface {
 // configured servers, connect or disconnect them individually or in
 // bulk, and read per-server config. Implemented by *Registry.
 //
-// Consumers: the ConnectServers free function (which the subagent
-// executor uses to bring up a curated server set per invocation). The
-// TUI /mcp selector needs methods beyond this interface (RemoveServer,
-// SetDisabled, SetConnectError, …) and depends on *Registry directly.
+// The TUI /mcp selector consumes this interface. Per-Agent connection leases
+// intentionally require *Registry because their epoch-aware operations are
+// internal lifecycle details, not ordinary connection ownership.
 type Servers interface {
 	List() []Server
 	Connect(ctx context.Context, name string) error
@@ -87,7 +86,7 @@ func Initialize(opts Options) error {
 	// the old project and the new one — tearing it down would drop every
 	// mcp__* tool from the agent mid-session, with nothing to reconnect it
 	// (AutoConnect only runs at startup).
-	reg.adoptLiveClients(DefaultRegistry())
+	reg.transferRetainedConnectionsFrom(DefaultRegistry())
 	setDefaultRegistry(reg)
 	return nil
 }

--- a/internal/subagent/executor.go
+++ b/internal/subagent/executor.go
@@ -45,7 +45,7 @@ type Executor struct {
 	projectInstructions        string               // project memory (CLAUDE.md/AGENTS.md) for edit-capable subagents
 	skillsPrompt               string               // available skills section for capable subagents
 	mcpTools                   mcp.Tools            // tool schemas + execution
-	mcpServers                 mcp.Servers          // connect/disconnect for per-subagent server sets
+	mcpConnectionRegistry      *mcp.Registry        // per-Agent connection leases
 }
 
 type SubagentSessionStore interface {
@@ -138,12 +138,11 @@ func (e *Executor) SetSkillsDirectory(skillsPrompt string) {
 	e.skillsPrompt = skillsPrompt
 }
 
-// SetMCP wires the parent's MCP access for the subagent. Tool schemas
-// and execution flow through tools; connection lifecycle for any
-// per-subagent server set flows through servers.
-func (e *Executor) SetMCP(tools mcp.Tools, servers mcp.Servers) {
+// SetMCPDependencies wires MCP tool access separately from the concrete
+// registry used to lease per-Agent server connections.
+func (e *Executor) SetMCPDependencies(tools mcp.Tools, connectionRegistry *mcp.Registry) {
 	e.mcpTools = tools
-	e.mcpServers = servers
+	e.mcpConnectionRegistry = connectionRegistry
 }
 
 // SetSessionStore configures session persistence for subagent conversations.
@@ -357,14 +356,14 @@ func (e *Executor) fireSubagentStart(req tool.AgentExecRequest, agentHookID stri
 func (e *Executor) buildAgent(ctx context.Context, run *preparedRun, onToolExec func(string, map[string]any), onEvent func(core.Event)) (core.Agent, func(), error) {
 	rc := run.cfg
 	agentCwd := run.cwd
-	cleanup := func() {}
+	releaseMCPLeases := func() {}
 
-	if len(rc.config.McpServers) > 0 && e.mcpServers != nil {
-		mcpCleanup, errs := mcp.ConnectServers(ctx, e.mcpServers, rc.config.McpServers)
-		if mcpCleanup != nil {
-			cleanup = mcpCleanup
+	if len(rc.config.McpServers) > 0 && e.mcpConnectionRegistry != nil {
+		releaseAcquiredMCPLeases, leaseAcquireErrors := mcp.AcquireServerConnectionLeases(ctx, e.mcpConnectionRegistry, rc.config.McpServers)
+		if releaseAcquiredMCPLeases != nil {
+			releaseMCPLeases = releaseAcquiredMCPLeases
 		}
-		for _, err := range errs {
+		for _, err := range leaseAcquireErrors {
 			log.Logger().Warn("Agent MCP server connection failed", zap.Error(err))
 		}
 	}
@@ -428,7 +427,7 @@ func (e *Executor) buildAgent(ctx context.Context, run *preparedRun, onToolExec 
 		OnEvent:     onEvent,
 	})
 
-	return ag, cleanup, nil
+	return ag, releaseMCPLeases, nil
 }
 
 // subagentCompactFunc summarizes the conversation on the run's own model so


### PR DESCRIPTION
Make MCP connections safe for concurrent per-Agent use.

- Add lease- and generation-aware connection ownership and cleanup.
- Preserve persistent intent and callbacks across reconnect, adoption, and reload.
- Connect configured MCP servers for TUI and headless Agent runs.

Stack: #410 → #411 → **3/3**