### PR TITLE
fix(tui): keep persona metadata rows within the panel

### DIFF
--- a/internal/app/input/on_persona.go
+++ b/internal/app/input/on_persona.go
@@ -187,7 +187,10 @@ func (s *PersonaSelector) Render() string {
 	sb.WriteString("\n\n")
 
 	const nameCol = 22
-	metaMax := max(16, panel.ContentWidth()-nameCol-12)
+	// A selectable row adds four columns before FormatAlignedRow's marker, and
+	// the panel has four columns of horizontal padding. Reserve both plus the
+	// marker/name gaps so the metadata (including its ellipsis) stays on one row.
+	metaMax := max(16, panel.ContentWidth()-nameCol-13)
 
 	startIdx, endIdx := s.nav.VisibleRange()
 

--- a/internal/app/input/on_persona_test.go
+++ b/internal/app/input/on_persona_test.go
@@ -3,9 +3,11 @@ package input
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	xansi "github.com/charmbracelet/x/ansi"
 
 	"github.com/genai-io/san/internal/persona"
 )
@@ -140,6 +142,36 @@ func TestPersonaSelector_NoActionsOnBuiltin(t *testing.T) {
 	}
 	if cmd := s.HandleKeypress(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl}); cmd != nil {
 		t.Error("Ctrl+O on the built-in default should be a no-op")
+	}
+}
+
+func TestPersonaSelector_RenderKeepsRowsWithinPanel(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	s := NewPersonaSelector(persona.NewRegistry(""), nil)
+	if err := s.EnterSelect(120, 24); err != nil {
+		t.Fatal(err)
+	}
+	s.items = append(s.items, personaItem{
+		Name:        "software-engineer",
+		Scope:       "project",
+		Description: strings.Repeat("long description ", 20),
+	})
+	s.nav.Total = len(s.items)
+
+	rendered := s.Render()
+	plain := xansi.Strip(rendered)
+	row := ""
+	for _, line := range strings.Split(plain, "\n") {
+		if strings.Contains(line, "software-engineer") {
+			row = strings.TrimSpace(line)
+			break
+		}
+	}
+	if row == "" {
+		t.Fatal("software-engineer row was not rendered")
+	}
+	if strings.Contains(row, "long description long description long description long description long") || !strings.HasSuffix(row, "…") {
+		t.Fatalf("long persona description was not truncated on its row: %q", row)
 	}
 }
 


### PR DESCRIPTION
Fix the persona selector's metadata width budget so long descriptions truncate on the row instead of spilling past the panel.

- Accounts for the selectable-row prefix in the remaining-width calculation.
- Adds a regression test for a very long persona description.

Stacked on #422 until that lands; it will reduce to the persona-only change after rebase.