### PR TITLE
fix(agent): use unknown names as display labels

### DIFF
--- a/internal/subagent/adapter.go
+++ b/internal/subagent/adapter.go
@@ -70,7 +70,7 @@ func (a *ExecutorAdapter) ResolveAgentSelection(name string) (tool.AgentConfigIn
 		return tool.AgentConfigInfo{}, nil, false
 	}
 	info := ToAgentConfigInfo(config)
-	if strings.TrimSpace(name) == "" {
+	if strings.TrimSpace(name) == "" || config.displayOnly {
 		info.PermissionMode = string(a.Executor.currentParentPermissionMode())
 	}
 	return info, config, true

--- a/internal/subagent/executor.go
+++ b/internal/subagent/executor.go
@@ -280,8 +280,9 @@ func baseAgentConfig() *AgentConfig {
 	}
 }
 
-// resolveAgentConfig returns the unnamed base configuration when no name is
-// requested. Named definitions are resolved through the registry.
+// resolveAgentConfig returns the base configuration for an omitted or unknown
+// name. A matching enabled definition overrides the base configuration; a
+// matching disabled definition is rejected instead of silently bypassed.
 func resolveAgentConfig(name string) (*AgentConfig, bool) {
 	return resolveAgentConfigFrom(Default(), name)
 }
@@ -292,9 +293,22 @@ func resolveAgentConfigFrom(registry *Registry, name string) (*AgentConfig, bool
 		return baseAgentConfig(), true
 	}
 	if registry == nil {
-		return nil, false
+		return displayOnlyAgentConfig(name), true
 	}
-	return registry.ResolveEnabledAgent(name)
+	if config, exists, enabled := registry.LookupAgent(name); exists {
+		return config, enabled
+	}
+	return displayOnlyAgentConfig(name), true
+}
+
+// displayOnlyAgentConfig preserves an unknown requested name for identity and
+// UI display while otherwise using the base agent template. In particular it
+// has no custom prompt, skills, tool rules, model override, or mode override.
+func displayOnlyAgentConfig(name string) *AgentConfig {
+	config := baseAgentConfig()
+	config.Name = strings.TrimSpace(name)
+	config.displayOnly = true
+	return config
 }
 
 func (e *Executor) resolveAgentConfig(name string) (*AgentConfig, bool) {

--- a/internal/subagent/executor_prompt.go
+++ b/internal/subagent/executor_prompt.go
@@ -174,7 +174,7 @@ func (e *Executor) requestPermissionMode(config *AgentConfig, req tool.AgentExec
 	case "edit":
 		return PermissionAcceptEdits
 	case "", "default":
-		if strings.TrimSpace(req.Agent) == "" {
+		if strings.TrimSpace(req.Agent) == "" || config.displayOnly {
 			return e.currentParentPermissionMode()
 		}
 		return NormalizePermissionMode(string(config.PermissionMode))

--- a/internal/subagent/executor_test.go
+++ b/internal/subagent/executor_test.go
@@ -748,8 +748,15 @@ func TestResolveAgentConfigUsesUnnamedAndNamedDefinitions(t *testing.T) {
 	if !ok || resolved != literalSubagent {
 		t.Fatalf("explicit subagent config = %#v, %v; want registered config", resolved, ok)
 	}
-	if _, ok := resolveAgentConfig("missing"); ok {
-		t.Fatal("unknown agent should not resolve")
+	resolved, ok = resolveAgentConfig("missing")
+	if !ok {
+		t.Fatal("unknown agent name should resolve through the base template")
+	}
+	if resolved.Name != "missing" || !resolved.displayOnly {
+		t.Fatalf("unknown agent config = %#v; want display-only name", resolved)
+	}
+	if resolved.SystemPrompt != "" || len(resolved.Skills) != 0 || resolved.AllowTools != nil || resolved.DenyTools != nil {
+		t.Fatalf("display-only config inherited custom behavior: %#v", resolved)
 	}
 }
 
@@ -795,6 +802,10 @@ func TestRequestPermissionModeInheritanceAndNamedConfig(t *testing.T) {
 
 	if got := executor.requestPermissionMode(baseAgentConfig(), tool.AgentExecRequest{}); got != PermissionBypass {
 		t.Fatalf("unnamed agent mode = %q, want inherited bypass", got)
+	}
+	displayOnly := displayOnlyAgentConfig("autopilot-suggestion")
+	if got := executor.requestPermissionMode(displayOnly, tool.AgentExecRequest{Agent: "autopilot-suggestion"}); got != PermissionBypass {
+		t.Fatalf("display-only agent mode = %q, want inherited bypass", got)
 	}
 	named := &AgentConfig{Name: "reviewer", PermissionMode: PermissionExplore}
 	if got := executor.requestPermissionMode(named, tool.AgentExecRequest{Agent: "reviewer"}); got != PermissionExplore {

--- a/internal/subagent/registry.go
+++ b/internal/subagent/registry.go
@@ -44,17 +44,25 @@ func (r *Registry) Get(name string) (*AgentConfig, bool) {
 	return config, ok
 }
 
-// ResolveEnabledAgent returns an enabled agent configuration by exact name.
-func (r *Registry) ResolveEnabledAgent(name string) (*AgentConfig, bool) {
+// LookupAgent returns an agent definition together with whether it exists and
+// is enabled. Keeping the two states separate lets callers reject an explicitly
+// disabled definition while treating an unknown name as a display-only label.
+func (r *Registry) LookupAgent(name string) (config *AgentConfig, exists, enabled bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	lowerName := strings.ToLower(strings.TrimSpace(name))
-	config, ok := r.agents[lowerName]
-	if !ok || r.isDisabledInternal(lowerName) {
-		return nil, false
+	config, exists = r.agents[lowerName]
+	if !exists {
+		return nil, false, false
 	}
-	return config, true
+	return config, true, !r.isDisabledInternal(lowerName)
+}
+
+// ResolveEnabledAgent returns an enabled agent configuration by exact name.
+func (r *Registry) ResolveEnabledAgent(name string) (*AgentConfig, bool) {
+	config, exists, enabled := r.LookupAgent(name)
+	return config, exists && enabled
 }
 
 // ListConfigs returns all registered agent configurations that are visible

--- a/internal/subagent/types.go
+++ b/internal/subagent/types.go
@@ -330,6 +330,10 @@ type AgentConfig struct {
 	McpServers   []string `yaml:"mcp-servers,omitempty" json:"mcp_servers,omitempty"`
 	SourceFile   string   `yaml:"-" json:"-"`
 
+	// displayOnly marks a runtime-only base-template config whose Name is just a
+	// UI label. It is never loaded from an agent definition.
+	displayOnly bool
+
 	systemPromptOnce sync.Once `yaml:"-" json:"-"`
 }
 

--- a/internal/tool/agent/agent_test.go
+++ b/internal/tool/agent/agent_test.go
@@ -104,15 +104,31 @@ func TestAgentToolOmittedNameStaysEmpty(t *testing.T) {
 	}
 }
 
-func TestAgentToolRejectsUnknownOrDisabledNameBeforePermission(t *testing.T) {
+func TestAgentToolAcceptsUnknownNameAsDisplayLabel(t *testing.T) {
+	fallbackConfig := &struct{ Template string }{Template: "default"}
+	executor := &recordingExecutor{configOK: true, resolvedConfig: fallbackConfig}
 	agentTool := NewAgentTool()
-	agentTool.SetExecutor(&recordingExecutor{})
-	_, err := agentTool.PreparePermission(context.Background(), map[string]any{
-		"name":        "missing",
-		"description": "Inspect code",
-		"prompt":      "Find references",
-	}, ".")
-	if err == nil {
-		t.Fatal("unknown or disabled custom name should fail")
+	agentTool.SetExecutor(executor)
+	params := map[string]any{
+		"name":              "autopilot-suggestion",
+		"description":       "Trace autopilot suggestions",
+		"prompt":            "Trace the suggestion flow",
+		"run_in_background": true,
+	}
+
+	permission, err := agentTool.PreparePermission(context.Background(), params, ".")
+	if err != nil {
+		t.Fatalf("display-only name should be accepted: %v", err)
+	}
+	if permission.AgentMeta.AgentName != "autopilot-suggestion" {
+		t.Fatalf("permission agent name = %q", permission.AgentMeta.AgentName)
+	}
+
+	result := agentTool.ExecuteApproved(context.Background(), params, ".")
+	if !result.Success {
+		t.Fatalf("background display-only agent failed: %s", result.Error)
+	}
+	if executor.runReq.Agent != "autopilot-suggestion" || executor.runReq.ResolvedAgentConfig != fallbackConfig {
+		t.Fatalf("execution request = %#v", executor.runReq)
 	}
 }

--- a/internal/tool/agent/schema.go
+++ b/internal/tool/agent/schema.go
@@ -66,7 +66,7 @@ var agentToolParameters = map[string]any{
 		},
 		"name": map[string]any{
 			"type":        "string",
-			"description": "Optional agent name. Use an available agent definition's exact name to apply its configured prompt and settings. Any other name is only a display label and uses the default agent template with no custom agent prompt. Omit it to use the default template and standard display name.",
+			"description": "Choose an available agent, or name a new general-purpose agent for this task. New names are for display only.",
 		},
 		"run_in_background": map[string]any{
 			"type":        "boolean",

--- a/internal/tool/agent/schema.go
+++ b/internal/tool/agent/schema.go
@@ -66,7 +66,7 @@ var agentToolParameters = map[string]any{
 		},
 		"name": map[string]any{
 			"type":        "string",
-			"description": "Optional agent name.",
+			"description": "Optional agent name. Use an available agent definition's exact name to apply its configured prompt and settings. Any other name is only a display label and uses the default agent template with no custom agent prompt. Omit it to use the default template and standard display name.",
 		},
 		"run_in_background": map[string]any{
 			"type":        "boolean",

--- a/internal/tool/agent/schema_test.go
+++ b/internal/tool/agent/schema_test.go
@@ -43,14 +43,17 @@ func TestAgentToolSchemaMatchesEmptyDirectory(t *testing.T) {
 	}
 }
 
-func TestAgentSchemaUsesOptionalName(t *testing.T) {
+func TestAgentSchemaExplainsNameResolution(t *testing.T) {
 	properties := agentToolParameters["properties"].(map[string]any)
 	name, ok := properties["name"].(map[string]any)
 	if !ok {
 		t.Fatal("Agent schema should expose name")
 	}
-	if name["description"] != "Optional agent name." {
-		t.Fatalf("name description = %q", name["description"])
+	description, _ := name["description"].(string)
+	for _, want := range []string{"available agent definition", "display label", "default agent template", "no custom agent prompt"} {
+		if !strings.Contains(description, want) {
+			t.Fatalf("name description %q should contain %q", description, want)
+		}
 	}
 }
 

--- a/internal/tool/agent/schema_test.go
+++ b/internal/tool/agent/schema_test.go
@@ -49,11 +49,9 @@ func TestAgentSchemaExplainsNameResolution(t *testing.T) {
 	if !ok {
 		t.Fatal("Agent schema should expose name")
 	}
-	description, _ := name["description"].(string)
-	for _, want := range []string{"available agent definition", "display label", "default agent template", "no custom agent prompt"} {
-		if !strings.Contains(description, want) {
-			t.Fatalf("name description %q should contain %q", description, want)
-		}
+	want := "Choose an available agent, or name a new general-purpose agent for this task. New names are for display only."
+	if description := name["description"]; description != want {
+		t.Fatalf("name description = %q, want %q", description, want)
 	}
 }
 

--- a/tests/integration/agent/agent_test.go
+++ b/tests/integration/agent/agent_test.go
@@ -52,16 +52,23 @@ func TestAgent_GeneralExploreMode(t *testing.T) {
 	}
 }
 
-func TestAgent_UnknownAgent(t *testing.T) {
-	mp := &testutil.MockProvider{}
+func TestAgent_UnknownNameUsesDefaultTemplate(t *testing.T) {
+	mp := &testutil.MockProvider{
+		Responses: []llm.CompletionResponse{
+			{Content: "completed with default template", StopReason: "end_turn"},
+		},
+	}
 	executor := subagent.NewExecutor(mp, t.TempDir(), "fake-model", nil)
 
-	_, err := executor.Run(context.Background(), tool.AgentExecRequest{
+	result, err := executor.Run(context.Background(), tool.AgentExecRequest{
 		Agent:  "NonExistent",
 		Prompt: "do something",
 	})
-	if err == nil {
-		t.Fatal("expected error for unknown agent")
+	if err != nil {
+		t.Fatalf("unknown display name should use the default template: %v", err)
+	}
+	if !result.Success || result.AgentName != "NonExistent" {
+		t.Fatalf("unexpected result: %#v", result)
 	}
 }
 


### PR DESCRIPTION
## Summary

- treat unknown Agent `name` values as display-only labels backed by the default agent template
- continue using enabled named definitions and reject definitions that exist but are disabled
- clarify the Agent tool schema and cover foreground/background resolution behavior

## Testing

- `go test ./...`
- `go vet ./...`
- `git diff --check`