### PR TITLE
feat: add ollama ui support

### DIFF
--- a/internal/app/input/on_provider.go
+++ b/internal/app/input/on_provider.go
@@ -128,6 +128,11 @@ type ProviderSelector struct {
 	customFormFocus  int
 	customFormErr    string
 
+	// Inline Ollama form (base URL only); see on_provider_ollama.go
+	ollamaFormActive bool
+	ollamaURLInput   textinput.Model
+	ollamaFormErr    string
+
 	// Inline confirm-remove prompt
 	confirmRemoveActive  bool
 	confirmRemoveEnvVar  string

--- a/internal/app/input/on_provider_auth.go
+++ b/internal/app/input/on_provider_auth.go
@@ -110,6 +110,12 @@ func (s *ProviderSelector) handleCredentialEditForProvider(item providerListItem
 		return nil
 	}
 
+	// Ollama edits its base URL via a dedicated form (no API key).
+	if s.isOllamaProvider(p.Provider) {
+		s.openOllamaForm()
+		return nil
+	}
+
 	// Single auth method: activate API key input directly
 	if len(p.AuthMethods) == 1 {
 		am := p.AuthMethods[0]

--- a/internal/app/input/on_provider_data.go
+++ b/internal/app/input/on_provider_data.go
@@ -23,6 +23,7 @@ func (s *ProviderSelector) Enter(ctx context.Context, width, height int) (tea.Cm
 	s.expandedProviderIdx = -1
 	s.apiKeyActive = false
 	s.closeCustomForm()
+	s.closeOllamaForm()
 	s.active = true
 	s.activeTab = providerTabModels
 	s.width = width
@@ -428,6 +429,7 @@ func (s *ProviderSelector) Cancel() {
 	s.expandedProviderIdx = -1
 	s.apiKeyActive = false
 	s.closeCustomForm()
+	s.closeOllamaForm()
 	s.store = nil
 	s.resetNavigation()
 	s.resetModelSearch()

--- a/internal/app/input/on_provider_nav.go
+++ b/internal/app/input/on_provider_nav.go
@@ -55,6 +55,7 @@ func (s *ProviderSelector) switchTab(t providerTab) {
 	s.expandedProviderIdx = -1
 	s.apiKeyActive = false
 	s.closeCustomForm()
+	s.closeOllamaForm()
 	s.rebuildVisibleItems()
 }
 
@@ -64,6 +65,10 @@ func (s *ProviderSelector) PrevTab() { s.switchTab((s.activeTab + 1 + 2) % 2) }
 func (s *ProviderSelector) GoBack() bool {
 	if s.customFormActive {
 		s.closeCustomForm()
+		return true
+	}
+	if s.ollamaFormActive {
+		s.closeOllamaForm()
 		return true
 	}
 	if s.apiKeyActive {
@@ -112,6 +117,11 @@ func (s *ProviderSelector) HandleKeypress(key tea.KeyMsg) tea.Cmd {
 	// Route to the custom provider form if active
 	if s.customFormActive {
 		return s.handleCustomFormKey(key)
+	}
+
+	// Route to the Ollama form if active
+	if s.ollamaFormActive {
+		return s.handleOllamaFormKey(key)
 	}
 
 	// Route to API key input if active
@@ -318,6 +328,12 @@ func (s *ProviderSelector) selectProvider(item providerListItem) tea.Cmd {
 	// instead of the single API-key input. Once connected, Enter refreshes as usual.
 	if len(p.AuthMethods) == 1 && s.isCustomProvider(p.Provider) && p.AuthMethods[0].Status != llm.StatusConnected {
 		s.openCustomForm()
+		return nil
+	}
+
+	// Ollama similarly uses a dedicated base-URL form (no API key needed).
+	if len(p.AuthMethods) == 1 && s.isOllamaProvider(p.Provider) && p.AuthMethods[0].Status != llm.StatusConnected {
+		s.openOllamaForm()
 		return nil
 	}
 

--- a/internal/app/input/on_provider_ollama.go
+++ b/internal/app/input/on_provider_ollama.go
@@ -1,0 +1,114 @@
+// Provider selector: the Ollama provider form for setting the base URL.
+// Ollama is a local provider that speaks the OpenAI-compatible API. Unlike
+// API-key-based providers, its configuration is just a base URL — no secret
+// key — so the form shows a single (non-password-masked) URL input.
+package input
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/secret"
+)
+
+// ollamaEnvVar is the env/secret-store key holding the Ollama base URL.
+const ollamaEnvVar = "OLLAMA_BASE_URL"
+
+// isOllamaProvider reports whether name is the Ollama provider.
+func (s *ProviderSelector) isOllamaProvider(name llm.Name) bool {
+	return name == llm.Ollama
+}
+
+// openOllamaForm initializes the inline URL form, prefilled from the saved config.
+func (s *ProviderSelector) openOllamaForm() {
+	baseURL := ""
+	if store := secret.Default(); store != nil {
+		if v := store.Get(ollamaEnvVar); v != "" {
+			baseURL = v
+		}
+	}
+	if baseURL == "" {
+		baseURL = os.Getenv(ollamaEnvVar)
+	}
+
+	urlInput := textinput.New()
+	urlInput.Placeholder = "http://localhost:11434/v1"
+	urlInput.SetValue(baseURL)
+	urlInput.CharLimit = 256
+	urlInput.SetWidth(40)
+	urlInput.Focus()
+
+	s.ollamaURLInput = urlInput
+	s.ollamaFormErr = ""
+	s.ollamaFormActive = true
+}
+
+func (s *ProviderSelector) closeOllamaForm() {
+	s.ollamaFormActive = false
+	s.ollamaFormErr = ""
+}
+
+func (s *ProviderSelector) handleOllamaFormKey(key tea.KeyMsg) tea.Cmd {
+	switch key.String() {
+	case "esc":
+		s.closeOllamaForm()
+		return nil
+	case "enter":
+		return s.submitOllamaForm()
+	default:
+		var cmd tea.Cmd
+		s.ollamaURLInput, cmd = s.ollamaURLInput.Update(key)
+		return cmd
+	}
+}
+
+// validateOllamaForm normalizes and validates the URL field.
+func (s *ProviderSelector) validateOllamaForm() (string, error) {
+	baseURL := strings.TrimSpace(s.ollamaURLInput.Value())
+	if baseURL == "" {
+		return "", fmt.Errorf("base URL is required")
+	}
+	if !strings.HasPrefix(baseURL, "https://") && !strings.HasPrefix(baseURL, "http://") {
+		return "", fmt.Errorf("base URL must start with https:// or http://")
+	}
+	return baseURL, nil
+}
+
+// submitOllamaForm persists the URL to the secret store, then connects.
+func (s *ProviderSelector) submitOllamaForm() tea.Cmd {
+	baseURL, err := s.validateOllamaForm()
+	if err != nil {
+		s.ollamaFormErr = err.Error()
+		return nil
+	}
+
+	if store := secret.Default(); store != nil {
+		_ = store.Set(ollamaEnvVar, baseURL)
+	}
+	os.Setenv(ollamaEnvVar, baseURL)
+	s.closeOllamaForm()
+
+	// Rebuild from the store so the Providers tab reflects the update, then
+	// point the selection at the Ollama row so the connect result renders there.
+	_, _ = s.loadProviderData()
+	s.rebuildVisibleItems()
+	for i := range s.allProviders {
+		p := &s.allProviders[i]
+		if p.Provider != llm.Ollama || len(p.AuthMethods) != 1 {
+			continue
+		}
+		for vi, item := range s.visibleItems {
+			if item.Kind == providerItemProvider && item.ProviderIdx == i {
+				s.selectedIdx = vi
+				break
+			}
+		}
+		return s.connectAuthMethod(p.AuthMethods[0], s.selectedIdx)
+	}
+	return nil
+}

--- a/internal/app/input/on_provider_view.go
+++ b/internal/app/input/on_provider_view.go
@@ -100,6 +100,11 @@ func (s *ProviderSelector) renderItemList(sb *strings.Builder) {
 			sb.WriteString(s.renderCustomForm())
 			sb.WriteString("\n")
 		}
+		// Inline Ollama form (render below the relevant item)
+		if s.ollamaFormActive && isSelected {
+			sb.WriteString(s.renderOllamaForm())
+			sb.WriteString("\n")
+		}
 
 		// Inline confirm-remove prompt (render below the relevant item)
 		if s.confirmRemoveActive && i == s.confirmRemoveItemIdx {
@@ -341,6 +346,23 @@ func (s *ProviderSelector) renderCustomForm() string {
 	return strings.Join(lines, "\n")
 }
 
+// renderOllamaForm renders the Ollama provider's single-field form (base URL)
+// below its provider row, with the validation error underneath when present.
+func (s *ProviderSelector) renderOllamaForm() string {
+	inputBg := kit.AdaptiveColor{Dark: "#1E293B", Light: "#F1F5F9"}
+	boxStyle := lipgloss.NewStyle().
+		Background(inputBg).
+		Padding(0, 1)
+
+	label := kit.DimStyle().Render("Base URL: ")
+	line := "      " + boxStyle.Render(label+s.ollamaURLInput.View())
+	if s.ollamaFormErr != "" {
+		errStyle := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Error)
+		line += "\n" + "      " + errStyle.Render(s.ollamaFormErr)
+	}
+	return line
+}
+
 func (s *ProviderSelector) renderConfirmRemove() string {
 	warnStyle := lipgloss.NewStyle().
 		Foreground(kit.AdaptiveColor{Dark: "#F87171", Light: "#DC2626"})
@@ -360,6 +382,9 @@ func (s *ProviderSelector) renderConfirmRemove() string {
 func (s *ProviderSelector) renderHints() string {
 	if s.customFormActive {
 		return kit.DimStyle().Render("Tab/↑/↓ switch field · Enter save & connect · Esc cancel")
+	}
+	if s.ollamaFormActive {
+		return kit.DimStyle().Render("Enter save & connect · Esc cancel")
 	}
 	if s.apiKeyActive {
 		return kit.DimStyle().Render("Paste API key · Enter confirm · Esc cancel")

--- a/internal/llm/ollama/apikey.go
+++ b/internal/llm/ollama/apikey.go
@@ -15,11 +15,11 @@ import (
 // APIKeyMeta is the metadata for Ollama (keyless / local).
 // Ollama does not require an API key; we pass a placeholder so the
 // OpenAI-compatible SDK still sends Authorization: Bearer (which Ollama
-// ignores).
+// ignores). The base URL is configurable via OLLAMA_BASE_URL.
 var APIKeyMeta = llm.Meta{
 	Provider:    llm.Ollama,
 	AuthMethod:  llm.AuthAPIKey,
-	EnvVars:     nil,
+	EnvVars:     []string{"OLLAMA_BASE_URL"},
 	DisplayName: "Local (Ollama)",
 }
 

--- a/internal/llm/registry.go
+++ b/internal/llm/registry.go
@@ -125,6 +125,17 @@ func (r *Registry) IsReady(meta Meta) bool {
 			return false
 		}
 	}
+	// No env vars means an OAuth/credential-based auth method (e.g. ChatGPT
+	// Subscription). Without stored credentials it is not ready — treat it as
+	// "not configured" rather than showing a misleading yellow "Available" icon.
+	if len(meta.EnvVars) == 0 {
+		if a := r.authenticator(meta.Provider, meta.AuthMethod); a != nil {
+			if sca, ok := a.(StoredCredentialAuthenticator); ok {
+				return sca.HasCredentials()
+			}
+		}
+		return false
+	}
 	return true
 }
 


### PR DESCRIPTION
The PR used to add the ui configuration for ollama providers. the old behavior is the base_url is hardcoded.