### PR TITLE
fix(input): align composer cursor with wrapped input rows

### DIFF
--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -173,7 +173,26 @@ func (m model) renderInputView() string {
 		!m.conv.Stream.Active && !m.userInput.Suggestions.IsVisible() {
 		return prompt + ghostTextStyle.Render(m.userInput.PromptSuggestion.Text)
 	}
-	return prompt + m.userInput.RenderTextarea()
+	return prompt + hangComposerRows(m.userInput.RenderTextarea())
+}
+
+// hangComposerRows indents every composer row after the first by the prompt's
+// width, so wrapped and newline-split input hangs under the first row's text
+// instead of falling back to column 0. Two reasons it has to: a committed user
+// message renders the same way in scrollback (RenderUserMessage joins the
+// prompt and the body side by side), and inputCursor shifts the cursor right by
+// that same prompt width on *every* row — without the indent the cursor sits
+// two columns past the character it should precede on every line but the first.
+func hangComposerRows(view string) string {
+	lines := strings.Split(view, "\n")
+	if len(lines) < 2 {
+		return view
+	}
+	gutter := strings.Repeat(" ", lipgloss.Width(conv.InputPrompt))
+	for i := 1; i < len(lines); i++ {
+		lines[i] = gutter + lines[i]
+	}
+	return strings.Join(lines, "\n")
 }
 
 // renderChatSection assembles the active chat content (uncommitted messages,

--- a/internal/app/view_test.go
+++ b/internal/app/view_test.go
@@ -3,7 +3,68 @@ package app
 import (
 	"strings"
 	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/genai-io/san/internal/app/conv"
+	"github.com/genai-io/san/internal/app/input"
 )
+
+// The composer prints the "❭ " prompt once, on the first row, while inputCursor
+// offsets the cursor by that prompt's width on every row. hangComposerRows is
+// what keeps the two in step: without the gutter, wrapped and newline-split rows
+// start at column 0 and the cursor floats two columns right of the text.
+func TestComposerCursorAlignsWithEveryRow(t *testing.T) {
+	const width = 80
+
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"hard newline", "first line\nsecond"},
+		{"soft wrap", strings.TrimSpace(strings.Repeat("ab/cd-ef ", 12))},
+		{"cjk soft wrap", strings.Repeat("看看当前分支对 readme 的更改，", 6)},
+		{"single row", "short"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &model{
+				env:       env{Width: width, Height: 24, Ready: true},
+				conv:      conv.NewModel(width),
+				userInput: input.New("", width, nil, input.SelectorDeps{}),
+			}
+			m.userInput.Textarea.SetWidth(width - 4 - 2)
+			m.userInput.Textarea.SetValue(tt.value)
+			m.userInput.Textarea.CursorEnd()
+
+			lines := strings.Split(m.renderInputView(), "\n")
+			cursor := m.inputCursor(0)
+			if cursor == nil {
+				t.Fatal("composer reported no cursor")
+			}
+			if cursor.Position.Y != len(lines)-1 {
+				t.Fatalf("cursor on row %d, but the value ends on row %d", cursor.Position.Y, len(lines)-1)
+			}
+
+			// The cursor sits at the end of the value, so it must land exactly
+			// where the drawn row's text stops.
+			row := strings.TrimRight(ansi.Strip(lines[cursor.Position.Y]), " ")
+			if got := lipgloss.Width(row); got != cursor.Position.X {
+				t.Fatalf("cursor at column %d, but row %q ends at column %d", cursor.Position.X, row, got)
+			}
+
+			// Every row has to fit the terminal, gutter included, or the
+			// terminal rewraps the composer under the cursor.
+			for i, line := range lines {
+				if w := lipgloss.Width(line); w > width {
+					t.Fatalf("row %d is %d columns wide, exceeds terminal width %d", i, w, width)
+				}
+			}
+		})
+	}
+}
 
 func TestTailLines(t *testing.T) {
 	five := "L0\nL1\nL2\nL3\nL4"


### PR DESCRIPTION
The terminal cursor drifts two columns right of the text as soon as the composer holds more than one row — visible whenever input soft-wraps or contains a newline:

```
❭ ....
https://example.com/fdsni  ▌   <- cursor sits here, text ends two columns earlier
```

`renderInputView` prefixes the `❭ ` prompt to the **first** row only, while `inputCursor` adds `lipgloss.Width(InputPrompt)` to the cursor on **every** row. The two only agree on row 0.

Fix: hang every row after the first under the prompt (`hangComposerRows`), so the drawn text and the cursor offset match on all rows. This also makes the live composer read like a committed user message, which already indents its continuation lines — `RenderUserMessage` joins the prompt and body side by side. The textarea is sized `width-6`, so the 2-column gutter still leaves the rows inside the terminal.

- `TestComposerCursorAlignsWithEveryRow` covers hard newline, soft wrap, CJK soft wrap, and the single-row case, asserting the cursor column equals the display width of its rendered row and that no row exceeds the terminal width.