### PR TITLE
docs(site): rebuild the homepage around 三

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <h1>&lt; SAN ✦ /&gt;</h1>
-  <p><strong>Minimal harness. Maximum agent.</strong></p>
+  <p><strong>Minimal overhead. Maximum agent.</strong></p>
   <p>Small context, native speed, open all the way down.</p>
   <p>
     <a href="https://github.com/genai-io/san/releases"><img src="https://img.shields.io/github/v/release/genai-io/san?style=flat-square" alt="Release"></a>
@@ -36,7 +36,7 @@ Three properties, and San refuses to trade any one of them for the others.
 
 **Open** — plug in models, skills, subagents, and MCP servers; write your own system prompt, autopilot goals, and self-learning strategy; replay any run in `san inspector`.
 
-**A minimal harness, not a minimal agent.**
+**Minimal overhead, not a minimal agent.**
 
 <sub>*The name — **San**, written **三** ("three") and drawn **☰**. From the Dao De Jing, 三生万物 — "three begets the ten-thousand things": one runtime that becomes any agent, running a three-step loop (reason → act → observe). The command stays `san`.*</sub>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,6 +1,6 @@
 <div align="center">
   <h1>&lt; SAN ✦ /&gt;</h1>
-  <p><strong>框架最小，Agent 最强。</strong></p>
+  <p><strong>开销最小，Agent 最强。</strong></p>
   <p>上下文精简，原生性能，从里到外都开放。</p>
   <p>
     <a href="https://github.com/genai-io/san/releases"><img src="https://img.shields.io/github/v/release/genai-io/san?style=flat-square" alt="Release"></a>
@@ -34,7 +34,7 @@ San 是一个开源的终端 Agent 运行时：一个原生 Go 二进制，不�
 
 **开** —— 模型、skills、subagents、MCP servers，想接就接；system prompt、Autopilot 的目标、自我学习的策略，都由你来写；`san inspector` 回放任意一次运行。
 
-**小的是框架，不是 Agent 的能力。**
+**小的是开销，不是 Agent 的能力。**
 
 <sub>*关于名字 —— **San**，即 **三**，符号取自 **☰**。语出《道德经》「三生万物」—— 一个运行时即可化身为任意 Agent，并以三步循环运转（推理 → 行动 → 观察）。命令仍是 `san`。*</sub>
 

--- a/site/docs.html
+++ b/site/docs.html
@@ -20,12 +20,12 @@
     <span class="logo"><a href="index.html">&lt; SAN <span class="spark">✦</span> /&gt;</a></span>
     <button class="nav-toggle" aria-label="Toggle menu" aria-expanded="false" onclick="toggleNav(this)">≡</button>
     <div class="nav-links" id="nav-links">
-      <a href="index.html#features">Features</a>
-      <a href="index.html#deploy">Deploy</a>
-      <a href="index.html#footprint">Footprint</a>
+      <a href="index.html#why">Why</a>
+      <a href="index.html#benchmark">Benchmark</a>
+      <a href="index.html#community">Community</a>
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="intro.html">Intro</a>
-      <a href="getting-started.html">Get Started</a>
+      <a href="getting-started.html">Start</a>
       <a href="docs.html">Docs</a>
       <span class="lang-switch">
         <button class="lang-btn" id="lang-btn" aria-haspopup="listbox" aria-expanded="false">
@@ -34,7 +34,7 @@
         </button>
         <div class="lang-menu" id="lang-menu" role="listbox"></div>
       </span>
-      <a class="nav-cta" href="https://github.com/genai-io/san">★ Star on GitHub</a>
+      <a class="nav-cta" href="https://github.com/genai-io/san">★ GitHub</a>
     </div>
   </div>
 </nav>
@@ -51,7 +51,7 @@
     <div class="grid">
 
       <div class="card doc-card">
-        <h3><span class="ico">🚀</span> Start here</h3>
+        <h3>Start here</h3>
         <ul>
           <li><a href="getting-started.html">Getting Started</a></li>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/architecture.md">Architecture overview</a></li>
@@ -60,7 +60,7 @@
       </div>
 
       <div class="card doc-card">
-        <h3><span class="ico">📘</span> Guides</h3>
+        <h3>Guides</h3>
         <ul>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/guides/writing-a-skill.md">Writing a skill</a></li>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/guides/writing-a-subagent.md">Writing a subagent</a></li>
@@ -70,7 +70,7 @@
       </div>
 
       <div class="card doc-card">
-        <h3><span class="ico">🧠</span> Concepts</h3>
+        <h3>Concepts</h3>
         <ul>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/concepts/persona.md">Personas</a></li>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/concepts/harness-channels.md">Harness channels &amp; identity</a></li>
@@ -82,7 +82,7 @@
       </div>
 
       <div class="card doc-card">
-        <h3><span class="ico">📑</span> Reference</h3>
+        <h3>Reference</h3>
         <ul>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/reference/slash-commands.md">Slash commands</a></li>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/reference/configuration.md">Configuration</a></li>
@@ -93,7 +93,7 @@
       </div>
 
       <div class="card doc-card">
-        <h3><span class="ico">🏗️</span> Architecture &amp; packages</h3>
+        <h3>Architecture &amp; packages</h3>
         <ul>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/architecture.md">Architecture</a></li>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/packages/index.md">Package index</a></li>
@@ -102,7 +102,7 @@
       </div>
 
       <div class="card doc-card">
-        <h3><span class="ico">🛠️</span> Operations</h3>
+        <h3>Operations</h3>
         <ul>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/operations/testing.md">Testing</a></li>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/operations/benchmark.md">Benchmark</a></li>

--- a/site/docs.zh.html
+++ b/site/docs.zh.html
@@ -20,12 +20,12 @@
     <span class="logo"><a href="index.zh.html">&lt; SAN <span class="spark">✦</span> /&gt;</a></span>
     <button class="nav-toggle" aria-label="切换菜单" aria-expanded="false" onclick="toggleNav(this)">≡</button>
     <div class="nav-links" id="nav-links">
-      <a href="index.zh.html#features">功能</a>
-      <a href="index.zh.html#deploy">部署</a>
-      <a href="index.zh.html#footprint">性能</a>
+      <a href="index.zh.html#why">为什么</a>
+      <a href="index.zh.html#benchmark">基准</a>
+      <a href="index.zh.html#community">社区</a>
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="intro.html">介绍</a>
-      <a href="getting-started.zh.html">快速开始</a>
+      <a href="getting-started.zh.html">开始</a>
       <a href="docs.zh.html">文档</a>
       <span class="lang-switch">
         <button class="lang-btn" id="lang-btn" aria-haspopup="listbox" aria-expanded="false">
@@ -34,7 +34,7 @@
         </button>
         <div class="lang-menu" id="lang-menu" role="listbox"></div>
       </span>
-      <a class="nav-cta" href="https://github.com/genai-io/san">★ 在 GitHub 标星</a>
+      <a class="nav-cta" href="https://github.com/genai-io/san">★ GitHub</a>
     </div>
   </div>
 </nav>
@@ -51,16 +51,16 @@
     <div class="grid">
 
       <div class="card doc-card">
-        <h3><span class="ico">🚀</span> 从这里开始</h3>
+        <h3>从这里开始</h3>
         <ul>
-          <li><a href="getting-started.zh.html">快速开始</a></li>
+          <li><a href="getting-started.zh.html">开始</a></li>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/architecture.md">架构概览</a></li>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/operations/development.md">本地开发</a></li>
         </ul>
       </div>
 
       <div class="card doc-card">
-        <h3><span class="ico">📘</span> 指南</h3>
+        <h3>指南</h3>
         <ul>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/guides/writing-a-skill.md">编写技能</a></li>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/guides/writing-a-subagent.md">编写子智能体</a></li>
@@ -70,7 +70,7 @@
       </div>
 
       <div class="card doc-card">
-        <h3><span class="ico">🧠</span> 概念</h3>
+        <h3>概念</h3>
         <ul>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/concepts/persona.md">角色</a></li>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/concepts/harness-channels.md">通信通道与身份</a></li>
@@ -82,7 +82,7 @@
       </div>
 
       <div class="card doc-card">
-        <h3><span class="ico">📑</span> 参考</h3>
+        <h3>参考</h3>
         <ul>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/reference/slash-commands.md">斜杠命令</a></li>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/reference/configuration.md">配置</a></li>
@@ -93,7 +93,7 @@
       </div>
 
       <div class="card doc-card">
-        <h3><span class="ico">🏗️</span> 架构与包</h3>
+        <h3>架构与包</h3>
         <ul>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/architecture.md">架构</a></li>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/packages/index.md">包索引</a></li>
@@ -102,7 +102,7 @@
       </div>
 
       <div class="card doc-card">
-        <h3><span class="ico">🛠️</span> 运维</h3>
+        <h3>运维</h3>
         <ul>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/operations/testing.md">测试</a></li>
           <li><a href="https://github.com/genai-io/san/blob/main/docs/operations/benchmark.md">基准测试</a></li>

--- a/site/getting-started.html
+++ b/site/getting-started.html
@@ -20,12 +20,12 @@
     <span class="logo"><a href="index.html">&lt; SAN <span class="spark">✦</span> /&gt;</a></span>
     <button class="nav-toggle" aria-label="Toggle menu" aria-expanded="false" onclick="toggleNav(this)">≡</button>
     <div class="nav-links" id="nav-links">
-      <a href="index.html#features">Features</a>
-      <a href="index.html#deploy">Deploy</a>
-      <a href="index.html#footprint">Footprint</a>
+      <a href="index.html#why">Why</a>
+      <a href="index.html#benchmark">Benchmark</a>
+      <a href="index.html#community">Community</a>
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="intro.html">Intro</a>
-      <a href="getting-started.html">Get Started</a>
+      <a href="getting-started.html">Start</a>
       <a href="docs.html">Docs</a>
       <span class="lang-switch">
         <button class="lang-btn" id="lang-btn" aria-haspopup="listbox" aria-expanded="false">
@@ -34,7 +34,7 @@
         </button>
         <div class="lang-menu" id="lang-menu" role="listbox"></div>
       </span>
-      <a class="nav-cta" href="https://github.com/genai-io/san">★ Star on GitHub</a>
+      <a class="nav-cta" href="https://github.com/genai-io/san">★ GitHub</a>
     </div>
   </div>
 </nav>

--- a/site/getting-started.zh.html
+++ b/site/getting-started.zh.html
@@ -20,12 +20,12 @@
     <span class="logo"><a href="index.zh.html">&lt; SAN <span class="spark">✦</span> /&gt;</a></span>
     <button class="nav-toggle" aria-label="切换菜单" aria-expanded="false" onclick="toggleNav(this)">≡</button>
     <div class="nav-links" id="nav-links">
-      <a href="index.zh.html#features">功能</a>
-      <a href="index.zh.html#deploy">部署</a>
-      <a href="index.zh.html#footprint">性能</a>
+      <a href="index.zh.html#why">为什么</a>
+      <a href="index.zh.html#benchmark">基准</a>
+      <a href="index.zh.html#community">社区</a>
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="intro.html">介绍</a>
-      <a href="getting-started.zh.html">快速开始</a>
+      <a href="getting-started.zh.html">开始</a>
       <a href="docs.zh.html">文档</a>
       <span class="lang-switch">
         <button class="lang-btn" id="lang-btn" aria-haspopup="listbox" aria-expanded="false">
@@ -34,7 +34,7 @@
         </button>
         <div class="lang-menu" id="lang-menu" role="listbox"></div>
       </span>
-      <a class="nav-cta" href="https://github.com/genai-io/san">★ 在 GitHub 标星</a>
+      <a class="nav-cta" href="https://github.com/genai-io/san">★ GitHub</a>
     </div>
   </div>
 </nav>

--- a/site/index.html
+++ b/site/index.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>San — Fast, open agent harness for the terminal</title>
-<meta name="description" content="San is a fast, open terminal agent harness: one ~12 MB Go binary connecting models, tools, permissions, memory, persona bundles, skills, plugins, MCP, and subagents.">
-<meta property="og:title" content="San — Fast, open agent harness for the terminal">
-<meta property="og:description" content="One small Go binary. Bring any model and extension; San gives them a fast, inspectable agent loop in your terminal.">
+<title>San — Minimal overhead. Maximum agent.</title>
+<meta name="description" content="San is an open-source terminal agent runtime: one 12 MB Go binary, ~2.3k tokens of harness, no Node.js or Python. Prompt, tools, providers and extensions all stay yours to change.">
+<meta property="og:title" content="San — Minimal overhead. Maximum agent.">
+<meta property="og:description" content="Small context, native speed, open all the way down. An open-source terminal agent runtime in one 12 MB Go binary.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://genai-io.github.io/san/">
 <meta property="og:image" content="https://genai-io.github.io/san/san.png">
@@ -23,13 +23,12 @@
     <span class="logo"><a href="#top">&lt; SAN <span class="spark">✦</span> /&gt;</a></span>
     <button class="nav-toggle" aria-label="Toggle menu" aria-expanded="false" onclick="toggleNav(this)">≡</button>
     <div class="nav-links" id="nav-links">
-      <a href="#features">Features</a>
-      <a href="#deploy">Deploy</a>
-      <a href="#footprint">Footprint</a>
+      <a href="#why">Why</a>
+      <a href="#benchmark">Benchmark</a>
       <a href="#community">Community</a>
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="intro.html">Intro</a>
-      <a href="getting-started.html">Get Started</a>
+      <a href="getting-started.html">Start</a>
       <a href="docs.html">Docs</a>
       <span class="lang-switch">
         <button class="lang-btn" id="lang-btn" aria-haspopup="listbox" aria-expanded="false">
@@ -38,7 +37,7 @@
         </button>
         <div class="lang-menu" id="lang-menu" role="listbox"></div>
       </span>
-      <a class="nav-cta" href="https://github.com/genai-io/san">★ Star on GitHub</a>
+      <a class="nav-cta" href="https://github.com/genai-io/san">★ GitHub</a>
     </div>
   </div>
 </nav>
@@ -46,125 +45,175 @@
 <header class="hero" id="top">
   <div class="wrap">
     <div class="hero-head">
-      <span class="kicker load-up d1">Open-source agent harness · Apache-2.0</span>
-      <h1 class="load-up d2">San — the open harness<br>for <span class="grad">terminal agents</span></h1>
-      <p class="sub load-up d3">One small Go binary — a fast, open harness that runs any model and extension in an inspectable, permission-gated loop.</p>
-    </div>
-
-    <div class="screen-frame load-up d4">
-      <div class="intro-embed">
-        <iframe src="intro.html?theme=dark" title="San — animated intro" loading="lazy" allow="fullscreen"></iframe>
+      <span class="kicker load-up d1">Open source · Apache-2.0</span>
+      <h1 class="load-up d2">Minimal overhead.<br>Maximum <em>agent</em>.</h1>
+      <p class="sub load-up d3">San is an open-source terminal agent runtime: one native Go binary, no Node.js or Python. Everything the model touches — prompt, tools, providers, extensions — stays yours to change.</p>
+      <div class="metrics load-up d4">
+        <span><b>~0.01s</b> cold start</span>
+        <span><b>~12 MB</b> binary</span>
+        <span><b>~2.3k</b> tokens of harness</span>
+        <span><b>zero</b> runtime deps</span>
       </div>
     </div>
-    <p class="intro-cap load-up d4"><a href="intro.html" target="_blank" rel="noopener">Watch full screen ↗</a></p>
 
-    <div class="hero-actions load-up d5">
-      <a class="btn btn-primary" href="getting-started.html">Get started →</a>
-      <a class="btn btn-ghost" href="https://github.com/genai-io/san">View on GitHub</a>
+    <div class="install load-up d5">
+      <div class="install-tabs" role="tablist" aria-label="Install method">
+        <button class="install-tab active" role="tab" aria-selected="true" data-cmd="curl -fsSL https://raw.githubusercontent.com/genai-io/san/main/install.sh | bash">curl</button>
+        <button class="install-tab" role="tab" aria-selected="false" data-cmd="irm https://raw.githubusercontent.com/genai-io/san/main/install.ps1 | iex">powershell</button>
+        <button class="install-tab" role="tab" aria-selected="false" data-cmd="go install github.com/genai-io/san/cmd/san@latest">go install</button>
+      </div>
+      <div class="install-body">
+        <span class="prompt">$</span>
+        <code id="install-cmd">curl -fsSL https://raw.githubusercontent.com/genai-io/san/main/install.sh | bash</code>
+        <button class="copy-btn" onclick="copyInstall(this)">Copy</button>
+      </div>
     </div>
 
-    <div class="install-bar load-up d6">
-      <span class="prompt">$</span>
-      <code id="install-cmd">curl -fsSL https://raw.githubusercontent.com/genai-io/san/main/install.sh | bash</code>
-      <button class="copy-btn" onclick="copyInstall(this)">Copy</button>
+    <div class="hero-actions load-up d6">
+      <a class="btn btn-primary" href="getting-started.html">Get started</a>
+      <a class="btn btn-ghost" href="intro.html">Watch the intro</a>
+      <a class="btn btn-ghost" href="https://github.com/genai-io/san">GitHub</a>
     </div>
 
     <div class="badges load-up d6">
-      <a href="https://github.com/genai-io/san/releases"><img src="https://img.shields.io/github/v/release/genai-io/san?style=flat-square&color=0d9488" alt="Release"></a>
-      <a href="https://github.com/genai-io/san/stargazers"><img src="https://img.shields.io/github/stars/genai-io/san?style=flat-square&color=14b8a6" alt="Stars"></a>
-      <img src="https://img.shields.io/badge/license-Apache%202.0-0b7d72?style=flat-square" alt="License">
+      <a href="https://github.com/genai-io/san/releases"><img src="https://img.shields.io/github/v/release/genai-io/san?style=flat-square&color=0d9488&labelColor=f1efe9" alt="Release"></a>
+      <a href="https://github.com/genai-io/san/stargazers"><img src="https://img.shields.io/github/stars/genai-io/san?style=flat-square&color=0d9488&labelColor=f1efe9" alt="Stars"></a>
+      <img src="https://img.shields.io/badge/license-Apache%202.0-0d9488?style=flat-square&labelColor=f1efe9" alt="License">
     </div>
   </div>
 </header>
 
-<section id="features">
-  <div class="wrap">
-    <div class="section-head">
-      <span class="kicker">Features</span>
-      <h2 class="section-title">Open <em>by design</em></h2>
-      <p class="section-sub">Every layer is swappable at runtime. No lock-in.</p>
+<section id="demo" style="padding-top: 24px;">
+  <div class="wrap wide">
+    <div class="stage-tabs" role="tablist" aria-label="Demo">
+      <button class="stage-tab active" role="tab" aria-selected="true" data-stage="intro">Watch the intro</button>
+      <button class="stage-tab" role="tab" aria-selected="false" data-stage="turn">Run a turn</button>
     </div>
-    <div class="grid">
-      <div class="card reveal">
-        <span class="idx">01</span>
-        <h3><span class="ico">🔌</span> Multi-LLM providers</h3>
-        <p>Bring any LLM — from Anthropic to Z.ai. Switch with <code>/models</code>.</p>
+
+    <div id="stage-intro">
+      <div class="intro-embed">
+        <iframe src="intro.html?theme=dark" title="San — animated intro" loading="lazy" allow="fullscreen"></iframe>
       </div>
-      <div class="card reveal">
-        <span class="idx">02</span>
-        <h3><span class="ico">🔍</span> Pluggable search</h3>
-        <p>Exa, Tavily, Brave, or Serper. Switch with <code>/search</code>.</p>
-      </div>
-      <div class="card reveal">
-        <span class="idx">03</span>
-        <h3><span class="ico">🧩</span> Skills &amp; extensions</h3>
-        <p>Skills, plugins, MCP servers, and subagents — Claude Code compatible, run unmodified.</p>
-      </div>
-      <div class="card reveal">
-        <span class="idx">04</span>
-        <h3><span class="ico">🎭</span> Personas</h3>
-        <p>Persona bundles define reusable profiles with system prompt parts, skills, subagent visibility, and config overlays.</p>
-      </div>
-      <div class="card reveal">
-        <span class="idx">05</span>
-        <h3><span class="ico">⚡</span> Native performance</h3>
-        <p>A single Go binary. 12 MB, ~0.01s startup, no runtime.</p>
-      </div>
-      <div class="card reveal">
-        <span class="idx">06</span>
-        <h3><span class="ico">💾</span> Session persistence</h3>
-        <p>Sessions auto-save, resume, and fork, with automatic context compaction.</p>
-      </div>
-      <div class="card wide reveal">
-        <span class="idx">07</span>
-        <div>
-          <h3><span class="ico">✦</span> Self-evolving <span class="soon">Level 1 · live</span></h3>
-          <p>Every few turns, a background reviewer distills your recent work into durable memory and reusable skills — so the agent levels up as you work, no manual tuning. Level 1 is live today; deeper levels are on the way.</p>
+      <p class="panel-cap"><a href="intro.html" target="_blank" rel="noopener">Open the full-quality intro ↗</a> · 54s, no sound</p>
+    </div>
+
+    <div id="stage-turn" hidden>
+      <div class="term">
+        <div class="term-bar">
+          <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+          <span class="where">san — ~/acme-api</span>
+          <span class="model">◆ <b>sonnet-4-6</b></span>
         </div>
-        <div class="levels">
-          <span class="level live"><b>Lv.1</b> Curious</span>
-          <span class="arrow">→</span>
-          <span class="level"><b>Lv.10</b> Better</span>
-          <span class="arrow">→</span>
-          <span class="level"><b>Lv.50</b> Stronger</span>
-          <span class="arrow">→</span>
-          <span class="level"><b>Lv.∞</b> Legendary</span>
+        <div class="term-out" id="term-out"></div>
+        <div class="term-ask">
+          <form class="term-line" id="term-form" autocomplete="off">
+            <span class="q">❯</span>
+            <input id="term-in" type="text" placeholder="ask San something…" aria-label="Ask San something">
+            <span class="enter">↵ run</span>
+          </form>
+          <div class="term-chips" id="term-chips"></div>
         </div>
       </div>
+      <p class="panel-cap">Scripted turn, example repo · what a real San run looks like</p>
     </div>
   </div>
 </section>
 
-<section id="deploy" style="background: var(--bg-soft);">
+<section id="why">
   <div class="wrap">
     <div class="section-head">
-      <span class="kicker">Deploy anywhere</span>
-      <h2 class="section-title">One binary. <em>Runs anywhere.</em></h2>
-      <p class="section-sub">A single ~12&nbsp;MB binary, zero runtime dependencies — the same file runs unchanged on a laptop, a cloud node, or a 256&nbsp;MB edge device.</p>
+      <span class="kicker">Why San</span>
+      <h2 class="section-title">Minimal overhead,<br><em>not a minimal agent</em>.</h2>
+      <p class="section-sub">Three properties — 小 small, 快 fast, 开 open — and San refuses to trade any one of them for the others. Three strokes, one 三.</p>
     </div>
-    <div class="deploy-targets">
-      <span class="pill">💻 macOS &amp; Linux laptops</span>
-      <span class="pill">☁️ Cloud nodes &amp; VMs</span>
-      <span class="pill">📟 ARM edge devices</span>
-      <span class="pill">🐳 <code>scratch</code> containers</span>
-      <span class="pill">⚙️ CI steps &amp; lifecycle hooks</span>
-      <span class="pill">🔒 Air-gapped &amp; locked-down hosts</span>
+
+    <div class="trigram">
+      <article class="stroke">
+        <div class="rail">
+          <span class="glyph" aria-hidden="true">一</span>
+          <span class="name">Small</span>
+        </div>
+        <div class="body">
+          <h3>The context window is for your work</h3>
+          <p>What the harness sends before your first message stays small, so the window belongs to the task at hand. On disk it is one file that needs nothing else installed.</p>
+          <dl class="rows">
+            <dt>harness context</dt><dd>~2.3k tokens</dd>
+            <dt>binary</dt><dd>12 MB <span class="dim">· macos · linux · windows</span></dd>
+            <dt>runtime deps</dt><dd>none</dd>
+          </dl>
+          <div class="pills">
+            <span class="pill"><span class="ico">💻</span> Laptop</span>
+            <span class="pill"><span class="ico">☁️</span> Cloud VM</span>
+            <span class="pill"><span class="ico">📟</span> ARM edge</span>
+            <span class="pill"><span class="ico">🐳</span> Container</span>
+            <span class="pill"><span class="ico">⚙️</span> CI step</span>
+            <span class="pill"><span class="ico">🔒</span> Air-gapped host</span>
+          </div>
+          <p class="more"><a href="https://github.com/genai-io/san/blob/main/docs/operations/footprint.md">Why small matters</a></p>
+        </div>
+      </article>
+
+      <article class="stroke">
+        <div class="rail">
+          <span class="glyph" aria-hidden="true">二</span>
+          <span class="name">Fast</span>
+        </div>
+        <div class="body">
+          <h3>What you wait on is the model</h3>
+          <p>Native Go, so nothing boots before you type: no interpreter, no <code>node_modules</code> to read off disk. What you wait on is the model.</p>
+          <dl class="rows">
+            <dt>cold start</dt><dd>~0.01s</dd>
+            <dt>simple task</dt><dd>~2.4s</dd>
+            <dt>tool-use task</dt><dd>~3.3s</dd>
+            <dt>memory</dt><dd>~32 MB idle <span class="dim">· ~39 MB under load</span></dd>
+          </dl>
+          <p class="more"><a href="#benchmark">See the numbers</a></p>
+        </div>
+      </article>
+
+      <article class="stroke">
+        <div class="rail">
+          <span class="glyph" aria-hidden="true">三</span>
+          <span class="name">Open</span>
+        </div>
+        <div class="body">
+          <h3>Open all the way down</h3>
+          <p>What the model sees and what it may do are both yours to write — and to replay afterwards.</p>
+          <div class="trio">
+            <div class="facet">
+              <h4>Plug in</h4>
+              <p>Anthropic, OpenAI, Google, DeepSeek, Ollama and a dozen more providers; the search backend of your choice; skills, plugins, MCP servers, subagents and hooks, all unmodified.</p>
+              <div class="keys"><span>/models</span><span>/search</span></div>
+            </div>
+            <div class="facet">
+              <h4>Write</h4>
+              <p>Compose the system prompt, bundle it into a persona you can switch, hand autopilot a goal, set the strategy self-learning follows.</p>
+              <div class="keys"><span>/identity</span><span>/goal</span><span>/evolve</span></div>
+            </div>
+            <div class="facet">
+              <h4>Oversee</h4>
+              <p>You choose how much San may do without asking, and subagents inherit that choice. The inspector replays a run exactly as the model saw it.</p>
+              <div class="keys"><span>Shift+Tab</span><span>san inspector</span></div>
+            </div>
+          </div>
+          <p class="more"><a href="https://github.com/genai-io/san/blob/main/docs/concepts/harness-channels.md">Compose the system prompt</a></p>
+        </div>
+      </article>
     </div>
-    <p class="bench-note">No Node.js, no Python, no <code>node_modules</code>. <a href="https://github.com/genai-io/san/blob/main/docs/operations/footprint.md">Why small matters &amp; where it runs →</a></p>
   </div>
 </section>
 
-<section id="footprint">
+<section id="benchmark" class="band">
   <div class="wrap">
     <div class="section-head">
-      <span class="kicker">Footprint</span>
-      <h2 class="section-title">Small and fast, <em>by design</em></h2>
-      <p class="section-sub">Same model (<span class="mono">claude-sonnet-4-6</span>), same tasks, on Apple Silicon — measured against Claude Code for reference.</p>
+      <span class="kicker">Benchmark</span>
+      <h2 class="section-title">Small and fast, <em>measured</em>.</h2>
+      <p class="section-sub">Against Claude Code v2.1.112 on Apple Silicon, same model (<span class="mono">claude-sonnet-4-6</span>), same tasks.</p>
     </div>
     <div class="bench-wrap reveal">
       <table>
         <thead>
-          <tr><th>Metric</th><th>San</th><th>Claude Code</th><th>Difference</th></tr>
+          <tr><th>Metric</th><th>San</th><th>Claude Code</th><th>Advantage</th></tr>
         </thead>
         <tbody>
           <tr><td>Download size</td><td>12 MB</td><td>63 MB + Node 112 MB</td><td class="adv">5× smaller</td></tr>
@@ -173,24 +222,11 @@
           <tr><td>Startup memory</td><td>~32 MB</td><td>~189 MB</td><td class="adv">5.8× less</td></tr>
           <tr><td>Simple task</td><td>~2.4s / 39 MB</td><td>~10.4s / 286 MB</td><td class="adv">4.3× faster</td></tr>
           <tr><td>Tool-use task</td><td>~3.3s / 39 MB</td><td>~26.0s / 285 MB</td><td class="adv">7.9× faster</td></tr>
+          <tr><td>Harness context</td><td>~2.3k tokens</td><td>~20.9k tokens</td><td class="adv">~9× leaner</td></tr>
         </tbody>
       </table>
     </div>
-    <p class="bench-note">San runs Claude Code's skills, plugins, and MCP unmodified — the gap is a native Go binary vs a Node.js runtime. <a href="https://github.com/genai-io/san/blob/main/docs/operations/benchmark.md">Reproduce the numbers →</a></p>
-  </div>
-</section>
-
-<section style="background: var(--bg-soft);">
-  <div class="wrap">
-    <div class="cta-box reveal">
-      <span class="kicker" style="justify-content:center;">Get started</span>
-      <h2>Try it in 30 seconds</h2>
-      <p>Open source under Apache 2.0. Star the repo if it's useful — it genuinely helps.</p>
-      <div class="hero-actions">
-        <a class="btn btn-primary" href="https://github.com/genai-io/san">★ Star on GitHub</a>
-        <a class="btn btn-ghost" href="getting-started.html">Get started</a>
-      </div>
-    </div>
+    <p class="bench-note">Comparable feature sets — San runs Claude Code's skills, plugins and MCP servers unmodified — so the gap is client-side overhead, not capability. <a href="https://github.com/genai-io/san/blob/main/docs/operations/benchmark.md">Method and how to reproduce →</a></p>
   </div>
 </section>
 
@@ -198,17 +234,17 @@
   <div class="wrap">
     <div class="section-head">
       <span class="kicker">Community</span>
-      <h2 class="section-title">Join the <em>conversation</em></h2>
-      <p class="section-sub">Two ways in — WeChat for the Chinese community, Slack for everyone else.</p>
+      <h2 class="section-title">Two ways <em>in</em>.</h2>
+      <p class="section-sub">WeChat for the Chinese community, Slack for everyone else.</p>
     </div>
     <div class="qr-row reveal">
       <div class="qr-card">
-        <img src="wechat.jpg" alt="WeChat official account 极客外传 QR code" width="200" height="200" loading="lazy">
+        <img src="wechat.jpg" alt="WeChat official account 极客外传 QR code" width="190" height="190" loading="lazy">
         <p class="qr-cap">关注公众号「极客外传」· 回复 <span class="mono">san</span> 或 <span class="mono">三</span> 入群</p>
       </div>
       <div class="qr-card">
-        <img src="slack.png" alt="San Slack QR code" width="200" height="200" loading="lazy">
-        <p class="qr-cap">Scan or <a href="https://join.slack.com/t/sanaico/shared_invite/zt-3zvfr8v6f-dchFpvpufY7fKA7tG7lhIg">join us on Slack</a></p>
+        <img src="slack.png" alt="San Slack QR code" width="190" height="190" loading="lazy">
+        <p class="qr-cap">Scan, or <a href="https://join.slack.com/t/sanaico/shared_invite/zt-3zvfr8v6f-dchFpvpufY7fKA7tG7lhIg">join us on Slack</a></p>
       </div>
     </div>
   </div>
@@ -231,11 +267,22 @@
     const text = document.getElementById('install-cmd').innerText;
     navigator.clipboard.writeText(text).then(() => {
       const old = btn.innerText;
-      btn.innerText = 'Copied!';
+      btn.innerText = 'Copied';
       setTimeout(() => btn.innerText = old, 1500);
     });
   }
   document.getElementById('year').innerText = new Date().getFullYear();
+
+  // Install method tabs — each tab carries its own command
+  document.querySelectorAll('.install-tab').forEach(tab => {
+    tab.addEventListener('click', () => {
+      document.querySelectorAll('.install-tab').forEach(t => {
+        t.classList.toggle('active', t === tab);
+        t.setAttribute('aria-selected', t === tab);
+      });
+      document.getElementById('install-cmd').innerText = tab.dataset.cmd;
+    });
+  });
 
   // Mobile nav toggle
   function toggleNav(btn) {
@@ -247,7 +294,7 @@
   document.querySelectorAll('#nav-links a').forEach(a =>
     a.addEventListener('click', () => document.getElementById('nav').classList.remove('open')));
 
-  // Nav gains a solid background once the page scrolls
+  // Nav gains a hairline rule once the page scrolls
   const nav = document.getElementById('nav');
   const onScroll = () => nav.classList.toggle('scrolled', window.scrollY > 8);
   onScroll();
@@ -257,10 +304,7 @@
   const io = new IntersectionObserver((entries) => {
     entries.forEach(e => { if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } });
   }, { threshold: 0.12, rootMargin: '0px 0px -8% 0px' });
-  document.querySelectorAll('.reveal').forEach((el, i) => {
-    el.style.transitionDelay = (i % 6) * 60 + 'ms';
-    io.observe(el);
-  });
+  document.querySelectorAll('.reveal').forEach(el => io.observe(el));
 
   // Scroll-spy: highlight the active in-page nav link
   const spyLinks = [...document.querySelectorAll('#nav-links a[href^="#"]')];
@@ -283,10 +327,204 @@
     const box = document.querySelector('.intro-embed');
     if (!box) return;
     const frame = box.querySelector('iframe');
-    const scaleFrame = () => { frame.style.transform = 'scale(' + (box.clientWidth / 1280) + ')'; };
+    // the box has no width while its tab is hidden — leave the scale alone
+    const scaleFrame = () => {
+      if (!box.clientWidth) return;
+      frame.style.transform = 'scale(' + (box.clientWidth / 1280) + ')';
+    };
     scaleFrame();
     new ResizeObserver(scaleFrame).observe(box);
   })();
+
+  // The demo slot: one tab per view of the same dark screen
+  document.querySelectorAll('.stage-tab').forEach(tab => {
+    tab.addEventListener('click', () => {
+      document.querySelectorAll('.stage-tab').forEach(t => {
+        const on = t === tab;
+        t.classList.toggle('active', on);
+        t.setAttribute('aria-selected', on);
+        document.getElementById('stage-' + t.dataset.stage).hidden = !on;
+      });
+    });
+  });
+
+  // A San turn, played out in the terminal: the ask, one row per tool, then
+  // what San said. The turns are scripted — typing anything says so plainly
+  // rather than inventing an answer.
+  (function () {
+    const out   = document.getElementById('term-out');
+    const form  = document.getElementById('term-form');
+    const input = document.getElementById('term-in');
+    const chips = document.getElementById('term-chips');
+    if (!out) return;
+
+    const still = matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    const TURNS = [
+      {
+        chip: 'add an endpoint',
+        ask: 'add a /healthz endpoint with a test',
+        steps: [
+          { tool: 'bash',  arg: 'rg -n "func register" internal/server', meta: '3 hits · 9ms' },
+          { tool: 'read',  arg: 'internal/server/router.go',             meta: '148 lines · 11ms' },
+          { tool: 'edit',  arg: 'internal/server/router.go',             meta: '+9 −0' },
+          { tool: 'write', arg: 'internal/server/healthz_test.go',       meta: '+24' },
+          { tool: 'bash',  arg: 'go test ./internal/server',             meta: 'ok · 0.42s', wait: 800 },
+          { say: ['/healthz now sits with the other routes in router.go. It reports the build revision, and returns 503 while the database pool is still warming — so a rolling deploy will not send traffic to a cold process. The test covers both states.'] },
+          { done: '5 tools · 2.1s · 118 tok/s' },
+        ],
+      },
+      {
+        chip: 'chase a flaky test',
+        ask: 'TestQueueDrain fails about one run in twenty — why?',
+        steps: [
+          { tool: 'bash', arg: 'rg -n "TestQueueDrain" internal/queue',        meta: '1 hit · 7ms' },
+          { tool: 'read', arg: 'internal/queue/drain_test.go',                 meta: '96 lines · 9ms' },
+          { tool: 'read', arg: 'internal/queue/drain.go',                      meta: '212 lines · 10ms' },
+          { say: ['The test sleeps 10ms and then asserts on q.pending. Drain() only clears the last batch once its ticker fires again, and that ticker runs every 5ms — so on a loaded machine the second tick lands after the assertion and one item is still pending. The sleep is the bug, not the drainer.'] },
+          { tool: 'edit', arg: 'internal/queue/drain_test.go',                 meta: '+4 −2' },
+          { tool: 'bash', arg: 'go test -run TestQueueDrain -count 50',        meta: '50/50 ok · 1.2s', wait: 900 },
+          { done: '5 tools · 4.7s' },
+        ],
+      },
+      {
+        chip: 'explain the codebase',
+        ask: 'what does this service do? three lines, no fluff',
+        steps: [
+          { tool: 'bash', arg: 'rg --files -g "*.go"',        meta: '38 files · 6ms' },
+          { tool: 'read', arg: 'cmd/api/main.go',             meta: '64 lines · 7ms' },
+          { tool: 'read', arg: 'internal/order/service.go',   meta: '241 lines · 9ms' },
+          { say: [
+            'An HTTP order service: cmd/api wires the config, a Postgres pool and the router, then hands every request to internal/order.',
+            'An order and its line items are written in one transaction; taking payment is a separate step, driven off an outbox table.',
+            'Retries, the reconciler and the metrics endpoint all hang off that outbox — so the write path stays a single round trip.',
+          ] },
+          { done: '3 tools · 1.6s' },
+        ],
+      },
+    ];
+
+    const FALLBACK = [
+      { say: [
+        'This terminal is scripted — there is no model and no repo behind the page, so that one it cannot answer.',
+        'Install San and ask it inside your own project:',
+      ] },
+      { cmd: 'curl -fsSL https://raw.githubusercontent.com/genai-io/san/main/install.sh | bash' },
+      { say: ['Or run one of the scripted turns below.'] },
+    ];
+
+    const sleep = (ms) => new Promise(done => setTimeout(done, still ? 0 : ms));
+    const toBottom = () => { out.scrollTop = out.scrollHeight; };
+
+    function addRow(kind) {
+      const el = document.createElement('div');
+      el.className = 'row ' + kind;
+      out.appendChild(el);
+      toBottom();
+      return el;
+    }
+    function addSpan(parent, kind, text) {
+      const el = document.createElement('span');
+      el.className = kind;
+      el.textContent = text;
+      parent.appendChild(el);
+      return el;
+    }
+
+    // San streams, so the answer arrives a character at a time behind a caret
+    async function stream(el, text, alive) {
+      const node = document.createTextNode('');
+      el.appendChild(node);
+      if (still) { node.data = text; return; }
+      const caret = addSpan(el, 'caret', '');
+      for (let i = 1; i <= text.length; i++) {
+        if (!alive()) { caret.remove(); return; }
+        node.data = text.slice(0, i);
+        if (i % 2 === 0) { await sleep(9); toBottom(); }
+      }
+      caret.remove();
+    }
+
+    async function playTool(step, alive) {
+      const el = addRow('tool');
+      const mark = addSpan(el, 'spin', '✦');
+      addSpan(el, 'tn', step.tool);
+      const rest = addSpan(el, 'rest', '');
+      addSpan(rest, 'arg', step.arg);
+      await sleep(step.wait || 340);
+      if (!alive()) return;
+      mark.textContent = '⏺';
+      mark.classList.add('settled');
+      addSpan(rest, 'meta' + (/^[+−]/.test(step.meta) ? ' diff' : ''), step.meta);
+    }
+
+    async function playSay(lines, alive) {
+      for (let i = 0; i < lines.length; i++) {
+        if (!alive()) return;
+        const el = addRow(i === 0 ? 'say' : 'say cont');
+        if (i === 0) addSpan(el, 'mk', '●');
+        await stream(addSpan(el, 'text', ''), lines[i], alive);
+      }
+    }
+
+    function playCmd(command) {
+      const el = addRow('cmd');
+      addSpan(el, 'prompt', '$');
+      el.appendChild(document.createTextNode(command));
+    }
+
+    function playDone(summary) {
+      const el = addRow('done');
+      addSpan(el, 'ok', '✓');
+      el.appendChild(document.createTextNode(' done · ' + summary));
+    }
+
+    let generation = 0;
+
+    async function play(turn) {
+      const mine = ++generation;
+      const alive = () => mine === generation;
+
+      out.textContent = '';
+      const asked = addRow('you');
+      addSpan(asked, 'q', '❯');
+      asked.appendChild(document.createTextNode(turn.ask));
+      await sleep(380);
+
+      for (const step of turn.steps) {
+        if (!alive()) return;
+        if (step.tool)      await playTool(step, alive);
+        else if (step.say)  await playSay(step.say, alive);
+        else if (step.cmd)  playCmd(step.cmd);
+        else if (step.done) playDone(step.done);
+        toBottom();
+        await sleep(90);
+      }
+    }
+
+    TURNS.forEach(turn => {
+      const chip = document.createElement('button');
+      chip.type = 'button';
+      chip.className = 'term-chip';
+      chip.textContent = turn.chip;
+      chip.addEventListener('click', () => play(turn));
+      chips.appendChild(chip);
+    });
+
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const asked = input.value.trim();
+      if (!asked) return;
+      input.value = '';
+      play({ ask: asked, steps: FALLBACK });
+    });
+
+    // the terminal sits behind a tab, so the first turn waits for that tab to
+    // open — once only, so coming back keeps whatever is already on screen
+    document.querySelector('.stage-tab[data-stage="turn"]')
+      .addEventListener('click', () => play(TURNS[0]), { once: true });
+  })();
+
   // Language switcher — custom dropdown
   (function() {
     const LANGS = { en: { label: 'EN', ext: '.html' }, zh: { label: '中文', ext: '.zh.html' } };

--- a/site/index.zh.html
+++ b/site/index.zh.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>San — 开源的统一智能体运行时</title>
-<meta name="description" content="San 是一个终端原生的统一智能体运行时：一个 ~12 MB 的 Go 二进制文件，可插拔的 LLM 提供商，完全兼容 Claude Code 技能、插件和 MCP。~0.01 秒冷启动，零运行时依赖。">
-<meta property="og:title" content="San — 终端的统一智能体运行时">
-<meta property="og:description" content="单一 Go 二进制文件。可插拔 LLM 提供商。兼容 Claude Code。~0.01 秒冷启动，~12 MB。">
+<title>San — 开销最小，Agent 最强。</title>
+<meta name="description" content="San 是一个开源的终端 Agent 运行时：一个 12 MB 的 Go 二进制，约 2.3k token 框架开销，不需要 Node.js 或 Python。prompt、工具、provider、扩展都留给你替换。">
+<meta property="og:title" content="San — 开销最小，Agent 最强。">
+<meta property="og:description" content="上下文精简，原生性能，从里到外都开放。一个 12 MB Go 二进制的开源终端 Agent 运行时。">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://genai-io.github.io/san/">
 <meta property="og:image" content="https://genai-io.github.io/san/san.png">
@@ -23,13 +23,12 @@
     <span class="logo"><a href="#top">&lt; SAN <span class="spark">✦</span> /&gt;</a></span>
     <button class="nav-toggle" aria-label="切换菜单" aria-expanded="false" onclick="toggleNav(this)">≡</button>
     <div class="nav-links" id="nav-links">
-      <a href="#features">功能</a>
-      <a href="#deploy">部署</a>
-      <a href="#footprint">性能</a>
+      <a href="#why">为什么</a>
+      <a href="#benchmark">基准</a>
       <a href="#community">社区</a>
       <span class="nav-sep" aria-hidden="true"></span>
       <a href="intro.html">介绍</a>
-      <a href="getting-started.zh.html">快速开始</a>
+      <a href="getting-started.zh.html">开始</a>
       <a href="docs.zh.html">文档</a>
       <span class="lang-switch">
         <button class="lang-btn" id="lang-btn" aria-haspopup="listbox" aria-expanded="false">
@@ -38,7 +37,7 @@
         </button>
         <div class="lang-menu" id="lang-menu" role="listbox"></div>
       </span>
-      <a class="nav-cta" href="https://github.com/genai-io/san">★ 在 GitHub 标星</a>
+      <a class="nav-cta" href="https://github.com/genai-io/san">★ GitHub</a>
     </div>
   </div>
 </nav>
@@ -46,120 +45,170 @@
 <header class="hero" id="top">
   <div class="wrap">
     <div class="hero-head">
-      <span class="kicker load-up d1">开源智能体运行时 · Apache-2.0</span>
-      <h1 class="load-up d2">San — 统一智能体<br>在你的<span class="grad">终端中进化</span></h1>
-      <p class="sub load-up d3">一个运行时，多种智能体——<strong>与你一起成长</strong></p>
-    </div>
-
-    <div class="screen-frame load-up d4">
-      <div class="intro-embed">
-        <iframe src="intro.html?theme=dark" title="San — 动画介绍" loading="lazy" allow="fullscreen"></iframe>
+      <span class="kicker load-up d1">开源 · Apache-2.0</span>
+      <h1 class="load-up d2">开销最小，<br>Agent <em>最强</em>。</h1>
+      <p class="sub load-up d3">San 是一个开源的终端 Agent 运行时：一个原生 Go 二进制，不需要 Node.js 或 Python。模型碰到的一切 —— prompt、工具、provider、扩展 —— 都留给你替换。</p>
+      <div class="metrics load-up d4">
+        <span><b>~0.01s</b> 冷启动</span>
+        <span><b>~12 MB</b> 单文件</span>
+        <span><b>~2.3k</b> token 框架开销</span>
+        <span><b>零</b>运行时依赖</span>
       </div>
     </div>
-    <p class="intro-cap load-up d4"><a href="intro.html" target="_blank" rel="noopener">全屏观看 ↗</a></p>
 
-    <div class="hero-actions load-up d5">
-      <a class="btn btn-primary" href="getting-started.zh.html">快速开始 →</a>
-      <a class="btn btn-ghost" href="https://github.com/genai-io/san">在 GitHub 上查看</a>
+    <div class="install load-up d5">
+      <div class="install-tabs" role="tablist" aria-label="安装方式">
+        <button class="install-tab active" role="tab" aria-selected="true" data-cmd="curl -fsSL https://raw.githubusercontent.com/genai-io/san/main/install.sh | bash">curl</button>
+        <button class="install-tab" role="tab" aria-selected="false" data-cmd="irm https://raw.githubusercontent.com/genai-io/san/main/install.ps1 | iex">powershell</button>
+        <button class="install-tab" role="tab" aria-selected="false" data-cmd="go install github.com/genai-io/san/cmd/san@latest">go install</button>
+      </div>
+      <div class="install-body">
+        <span class="prompt">$</span>
+        <code id="install-cmd">curl -fsSL https://raw.githubusercontent.com/genai-io/san/main/install.sh | bash</code>
+        <button class="copy-btn" onclick="copyInstall(this)">复制</button>
+      </div>
     </div>
 
-    <div class="install-bar load-up d6">
-      <span class="prompt">$</span>
-      <code id="install-cmd">curl -fsSL https://raw.githubusercontent.com/genai-io/san/main/install.sh | bash</code>
-      <button class="copy-btn" onclick="copyInstall(this)">复制</button>
+    <div class="hero-actions load-up d6">
+      <a class="btn btn-primary" href="getting-started.zh.html">快速开始</a>
+      <a class="btn btn-ghost" href="intro.html">看动画介绍</a>
+      <a class="btn btn-ghost" href="https://github.com/genai-io/san">GitHub</a>
     </div>
 
     <div class="badges load-up d6">
-      <a href="https://github.com/genai-io/san/releases"><img src="https://img.shields.io/github/v/release/genai-io/san?style=flat-square&color=0d9488" alt="版本"></a>
-      <a href="https://github.com/genai-io/san/stargazers"><img src="https://img.shields.io/github/stars/genai-io/san?style=flat-square&color=14b8a6" alt="星标"></a>
-      <img src="https://img.shields.io/badge/license-Apache%202.0-0b7d72?style=flat-square" alt="许可协议">
+      <a href="https://github.com/genai-io/san/releases"><img src="https://img.shields.io/github/v/release/genai-io/san?style=flat-square&color=0d9488&labelColor=f1efe9" alt="版本"></a>
+      <a href="https://github.com/genai-io/san/stargazers"><img src="https://img.shields.io/github/stars/genai-io/san?style=flat-square&color=0d9488&labelColor=f1efe9" alt="星标"></a>
+      <img src="https://img.shields.io/badge/license-Apache%202.0-0d9488?style=flat-square&labelColor=f1efe9" alt="许可协议">
     </div>
   </div>
 </header>
 
-<section id="features">
-  <div class="wrap">
-    <div class="section-head">
-      <span class="kicker">功能特性</span>
-      <h2 class="section-title">开放 <em>设计</em></h2>
-      <p class="section-sub">每一层都可以在运行时替换。无供应商锁定。</p>
+<section id="demo" style="padding-top: 24px;">
+  <div class="wrap wide">
+    <div class="stage-tabs" role="tablist" aria-label="演示">
+      <button class="stage-tab active" role="tab" aria-selected="true" data-stage="intro">看动画介绍</button>
+      <button class="stage-tab" role="tab" aria-selected="false" data-stage="turn">跑一个 turn</button>
     </div>
-    <div class="grid">
-      <div class="card reveal">
-        <span class="idx">01</span>
-        <h3><span class="ico">🔌</span> 多 LLM 提供商</h3>
-        <p>使用任何 LLM —— 从 Anthropic 到 Z.ai。通过 <code>/models</code> 随时切换。</p>
+
+    <div id="stage-intro">
+      <div class="intro-embed">
+        <iframe src="intro.html?theme=dark" title="San — 动画介绍" loading="lazy" allow="fullscreen"></iframe>
       </div>
-      <div class="card reveal">
-        <span class="idx">02</span>
-        <h3><span class="ico">🔍</span> 可插拔搜索</h3>
-        <p>Exa、Tavily、Brave 或 Serper。通过 <code>/search</code> 随时切换。</p>
-      </div>
-      <div class="card reveal">
-        <span class="idx">03</span>
-        <h3><span class="ico">🧩</span> 技能与扩展</h3>
-        <p>技能、插件、MCP 服务器和子智能体——兼容 Claude Code，无需修改即可运行。</p>
-      </div>
-      <div class="card reveal">
-        <span class="idx">04</span>
-        <h3><span class="ico">🎭</span> 角色系统</h3>
-        <p>Markdown 定义的角色——系统提示、技能和配置按用户或项目打包，通过 <code>/persona</code> 切换。</p>
-      </div>
-      <div class="card reveal">
-        <span class="idx">05</span>
-        <h3><span class="ico">⚡</span> 原生性能</h3>
-        <p>单一 Go 二进制文件。12 MB，~0.01 秒启动，零运行时依赖。</p>
-      </div>
-      <div class="card reveal">
-        <span class="idx">06</span>
-        <h3><span class="ico">💾</span> 会话持久化</h3>
-        <p>会话自动保存、恢复和分支，支持自动上下文压缩。</p>
-      </div>
-      <div class="card wide reveal">
-        <span class="idx">07</span>
-        <div>
-          <h3><span class="ico">✦</span> 自我进化 <span class="soon">Lv.1 · 已上线</span></h3>
-          <p>每经过几轮交互，后台审核者会将你最近的工作提炼为持久化记忆和可复用技能——智能体在你工作中不断升级，无需手动调优。Lv.1 现已上线；更深层级即将推出。</p>
+      <p class="panel-cap"><a href="intro.html" target="_blank" rel="noopener">打开高清完整版 ↗</a> · 54 秒，无声</p>
+    </div>
+
+    <div id="stage-turn" hidden>
+      <div class="term">
+        <div class="term-bar">
+          <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+          <span class="where">san — ~/acme-api</span>
+          <span class="model">◆ <b>sonnet-4-6</b></span>
         </div>
-        <div class="levels">
-          <span class="level live"><b>Lv.1</b> 好奇</span>
-          <span class="arrow">→</span>
-          <span class="level"><b>Lv.10</b> 更优</span>
-          <span class="arrow">→</span>
-          <span class="level"><b>Lv.50</b> 更强</span>
-          <span class="arrow">→</span>
-          <span class="level"><b>Lv.∞</b> 传奇</span>
+        <div class="term-out" id="term-out"></div>
+        <div class="term-ask">
+          <form class="term-line" id="term-form" autocomplete="off">
+            <span class="q">❯</span>
+            <input id="term-in" type="text" placeholder="问 San 点什么…" aria-label="问 San 点什么">
+            <span class="enter">↵ 运行</span>
+          </form>
+          <div class="term-chips" id="term-chips"></div>
         </div>
       </div>
+      <p class="panel-cap">脚本演示，示例仓库 · 一个真实 San turn 的样子</p>
     </div>
   </div>
 </section>
 
-<section id="deploy" style="background: var(--bg-soft);">
+<section id="why">
   <div class="wrap">
     <div class="section-head">
-      <span class="kicker">随处部署</span>
-      <h2 class="section-title">一个二进制。<em>随处运行。</em></h2>
-      <p class="section-sub">一个 ~12 MB 的二进制文件，零运行时依赖——同一文件可在笔记本、云节点或 256 MB 边缘设备上无需修改即可运行。</p>
+      <span class="kicker">为什么选 San</span>
+      <h2 class="section-title">小的是开销，<br><em>不是 Agent 的能力</em>。</h2>
+      <p class="section-sub">三个特性 —— 小、快、开 —— 谁也不为谁让路。三笔，正好一个「三」。</p>
     </div>
-    <div class="deploy-targets">
-      <span class="pill">💻 macOS 和 Linux 笔记本</span>
-      <span class="pill">☁️ 云节点和虚拟机</span>
-      <span class="pill">📟 ARM 边缘设备</span>
-      <span class="pill">🐳 <code>scratch</code> 容器</span>
-      <span class="pill">⚙️ CI 步骤和生命周期钩子</span>
-      <span class="pill">🔒 离线隔离环境</span>
+
+    <div class="trigram">
+      <article class="stroke">
+        <div class="rail">
+          <span class="glyph" aria-hidden="true">一</span>
+          <span class="name">小</span>
+        </div>
+        <div class="body">
+          <h3>上下文窗口留给你的正事</h3>
+          <p>你的第一句话之前，框架占的那点上下文很小，窗口留给手上的任务。落到磁盘上就一个文件，不用再装别的东西。</p>
+          <dl class="rows">
+            <dt>框架开销</dt><dd>~2.3k token</dd>
+            <dt>二进制</dt><dd>12 MB <span class="dim">· macos · linux · windows</span></dd>
+            <dt>运行时依赖</dt><dd>无</dd>
+          </dl>
+          <div class="pills">
+            <span class="pill"><span class="ico">💻</span> 笔记本</span>
+            <span class="pill"><span class="ico">☁️</span> 云主机</span>
+            <span class="pill"><span class="ico">📟</span> ARM 边缘设备</span>
+            <span class="pill"><span class="ico">🐳</span> 容器</span>
+            <span class="pill"><span class="ico">⚙️</span> CI 步骤</span>
+            <span class="pill"><span class="ico">🔒</span> 离线隔离环境</span>
+          </div>
+          <p class="more"><a href="https://github.com/genai-io/san/blob/main/docs/operations/footprint.md">为什么小很重要</a></p>
+        </div>
+      </article>
+
+      <article class="stroke">
+        <div class="rail">
+          <span class="glyph" aria-hidden="true">二</span>
+          <span class="name">快</span>
+        </div>
+        <div class="body">
+          <h3>你等的是模型，不是客户端</h3>
+          <p>原生 Go：按键之前没有解释器要启动，也不用先把 <code>node_modules</code> 读一遍。你等的是模型。</p>
+          <dl class="rows">
+            <dt>冷启动</dt><dd>~0.01s</dd>
+            <dt>简单任务</dt><dd>~2.4s</dd>
+            <dt>工具调用任务</dt><dd>~3.3s</dd>
+            <dt>内存</dt><dd>空载 ~32 MB <span class="dim">· 负载下 ~39 MB</span></dd>
+          </dl>
+          <p class="more"><a href="#benchmark">看数据</a></p>
+        </div>
+      </article>
+
+      <article class="stroke">
+        <div class="rail">
+          <span class="glyph" aria-hidden="true">三</span>
+          <span class="name">开</span>
+        </div>
+        <div class="body">
+          <h3>从里到外都开放</h3>
+          <p>模型看到什么、能做什么，都由你写 —— 事后还能原样回放。</p>
+          <div class="trio">
+            <div class="facet">
+              <h4>接得上</h4>
+              <p>Anthropic、OpenAI、Google、DeepSeek、Ollama 等十余家 provider；搜索后端随你挑；skills、plugins、MCP servers、subagents、hooks 一律无需修改就能跑。</p>
+              <div class="keys"><span>/models</span><span>/search</span></div>
+            </div>
+            <div class="facet">
+              <h4>写得了</h4>
+              <p>system prompt 自己拼，打包成可切换的 persona，给 autopilot 一个目标，自我学习跟哪套策略也由你定。</p>
+              <div class="keys"><span>/identity</span><span>/goal</span><span>/evolve</span></div>
+            </div>
+            <div class="facet">
+              <h4>看得住</h4>
+              <p>San 不问就能做到哪一步由你决定，subagent 继承这个选择。inspector 把一次运行按模型看到的原样回放。</p>
+              <div class="keys"><span>Shift+Tab</span><span>san inspector</span></div>
+            </div>
+          </div>
+          <p class="more"><a href="https://github.com/genai-io/san/blob/main/docs/concepts/harness-channels.md">怎么拼 system prompt</a></p>
+        </div>
+      </article>
     </div>
-    <p class="bench-note">无需 Node.js，无需 Python，无需 <code>node_modules</code>。<a href="https://github.com/genai-io/san/blob/main/docs/operations/footprint.md">为什么小很重要及运行环境 →</a></p>
   </div>
 </section>
 
-<section id="footprint">
+<section id="benchmark" class="band">
   <div class="wrap">
     <div class="section-head">
-      <span class="kicker">性能对比</span>
-      <h2 class="section-title">小而快，<em>设计使然</em></h2>
-      <p class="section-sub">相同模型（<span class="mono">claude-sonnet-4-6</span>），相同任务，Apple Silicon——以 Claude Code 为参考基准。</p>
+      <span class="kicker">基准测试</span>
+      <h2 class="section-title">小而快，<em>有数可依</em>。</h2>
+      <p class="section-sub">对比 Claude Code v2.1.112，Apple Silicon，相同模型（<span class="mono">claude-sonnet-4-6</span>）、相同任务。</p>
     </div>
     <div class="bench-wrap reveal">
       <table>
@@ -173,24 +222,11 @@
           <tr><td>启动内存</td><td>~32 MB</td><td>~189 MB</td><td class="adv">少 5.8 倍</td></tr>
           <tr><td>简单任务</td><td>~2.4 秒 / 39 MB</td><td>~10.4 秒 / 286 MB</td><td class="adv">快 4.3 倍</td></tr>
           <tr><td>工具调用任务</td><td>~3.3 秒 / 39 MB</td><td>~26.0 秒 / 285 MB</td><td class="adv">快 7.9 倍</td></tr>
+          <tr><td>框架上下文</td><td>~2.3k token</td><td>~20.9k token</td><td class="adv">精简 ~9 倍</td></tr>
         </tbody>
       </table>
     </div>
-    <p class="bench-note">San 无需修改即可运行 Claude Code 的技能、插件和 MCP——差距在于原生 Go 二进制与 Node.js 运行时的差异。<a href="https://github.com/genai-io/san/blob/main/docs/operations/benchmark.md">复现数据 →</a></p>
-  </div>
-</section>
-
-<section style="background: var(--bg-soft);">
-  <div class="wrap">
-    <div class="cta-box reveal">
-      <span class="kicker" style="justify-content:center;">开始使用</span>
-      <h2>30 秒内体验</h2>
-      <p>基于 Apache 2.0 开源。如果对你有用，请给仓库标星——这真的很有帮助。</p>
-      <div class="hero-actions">
-        <a class="btn btn-primary" href="https://github.com/genai-io/san">★ 在 GitHub 标星</a>
-        <a class="btn btn-ghost" href="getting-started.zh.html">快速开始</a>
-      </div>
-    </div>
+    <p class="bench-note">能力集相当 —— San 无需修改即可运行 Claude Code 的 skills、plugins 和 MCP servers —— 差距在客户端开销，不在能力。<a href="https://github.com/genai-io/san/blob/main/docs/operations/benchmark.md">测量方法与复现 →</a></p>
   </div>
 </section>
 
@@ -198,17 +234,17 @@
   <div class="wrap">
     <div class="section-head">
       <span class="kicker">社区</span>
-      <h2 class="section-title">加入 <em>对话</em></h2>
-      <p class="section-sub">两种方式——微信面向中文社区，Slack 面向全球用户。</p>
+      <h2 class="section-title">两个<em>入口</em>。</h2>
+      <p class="section-sub">微信面向中文社区，Slack 面向其他地方。</p>
     </div>
     <div class="qr-row reveal">
       <div class="qr-card">
-        <img src="wechat.jpg" alt="微信官方公众号 极客外传 二维码" width="200" height="200" loading="lazy">
+        <img src="wechat.jpg" alt="微信官方公众号 极客外传 二维码" width="190" height="190" loading="lazy">
         <p class="qr-cap">关注公众号「极客外传」· 回复 <span class="mono">san</span> 或 <span class="mono">三</span> 入群</p>
       </div>
       <div class="qr-card">
-        <img src="slack.png" alt="San Slack 二维码" width="200" height="200" loading="lazy">
-        <p class="qr-cap">扫描二维码或<a href="https://join.slack.com/t/sanaico/shared_invite/zt-3zvfr8v6f-dchFpvpufY7fKA7tG7lhIg">加入 Slack</a></p>
+        <img src="slack.png" alt="San Slack 二维码" width="190" height="190" loading="lazy">
+        <p class="qr-cap">扫描二维码，或<a href="https://join.slack.com/t/sanaico/shared_invite/zt-3zvfr8v6f-dchFpvpufY7fKA7tG7lhIg">加入 Slack</a></p>
       </div>
     </div>
   </div>
@@ -220,7 +256,7 @@
     <span>
       <a href="https://github.com/genai-io/san">GitHub</a> ·
       <a href="https://github.com/genai-io/san/tree/main/docs">文档</a> ·
-      <a href="https://github.com/genai-io/san/blob/main/CONTRIBUTING.md">贡献指南</a>
+      <a href="https://github.com/genai-io/san/blob/main/CONTRIBUTING.md">参与贡献</a>
     </span>
   </div>
 </footer>
@@ -231,13 +267,24 @@
     const text = document.getElementById('install-cmd').innerText;
     navigator.clipboard.writeText(text).then(() => {
       const old = btn.innerText;
-      btn.innerText = '已复制！';
+      btn.innerText = '已复制';
       setTimeout(() => btn.innerText = old, 1500);
     });
   }
   document.getElementById('year').innerText = new Date().getFullYear();
 
-  // 移动端导航切换
+  // 安装方式标签页 —— 每个标签自带命令
+  document.querySelectorAll('.install-tab').forEach(tab => {
+    tab.addEventListener('click', () => {
+      document.querySelectorAll('.install-tab').forEach(t => {
+        t.classList.toggle('active', t === tab);
+        t.setAttribute('aria-selected', t === tab);
+      });
+      document.getElementById('install-cmd').innerText = tab.dataset.cmd;
+    });
+  });
+
+  // 移动端导航
   function toggleNav(btn) {
     const nav = document.getElementById('nav');
     const open = nav.classList.toggle('open');
@@ -246,19 +293,19 @@
   document.querySelectorAll('#nav-links a').forEach(a =>
     a.addEventListener('click', () => document.getElementById('nav').classList.remove('open')));
 
+  // 滚动后导航栏出现发丝分隔线
   const nav = document.getElementById('nav');
   const onScroll = () => nav.classList.toggle('scrolled', window.scrollY > 8);
   onScroll();
   window.addEventListener('scroll', onScroll, { passive: true });
 
+  // 滚动淡入
   const io = new IntersectionObserver((entries) => {
     entries.forEach(e => { if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } });
   }, { threshold: 0.12, rootMargin: '0px 0px -8% 0px' });
-  document.querySelectorAll('.reveal').forEach((el, i) => {
-    el.style.transitionDelay = (i % 6) * 60 + 'ms';
-    io.observe(el);
-  });
+  document.querySelectorAll('.reveal').forEach(el => io.observe(el));
 
+  // 高亮当前所在小节
   const spyLinks = [...document.querySelectorAll('#nav-links a[href^="#"]')];
   const sections = spyLinks
     .map(a => document.getElementById(a.getAttribute('href').slice(1)))
@@ -273,15 +320,209 @@
   }, { rootMargin: '-45% 0px -50% 0px' });
   sections.forEach(s => spy.observe(s));
 
+  // intro 是固定 1280x720 的页面，整体缩放到容器宽度，保证舞台完整可见
   (function () {
     const box = document.querySelector('.intro-embed');
     if (!box) return;
     const frame = box.querySelector('iframe');
-    const scaleFrame = () => { frame.style.transform = 'scale(' + (box.clientWidth / 1280) + ')'; };
+    // 标签页藏起来时盒子没有宽度，这时保持原缩放不动
+    const scaleFrame = () => {
+      if (!box.clientWidth) return;
+      frame.style.transform = 'scale(' + (box.clientWidth / 1280) + ')';
+    };
     scaleFrame();
     new ResizeObserver(scaleFrame).observe(box);
   })();
-  // Language switcher — custom dropdown
+
+  // 演示位：同一块黑屏，两个标签页各看一面
+  document.querySelectorAll('.stage-tab').forEach(tab => {
+    tab.addEventListener('click', () => {
+      document.querySelectorAll('.stage-tab').forEach(t => {
+        const on = t === tab;
+        t.classList.toggle('active', on);
+        t.setAttribute('aria-selected', on);
+        document.getElementById('stage-' + t.dataset.stage).hidden = !on;
+      });
+    });
+  });
+
+  // 一个 San turn 在终端里跑完：你问的话、每个工具一行，然后 San 说了什么。
+  // turn 都是脚本写死的 —— 你自己打字进去，它会直说这一点，而不是编一个答案。
+  (function () {
+    const out   = document.getElementById('term-out');
+    const form  = document.getElementById('term-form');
+    const input = document.getElementById('term-in');
+    const chips = document.getElementById('term-chips');
+    if (!out) return;
+
+    const still = matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    const TURNS = [
+      {
+        chip: '加一个接口',
+        ask: '加一个 /healthz 接口，带测试',
+        steps: [
+          { tool: 'bash',  arg: 'rg -n "func register" internal/server', meta: '3 处 · 9ms' },
+          { tool: 'read',  arg: 'internal/server/router.go',             meta: '148 行 · 11ms' },
+          { tool: 'edit',  arg: 'internal/server/router.go',             meta: '+9 −0' },
+          { tool: 'write', arg: 'internal/server/healthz_test.go',       meta: '+24' },
+          { tool: 'bash',  arg: 'go test ./internal/server',             meta: 'ok · 0.42s', wait: 800 },
+          { say: ['/healthz 已经和 router.go 里其他路由放在一起。它会报出构建版本号，数据库连接池还在预热时返回 503 —— 这样滚动发布不会把流量打到冷进程上。测试覆盖了两种状态。'] },
+          { done: '5 个工具 · 2.1s · 118 tok/s' },
+        ],
+      },
+      {
+        chip: '查一个偶发失败的测试',
+        ask: 'TestQueueDrain 大概二十次跑挂一次，为什么？',
+        steps: [
+          { tool: 'bash', arg: 'rg -n "TestQueueDrain" internal/queue',  meta: '1 处 · 7ms' },
+          { tool: 'read', arg: 'internal/queue/drain_test.go',           meta: '96 行 · 9ms' },
+          { tool: 'read', arg: 'internal/queue/drain.go',                meta: '212 行 · 10ms' },
+          { say: ['测试 sleep 了 10ms 就去断言 q.pending。而 Drain() 要等 ticker 再触发一次才清掉最后一批，ticker 间隔是 5ms —— 机器一忙，第二次 tick 就落在断言后面，于是还剩一个没排空。问题在这个 sleep，不在 drainer。'] },
+          { tool: 'edit', arg: 'internal/queue/drain_test.go',           meta: '+4 −2' },
+          { tool: 'bash', arg: 'go test -run TestQueueDrain -count 50',  meta: '50/50 ok · 1.2s', wait: 900 },
+          { done: '5 个工具 · 4.7s' },
+        ],
+      },
+      {
+        chip: '讲讲这个代码库',
+        ask: '这个服务是干什么的？三行说清，别绕',
+        steps: [
+          { tool: 'bash', arg: 'rg --files -g "*.go"',       meta: '38 个文件 · 6ms' },
+          { tool: 'read', arg: 'cmd/api/main.go',            meta: '64 行 · 7ms' },
+          { tool: 'read', arg: 'internal/order/service.go',  meta: '241 行 · 9ms' },
+          { say: [
+            '一个 HTTP 订单服务：cmd/api 装配配置、Postgres 连接池和路由，然后把请求全交给 internal/order。',
+            '订单和它的明细在同一个事务里写入；扣款是单独一步，由一张 outbox 表驱动。',
+            '重试、对账、metrics 接口都挂在这张 outbox 上 —— 所以写路径始终只有一次往返。',
+          ] },
+          { done: '3 个工具 · 1.6s' },
+        ],
+      },
+    ];
+
+    const FALLBACK = [
+      { say: [
+        '这个终端是脚本写死的 —— 页面背后没有模型，也没有仓库，所以这句它答不了。',
+        '装上 San，在你自己的项目里问它：',
+      ] },
+      { cmd: 'curl -fsSL https://raw.githubusercontent.com/genai-io/san/main/install.sh | bash' },
+      { say: ['或者点下面任意一个脚本 turn。'] },
+    ];
+
+    const sleep = (ms) => new Promise(done => setTimeout(done, still ? 0 : ms));
+    const toBottom = () => { out.scrollTop = out.scrollHeight; };
+
+    function addRow(kind) {
+      const el = document.createElement('div');
+      el.className = 'row ' + kind;
+      out.appendChild(el);
+      toBottom();
+      return el;
+    }
+    function addSpan(parent, kind, text) {
+      const el = document.createElement('span');
+      el.className = kind;
+      el.textContent = text;
+      parent.appendChild(el);
+      return el;
+    }
+
+    // San 是流式输出的，所以答案跟在光标后面一个字一个字出来
+    async function stream(el, text, alive) {
+      const node = document.createTextNode('');
+      el.appendChild(node);
+      if (still) { node.data = text; return; }
+      const caret = addSpan(el, 'caret', '');
+      for (let i = 1; i <= text.length; i++) {
+        if (!alive()) { caret.remove(); return; }
+        node.data = text.slice(0, i);
+        if (i % 2 === 0) { await sleep(14); toBottom(); }
+      }
+      caret.remove();
+    }
+
+    async function playTool(step, alive) {
+      const el = addRow('tool');
+      const mark = addSpan(el, 'spin', '✦');
+      addSpan(el, 'tn', step.tool);
+      const rest = addSpan(el, 'rest', '');
+      addSpan(rest, 'arg', step.arg);
+      await sleep(step.wait || 340);
+      if (!alive()) return;
+      mark.textContent = '⏺';
+      mark.classList.add('settled');
+      addSpan(rest, 'meta' + (/^[+−]/.test(step.meta) ? ' diff' : ''), step.meta);
+    }
+
+    async function playSay(lines, alive) {
+      for (let i = 0; i < lines.length; i++) {
+        if (!alive()) return;
+        const el = addRow(i === 0 ? 'say' : 'say cont');
+        if (i === 0) addSpan(el, 'mk', '●');
+        await stream(addSpan(el, 'text', ''), lines[i], alive);
+      }
+    }
+
+    function playCmd(command) {
+      const el = addRow('cmd');
+      addSpan(el, 'prompt', '$');
+      el.appendChild(document.createTextNode(command));
+    }
+
+    function playDone(summary) {
+      const el = addRow('done');
+      addSpan(el, 'ok', '✓');
+      el.appendChild(document.createTextNode(' 完成 · ' + summary));
+    }
+
+    let generation = 0;
+
+    async function play(turn) {
+      const mine = ++generation;
+      const alive = () => mine === generation;
+
+      out.textContent = '';
+      const asked = addRow('you');
+      addSpan(asked, 'q', '❯');
+      asked.appendChild(document.createTextNode(turn.ask));
+      await sleep(380);
+
+      for (const step of turn.steps) {
+        if (!alive()) return;
+        if (step.tool)      await playTool(step, alive);
+        else if (step.say)  await playSay(step.say, alive);
+        else if (step.cmd)  playCmd(step.cmd);
+        else if (step.done) playDone(step.done);
+        toBottom();
+        await sleep(90);
+      }
+    }
+
+    TURNS.forEach(turn => {
+      const chip = document.createElement('button');
+      chip.type = 'button';
+      chip.className = 'term-chip';
+      chip.textContent = turn.chip;
+      chip.addEventListener('click', () => play(turn));
+      chips.appendChild(chip);
+    });
+
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const asked = input.value.trim();
+      if (!asked) return;
+      input.value = '';
+      play({ ask: asked, steps: FALLBACK });
+    });
+
+    // 终端藏在标签页后面，所以第一个 turn 等这个标签页被打开再跑；只跑这一次，
+    // 再切回来时保留屏幕上已有的内容
+    document.querySelector('.stage-tab[data-stage="turn"]')
+      .addEventListener('click', () => play(TURNS[0]), { once: true });
+  })();
+
+  // 语言切换
   (function() {
     const LANGS = { en: { label: 'EN', ext: '.html' }, zh: { label: '中文', ext: '.zh.html' } };
     const PAGES = new Set(['index', 'getting-started', 'docs']);

--- a/site/intro.html
+++ b/site/intro.html
@@ -222,6 +222,8 @@
   .timeline .fill{height:100%;width:0;background:linear-gradient(90deg,var(--accent-strong),var(--accent));border-radius:3px}
 
   .hud{position:absolute;left:36px;bottom:14px;z-index:7;font-size:11px;color:var(--faint)}
+  /* embedded on the site: the key hints need focus we don't have, so drop them */
+  html[data-embed] .hud{display:none}
   .hud kbd{border:1px solid var(--border);border-radius:4px;padding:0 5px;color:var(--dim)}
   .theme-btn{position:absolute;right:36px;bottom:12px;z-index:8;width:30px;height:30px;border-radius:8px;
     border:1px solid var(--border);background:var(--panel);color:var(--dim);font-size:15px;cursor:pointer;
@@ -349,7 +351,7 @@
       <section class="scene" data-start="36.4" data-dur="8.0" id="deploy">
         <div class="splash">
           <div class="logo reveal" id="d-logo">&lt; SAN <span class="sp">✦</span> /&gt;</div>
-          <div class="sub reveal" id="d-cap">one ~12 MB binary · zero deps</div>
+          <div class="sub reveal" id="d-cap">one binary · any model</div>
         </div>
       </section>
 
@@ -383,7 +385,7 @@
       </div>
       <div class="node reveal" id="d-n2">
         <div class="nicon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="3" y="6" width="18" height="12" rx="1"/><path d="M8 6v12M12 6v12M16 6v12"/></svg></div>
-        <div class="nlabel">scratch container</div><div class="nrole">ci-runner</div>
+        <div class="nlabel">container</div><div class="nrole">pr-review</div>
       </div>
       <div class="node reveal" id="d-n3">
         <div class="nicon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="7" y="7" width="10" height="10" rx="1.2"/><path d="M10 7V4.2M14 7V4.2M10 19.8V17M14 19.8V17M7 10H4.2M7 14H4.2M19.8 10H17M19.8 14H17"/></svg></div>
@@ -391,11 +393,11 @@
       </div>
       <div class="node reveal" id="d-n4">
         <div class="nicon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"><path d="M7 18h9.5a3.7 3.7 0 0 0 .4-7.4 5.2 5.2 0 0 0-10-1.4A3.6 3.6 0 0 0 7 18z"/></svg></div>
-        <div class="nlabel">cloud node</div><div class="nrole">api-review</div>
+        <div class="nlabel">cloud vm</div><div class="nrole">autopilot</div>
       </div>
       <div class="node reveal" id="d-n5">
-        <div class="nicon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><circle cx="12" cy="5" r="2.3"/><circle cx="5" cy="18" r="2.3"/><circle cx="19" cy="18" r="2.3"/><path d="M10.5 6.8 6.5 16M13.5 6.8 17.5 16M7.3 18h9.4"/></svg></div>
-        <div class="nlabel">edge gateway</div><div class="nrole">automation</div>
+        <div class="nicon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"><rect x="5" y="11" width="14" height="9" rx="1.6"/><path d="M8.2 11V8a3.8 3.8 0 0 1 7.6 0v3"/></svg></div>
+        <div class="nlabel">air-gapped host</div><div class="nrole">offline-audit</div>
       </div>
     </div>
     <div class="dfoot reveal" id="d-foot">One runtime, shipped everywhere — a fleet of specialized agents</div>
@@ -415,6 +417,8 @@ const root = document.documentElement;
 const params = new URLSearchParams(location.search);
 const SEEK = params.has('t') ? parseFloat(params.get('t')) : null;   // ?t=<sec> freezes the timeline (screenshots)
 
+if (window.self !== window.top) root.dataset.embed = '1';
+
 const mq = matchMedia('(prefers-color-scheme: dark)');
 let manualTheme = true;   // dark by default (cinematic); ◐ / T toggles. ?theme=light forces light.
 function applyAuto(){ if(!manualTheme) root.dataset.theme = mq.matches ? 'dark' : 'light'; }
@@ -428,14 +432,19 @@ const HOLD = 1.4;
 const SPEED = 1.0;   // master playback speed — <1 slower, >1 faster
 
 function fit(){ $('stage').style.transform = `scale(${Math.min(innerWidth/1280, innerHeight/720)})`; }
-addEventListener('resize', fit); fit();
+fit();
+// html is 100% of the viewport, so observing it covers window resizes as well
+// as the embedded case, where the parent's stylesheet sizes the frame after
+// this script has already run. The call above stays because the observer's
+// first callback is async — without it the stage renders one frame unscaled.
+new ResizeObserver(fit).observe(document.documentElement);
 
 const CAPS = {
   model:   {k:'OPEN ARCHITECTURE', t:'Multi-model switching',   d:'Switch provider or model with one command — fetched live, never hard-coded'},
   ident:   {k:'OPEN ARCHITECTURE', t:'Multi-persona switching', d:'Same agent, many personas — Markdown bundles scoped to user or project'},
   interact:{k:'NATIVE RUNTIME',    t:'Fast interaction',        d:'Native Go, single binary — read, edit, run the tests, stream back in seconds'},
   learn:   {k:'SELF-EVOLVING',     t:'Learns as you work',      d:'A background reviewer studies each session — writing memory, tuning skills, leveling up'},
-  deploy:  {k:'SMALL FOOTPRINT',   t:'Runs anywhere',           d:'One ~12 MB binary, zero deps — fan it out to edge devices, containers, and the cloud'},
+  deploy:  {k:'SMALL FOOTPRINT',   t:'Runs anywhere',           d:'One ~12 MB binary, zero deps — anywhere you can copy a file, against any model you can reach'},
 };
 
 const TICKS = [

--- a/site/style.css
+++ b/site/style.css
@@ -1,21 +1,20 @@
 /* ============================================================
    San — editorial-terminal design system
-   Type:  Newsreader (display / italic editorial)  ·
-          IBM Plex Mono (terminal voice: nav, code, data, labels) ·
-          Spline Sans (body)  — three families for 三.
-   Theme: warm parchment + deep teal, noise + radial glow,
-          terminal panels with traffic-light dots & a live cursor.
-   Shared by index.html, getting-started.html, docs.html.
+   Two voices:
+     Newsreader     — prose. Headlines are italic; body is serif.
+     IBM Plex Mono  — the machine: nav, buttons, code, data, labels.
+   Surface: the same warm parchment and teal as intro.html, so the page
+   and the embedded intro are one material. Hairline rules, soft corners,
+   one dark "screen" for the animation. No emoji, no glow stacks.
+   Shared by index.html, getting-started.html, docs.html (+ .zh).
    ============================================================ */
 
-@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;1,400&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,400;1,6..72,500&family=Spline+Sans:wght@400;500;600;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;1,6..72,400;1,6..72,500&display=swap");
 
 :root {
-  /* warm parchment surfaces — aligned 1:1 with intro.html's light theme
-     so the page and the embedded intro are the same material. */
+  /* warm parchment — aligned 1:1 with intro.html's light theme */
   --bg:        #f5f3ee;
   --bg-soft:   #f1efe9;
-  --bg-warm:   #ece9e1;
   --card:      #fffefb;
   --card-2:    #f8f6f1;
 
@@ -28,502 +27,604 @@
   --border:    #e4e0d6;
   --border-2:  #d7d2c4;
 
-  /* teal accent family — matches intro.html exactly */
-  --accent:    #0d9488;   /* deep teal — primary */
-  --accent-2:  #0b7d72;   /* darker teal — text on light */
-  --accent-br: #14b8a6;   /* bright teal */
-  --mint:      #2dd4bf;
-  --accent-soft: rgba(13,148,136,.11);
-  --accent-line: rgba(13,148,136,.30);
-  --glow:      rgba(13,148,136,.12);
+  /* San teal */
+  --accent:      #0d9488;
+  --accent-2:    #0b7d72;
+  --accent-soft: rgba(13, 148, 136, .10);
+  --accent-line: rgba(13, 148, 136, .30);
 
-  /* dark "screen" for terminals & embeds */
-  --screen:    #0a0c10;
-  --screen-2:  #11151b;
-  --screen-bar:#161b22;
-  --screen-fg: #e7efeb;
-  --screen-dim:#8b97a0;
-  --screen-border: #232b34;
-
-  --green:     #15803d;
-  --amber:     #c2740a;
+  /* the one dark surface: the animated intro's screen */
+  --screen:        #0a0c10;
+  --screen-border: #202834;
+  --screen-dim:    #808c9a;
+  --mint:          #2dd4bf;
 
   --mono:  "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  --serif: "Newsreader", Georgia, "Times New Roman", serif;
-  --sans:  "Spline Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  /* Chinese pages fall back to a serif Han face; SimSun is deliberately
+     not listed — the sans fallback reads better than it does. */
+  --serif: "Newsreader", "Source Han Serif SC", "Noto Serif SC", "Songti SC",
+           Georgia, "Times New Roman", serif;
 
-  --maxw: 1080px;
+  --maxw: 1120px;
+  --r:    10px;
   --ease: cubic-bezier(.22,.61,.36,1);
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
-html { scroll-behavior: smooth; scroll-padding-top: 84px; -webkit-text-size-adjust: 100%; }
+html { scroll-behavior: smooth; scroll-padding-top: 76px; -webkit-text-size-adjust: 100%; }
 
 body {
   background: var(--bg);
   color: var(--text);
-  font-family: var(--sans);
-  font-size: 16px;
+  font-family: var(--serif);
+  font-size: 18px;
   line-height: 1.62;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
   overflow-x: hidden;
 }
 
-/* atmosphere: fixed teal glow + faint grain, behind all content */
+/* paper grain, fixed behind everything — the same texture the intro uses */
 body::before {
-  content: ""; position: fixed; inset: 0; z-index: -2; pointer-events: none;
-  background:
-    radial-gradient(110% 70% at 50% -12%, var(--glow), transparent 56%),
-    radial-gradient(80% 60% at 100% 0%, rgba(13,148,136,.07), transparent 50%),
-    var(--bg);
-}
-body::after {
   content: ""; position: fixed; inset: 0; z-index: -1; pointer-events: none;
-  opacity: .045; mix-blend-mode: multiply;
+  opacity: .04; mix-blend-mode: multiply;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
 }
 
 ::selection { background: var(--accent); color: #fff; }
 
-a { color: var(--accent-2); text-decoration: none; transition: color .18s ease; }
-a:hover { color: var(--accent-br); text-decoration: none; }
+a { color: var(--accent); text-decoration: none; transition: color .18s ease; }
+a:hover { color: var(--accent-2); }
 
-.wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 28px; }
-.mono { font-family: var(--mono); }
+.wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 32px; }
+/* the intro screen breaks out wider than the reading column */
+.wrap.wide { max-width: 1280px; }
+.mono { font-family: var(--mono); font-size: .92em; }
 
-/* shared eyebrow / kicker */
+/* eyebrow */
 .kicker {
-  font-family: var(--mono); font-size: 12px; font-weight: 500;
-  letter-spacing: .22em; text-transform: uppercase; color: var(--accent-2);
+  font-family: var(--mono); font-size: 11.5px; font-weight: 400;
+  letter-spacing: .2em; text-transform: uppercase; color: var(--accent-2);
   display: inline-flex; align-items: center; gap: 9px;
 }
-.kicker::before { content: "✦"; color: var(--accent); font-size: 13px; }
+.kicker::before { content: "✦"; color: var(--accent); letter-spacing: 0; }
 
 /* ============================================================ NAV */
 nav {
   position: sticky; top: 0; z-index: 50;
-  background: rgba(245,242,234,.72);
-  backdrop-filter: saturate(140%) blur(14px);
-  -webkit-backdrop-filter: saturate(140%) blur(14px);
+  background: rgba(245,243,238,.80);
+  backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px);
   border-bottom: 1px solid transparent;
-  transition: background .25s ease, border-color .25s ease, box-shadow .25s ease;
+  transition: border-color .25s ease, background .25s ease;
 }
-nav.scrolled {
-  background: rgba(245,242,234,.9);
-  border-bottom-color: var(--border);
-  box-shadow: 0 1px 0 rgba(0,0,0,.02), 0 14px 30px -26px rgba(27,32,31,.5);
-}
-nav .wrap { display: flex; align-items: center; justify-content: space-between; height: 66px; gap: 18px; }
+nav.scrolled { background: rgba(245,243,238,.93); border-bottom-color: var(--border); }
+nav .wrap { display: flex; align-items: center; justify-content: space-between; height: 60px; gap: 18px; }
 
 .logo {
-  font-family: var(--mono); font-weight: 600; font-size: 16px; letter-spacing: -.01em;
+  font-family: var(--mono); font-weight: 500; font-size: 15px;
   color: var(--text); white-space: nowrap; display: inline-flex; align-items: center;
 }
 .logo a { color: var(--text); display: inline-flex; align-items: center; }
 .logo a:hover { color: var(--text); }
 .logo .spark { color: var(--accent); margin: 0 .12em; }
 .logo::after {
-  content: "▌"; color: var(--accent); margin-left: 2px;
-  animation: blink 1.05s steps(1) infinite;
+  content: "▌"; color: var(--accent); margin-left: 1px; opacity: .55;
+  animation: blink 1.4s steps(1) infinite;
 }
 @keyframes blink { 50% { opacity: 0; } }
 
-.nav-links { display: flex; gap: 6px; align-items: center; font-family: var(--mono); font-size: 13px; }
+.nav-links {
+  display: flex; gap: 20px; align-items: center;
+  font-family: var(--mono); font-size: 12px;
+  letter-spacing: .09em; text-transform: uppercase;
+}
 .nav-links a {
-  color: var(--muted); padding: 7px 11px; border-radius: 7px; position: relative;
-  transition: color .18s ease, background .18s ease;
-}
-.nav-links a:not(.nav-cta):hover { color: var(--text); background: rgba(13,148,136,.07); }
-.nav-links a.active { color: var(--accent-2); }
-.nav-links a.active::before {
-  content: ""; position: absolute; left: 11px; right: 11px; bottom: 2px; height: 2px;
-  background: var(--accent); border-radius: 2px;
-}
-.nav-cta {
-  margin-left: 6px; color: var(--accent-2) !important;
-  border: 1px solid var(--accent-line); background: var(--accent-soft);
-  padding: 7px 15px !important; border-radius: 8px; font-weight: 500;
-  transition: background .18s ease, color .18s ease, border-color .18s ease, transform .18s ease;
-}
-.nav-cta:hover {
-  background: var(--accent); color: #fff !important; border-color: var(--accent);
-  transform: translateY(-1px);
-}
-/* divider between in-page section links and destination-page links */
-.nav-sep { width: 1px; height: 16px; background: var(--border-2); margin: 0 6px; align-self: center; }
-
-/* language switcher — custom dropdown (always opens below) */
-.lang-switch { position: relative; display: inline-flex; align-items: center; margin-left: 4px; }
-.lang-btn {
-  display: inline-flex; align-items: center; gap: 4px;
-  font-family: var(--mono); font-size: 12px; color: var(--muted);
-  background: transparent; border: 1px solid var(--border-2);
-  border-radius: 6px; padding: 4px 8px; cursor: pointer; outline: none;
-  white-space: nowrap;
+  color: var(--muted); padding: 3px 0;
+  border-bottom: 1px solid transparent;
   transition: color .18s ease, border-color .18s ease;
 }
-.lang-btn:hover { color: var(--text); border-color: var(--accent-line); }
+.nav-links a:not(.nav-cta):hover { color: var(--text); border-bottom-color: var(--border-2); }
+.nav-links a.active { color: var(--text); border-bottom-color: var(--accent); }
+
+.nav-cta {
+  color: var(--accent-2) !important; border: 1px solid var(--accent-line);
+  background: var(--accent-soft); border-radius: 7px;
+  padding: 6px 13px !important; white-space: nowrap;
+  transition: background .18s ease, border-color .18s ease, color .18s ease;
+}
+.nav-cta:hover { background: var(--accent); color: #fff !important; border-color: var(--accent); }
+
+.nav-sep { width: 1px; height: 13px; background: var(--border-2); align-self: center; }
+
+/* language switcher */
+.lang-switch { position: relative; display: inline-flex; align-items: center; }
+.lang-btn {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-family: var(--mono); font-size: 11.5px; letter-spacing: .08em;
+  color: var(--muted); background: transparent;
+  border: 1px solid var(--border); border-radius: 6px;
+  padding: 4px 8px; cursor: pointer; outline: none; white-space: nowrap;
+  transition: color .18s ease, border-color .18s ease;
+}
+.lang-btn:hover { color: var(--text); border-color: var(--border-2); }
 .lang-arrow { transition: transform .18s ease; }
 .lang-btn[aria-expanded="true"] .lang-arrow { transform: rotate(180deg); }
 .lang-menu {
-  display: none; position: absolute; top: calc(100% + 4px); left: 0; z-index: 100;
-  min-width: 100%; background: var(--card); border: 1px solid var(--border);
-  border-radius: 8px; padding: 4px; box-shadow: 0 8px 24px rgba(0,0,0,.12);
+  display: none; position: absolute; top: calc(100% + 3px); left: 0; z-index: 100;
+  min-width: 100%; background: var(--card); border: 1px solid var(--border-2); border-radius: 8px; padding: 3px;
 }
 .lang-menu.open { display: block; }
 .lang-menu button {
   display: block; width: 100%; text-align: left;
-  font-family: var(--mono); font-size: 12px; color: var(--muted);
-  background: transparent; border: none; border-radius: 5px;
+  font-family: var(--mono); font-size: 11.5px; color: var(--muted);
+  background: transparent; border: none;
   padding: 6px 12px; cursor: pointer; white-space: nowrap;
   transition: background .15s ease, color .15s ease;
 }
 .lang-menu button:hover { background: var(--accent-soft); color: var(--text); }
-.lang-menu button.active { color: var(--accent-2); font-weight: 500; }
+.lang-menu button.active { color: var(--accent); }
 
 /* mobile toggle */
 .nav-toggle {
   display: none; background: none; border: 1px solid var(--border-2); color: var(--text);
-  width: 40px; height: 38px; border-radius: 9px; cursor: pointer;
-  font-size: 19px; line-height: 1; align-items: center; justify-content: center;
+  width: 36px; height: 34px; border-radius: 8px; cursor: pointer;
+  font-family: var(--mono); font-size: 17px; line-height: 1;
+  align-items: center; justify-content: center;
 }
-.nav-toggle:hover { border-color: var(--accent); color: var(--accent-2); }
+.nav-toggle:hover { border-color: var(--accent); color: var(--accent); }
 
-/* ============================================================ BUTTONS */
+/* ============================================================ BUTTONS
+   Terminal voice (mono, uppercase) with San's teal for the primary. */
 .btn {
-  padding: 12px 22px; border-radius: 10px; font-weight: 600; font-size: 14.5px;
-  font-family: var(--sans); display: inline-flex; align-items: center; gap: 9px;
-  transition: transform .18s var(--ease), box-shadow .2s ease, background .2s ease, border-color .2s ease;
+  font-family: var(--mono); font-size: 12px; font-weight: 500;
+  letter-spacing: .1em; text-transform: uppercase;
+  padding: 11px 18px; border: 1px solid transparent; border-radius: 8px;
+  color: var(--text); display: inline-flex; align-items: center; gap: 7px; white-space: nowrap;
+  transition: background .18s ease, border-color .18s ease, color .18s ease;
 }
-.btn-primary {
-  background: var(--accent); color: #fff;
-  box-shadow: 0 12px 26px -14px rgba(13,148,136,.8);
-}
-.btn-primary:hover { color: #fff; transform: translateY(-2px); box-shadow: 0 18px 34px -14px rgba(13,148,136,.9); background: var(--accent-2); }
-.btn-ghost { border: 1px solid var(--border-2); color: var(--text); background: var(--card); }
-.btn-ghost:hover { color: var(--text); border-color: var(--accent); background: var(--card-2); transform: translateY(-2px); }
-.hero-actions { margin-top: 26px; display: flex; gap: 14px; flex-wrap: wrap; justify-content: center; }
+.btn-primary { background: var(--accent); color: #fff; border-color: var(--accent); }
+.btn-primary:hover { background: var(--accent-2); border-color: var(--accent-2); color: #fff; }
+.btn-ghost { border-color: var(--border-2); background: var(--card); color: var(--text); }
+.btn-ghost:hover { border-color: var(--accent-line); color: var(--accent-2); }
+.hero-actions { margin-top: 26px; display: flex; gap: 10px; flex-wrap: wrap; justify-content: center; }
 
 /* ============================================================ HERO (home) */
-.hero { padding: 92px 0 64px; position: relative; text-align: center; }
-.hero .wrap { position: relative; }
-
-.hero-head { max-width: 840px; margin: 0 auto; }
+.hero { padding: 96px 0 72px; text-align: center; }
+.hero-head { max-width: 780px; margin: 0 auto; }
 .hero h1 {
-  font-family: var(--serif); font-weight: 500;
-  font-size: clamp(34px, 6vw, 68px); line-height: 1.06; letter-spacing: -.015em;
-  margin-top: 22px; color: var(--text);
+  font-family: var(--serif); font-style: italic; font-weight: 400;
+  font-size: clamp(36px, 5.6vw, 60px); line-height: 1.1; letter-spacing: -.012em;
+  margin-top: 20px; color: var(--text);
 }
-.hero h1 .grad {
-  font-style: italic; font-weight: 500; color: var(--accent-2);
-  background: linear-gradient(100deg, var(--accent-2), var(--accent-br));
-  -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
-}
+.hero h1 em { font-style: italic; color: var(--accent); }
 .hero p.sub {
-  font-size: clamp(17px, 2.1vw, 20px); color: var(--muted); max-width: 600px; margin: 22px auto 0;
+  font-size: clamp(17px, 1.7vw, 19.5px); color: var(--muted);
+  max-width: 620px; margin: 20px auto 0;
 }
-.hero p.sub strong { color: var(--text); font-weight: 600; }
+.hero p.sub strong { color: var(--text); font-weight: 500; }
 
-.badges { margin-top: 24px; display: flex; gap: 8px; flex-wrap: wrap; justify-content: center; }
-.badges img { height: 21px; }
+.badges { margin-top: 30px; display: flex; gap: 10px; flex-wrap: wrap; justify-content: center; opacity: .8; }
+.badges img { height: 19px; }
 
-/* copy button (used by the install bar) */
+/* ============================================================ INSTALL (tabbed) */
+.install {
+  margin: 34px auto 0; max-width: 660px; text-align: left; overflow: hidden;
+  border: 1px solid var(--border-2); border-radius: var(--r); background: var(--card);
+}
+.install-tabs { display: flex; border-bottom: 1px solid var(--border); background: var(--card-2); }
+.install-tab {
+  font-family: var(--mono); font-size: 11.5px; letter-spacing: .12em; text-transform: uppercase;
+  color: var(--faint); background: transparent; border: none;
+  border-right: 1px solid var(--border); padding: 10px 16px; cursor: pointer;
+  transition: color .18s ease, background .18s ease;
+}
+.install-tab:hover { color: var(--text); }
+.install-tab.active { color: var(--accent-2); background: var(--card); box-shadow: inset 0 2px 0 var(--accent); }
+.install-body {
+  display: flex; align-items: center; gap: 12px; padding: 16px 18px;
+  font-family: var(--mono); font-size: 13px;
+}
+.install-body .prompt { color: var(--accent); user-select: none; }
+.install-body code {
+  flex: 1; min-width: 0; color: var(--text); font-size: 13px;
+  background: none; padding: 0; overflow-x: auto; white-space: nowrap;
+}
+.install-body code::-webkit-scrollbar { height: 0; }
+
 .copy-btn {
-  background: rgba(255,255,255,.07); color: var(--screen-fg); border: 1px solid var(--screen-border);
-  padding: 6px 13px; border-radius: 7px; cursor: pointer; font-size: 12px;
-  font-family: var(--mono); white-space: nowrap; transition: background .18s ease, border-color .18s ease;
+  font-family: var(--mono); font-size: 11px; letter-spacing: .1em; text-transform: uppercase;
+  color: var(--muted); background: var(--card-2); border: 1px solid var(--border);
+  border-radius: 6px; padding: 6px 11px; cursor: pointer; white-space: nowrap;
+  transition: color .18s ease, border-color .18s ease, background .18s ease;
 }
-.copy-btn:hover { background: rgba(45,212,191,.16); border-color: var(--accent-br); }
+.copy-btn:hover { color: var(--accent-2); border-color: var(--accent-line); background: var(--accent-soft); }
 
-/* slim one-line install (sits below the intro in the visual-led hero) */
-.install-bar {
-  margin: 26px auto 0; max-width: 620px;
-  display: flex; align-items: center; gap: 12px;
-  background: var(--screen); border: 1px solid var(--screen-border);
-  border-radius: 12px; padding: 13px 16px;
-  font-family: var(--mono); font-size: 13.5px; text-align: left;
-  box-shadow: 0 24px 50px -32px rgba(10,12,16,.55);
+/* ============================================================ SECTIONS */
+section { padding: 84px 0; position: relative; }
+.band { background: var(--bg-soft); border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); }
+.section-head { max-width: 640px; }
+.section-head.center { margin: 0 auto; text-align: center; }
+.section-title {
+  font-family: var(--serif); font-style: italic; font-weight: 400;
+  font-size: clamp(27px, 3.2vw, 38px); line-height: 1.15; letter-spacing: -.01em; margin-top: 12px;
 }
-.install-bar .prompt { color: var(--mint); user-select: none; }
-.install-bar code { flex: 1; min-width: 0; color: var(--screen-fg); overflow-x: auto; white-space: nowrap; }
-.install-bar code::-webkit-scrollbar { height: 0; }
+.section-title em { font-style: italic; color: var(--accent); }
+.section-sub { color: var(--muted); margin-top: 12px; }
 
-/* animated intro — a dark "screen" on warm paper (the hybrid hero shot).
-   A clean monitor bezel, NOT a terminal; the intro contains its own. */
-.screen-frame {
-  width: min(1000px, 100%); margin: 44px auto 0;
-  padding: 8px; background: var(--screen-bar);
-  border: 1px solid var(--screen-border); border-radius: 18px; overflow: hidden;
-  box-shadow: 0 44px 100px -46px rgba(10,12,16,.62), inset 0 1px 0 rgba(255,255,255,.05);
+/* ============================================================ PANELS
+   Two kinds: a paper panel (spec sheets) and a "screen" — the one dark
+   surface on the site, because the animated intro is shot that way. */
+.panel { border: 1px solid var(--border-2); border-radius: var(--r); background: var(--card); overflow: hidden; }
+.panel-bar {
+  display: flex; align-items: center; justify-content: space-between; gap: 12px;
+  padding: 9px 13px; border-bottom: 1px solid var(--border);
+  font-family: var(--mono); font-size: 11px; letter-spacing: .13em; text-transform: uppercase;
+  color: var(--muted);
 }
+.panel-bar .dot { color: var(--accent); font-size: 9px; }
+.panel-bar .mark { color: var(--accent); letter-spacing: 0; }
+.panel-cap {
+  margin-top: 14px; text-align: center; font-family: var(--mono); font-size: 11px;
+  letter-spacing: .1em; text-transform: uppercase; color: var(--faint);
+}
+.panel-cap a { color: var(--muted); }
+.panel-cap a:hover { color: var(--accent); }
+
+/* the intro is its own screen — dark, rounded, lightly lifted off the paper.
+   No extra bezel: the stage inside already has one. */
 .intro-embed {
   position: relative; width: 100%; aspect-ratio: 1280 / 720; overflow: hidden;
-  background: var(--screen); border-radius: 11px;
+  background: var(--screen); border-radius: 16px;
+  box-shadow: 0 30px 70px -40px rgba(10,12,16,.55);
 }
 .intro-embed iframe {
   position: absolute; top: 0; left: 0; width: 1280px; height: 720px; border: 0;
   transform-origin: top left;
 }
-.intro-cap { text-align: center; margin-top: 16px; font-family: var(--mono); font-size: 12.5px; color: var(--faint); }
-.intro-cap a { color: var(--accent-2); }
 
-/* legacy screenshot helper (kept for compatibility) */
-.screenshot { margin: 56px auto 0; max-width: 920px; }
-.screenshot img { width: 100%; display: block; border-radius: 14px; border: 1px solid var(--border); box-shadow: 0 24px 50px -24px rgba(27,32,31,.3); }
-
-/* ============================================================ SECTIONS */
-section { padding: 76px 0; position: relative; }
-.section-head { max-width: 620px; margin: 0 auto; text-align: center; }
-.section-head.left { margin: 0; text-align: left; }
-.section-title {
-  font-family: var(--serif); font-weight: 500; letter-spacing: -.01em;
-  font-size: clamp(28px, 3.8vw, 42px); line-height: 1.1; margin-top: 14px;
+/* ============================================================ ⌨ THE TURN
+   The demo slot holds two views of the same dark screen: a terminal you can
+   type into, which replays recorded turns, and the animated intro. Both keep
+   the 1280/720 box so switching between them never moves the page. */
+.stage-tabs { display: flex; gap: 8px; margin-bottom: 16px; justify-content: center; }
+.stage-tab {
+  font-family: var(--mono); font-size: 11.5px; letter-spacing: .12em; text-transform: uppercase;
+  color: var(--faint); background: transparent; border: 1px solid var(--border-2);
+  border-radius: 20px; padding: 7px 16px; cursor: pointer;
+  transition: color .18s ease, border-color .18s ease, background .18s ease;
 }
-.section-title em { font-style: italic; color: var(--accent-2); }
-.section-sub { color: var(--muted); margin-top: 12px; font-size: 16.5px; }
-.section-sub code, .section-sub .mono {
-  font-family: var(--mono); font-size: 13.5px; background: var(--accent-soft);
-  padding: 1px 7px; border-radius: 5px; color: var(--accent-2);
+.stage-tab:hover { color: var(--text); }
+.stage-tab.active { color: var(--accent-2); border-color: var(--accent-line); background: var(--accent-soft); }
+
+.term {
+  position: relative; width: 100%; aspect-ratio: 1280 / 720; min-height: 430px;
+  display: flex; flex-direction: column; overflow: hidden;
+  background: var(--screen); border-radius: 16px;
+  box-shadow: 0 30px 70px -40px rgba(10, 12, 16, .55);
+  font-family: var(--mono); color: #d4dbe6;
+}
+.term-bar {
+  flex: 0 0 39px; display: flex; align-items: center; gap: 7px; padding: 0 15px;
+  border-bottom: 1px solid var(--screen-border); font-size: 11.5px; color: var(--screen-dim);
+}
+.term-bar .dot { width: 9px; height: 9px; border-radius: 50%; background: #2b3542; }
+.term-bar .where { flex: 1; text-align: center; }
+.term-bar .model { border: 1px solid var(--screen-border); border-radius: 20px; padding: 2px 10px; font-size: 10.5px; }
+.term-bar .model b { color: var(--mint); font-weight: 500; }
+
+/* output hugs the prompt and grows upward, the way a session actually reads */
+.term-out {
+  flex: 1; overflow-y: auto; padding: 20px 24px; font-size: 15px; line-height: 1.62;
+  display: flex; flex-direction: column; justify-content: flex-end;
+}
+.term-out .row { flex: 0 0 auto; }
+.term-out::-webkit-scrollbar { width: 7px; }
+.term-out::-webkit-scrollbar-thumb { background: #232c38; border-radius: 4px; }
+
+/* one row per beat of the turn: what you asked, each tool, what San said */
+.row.you { color: #eef3f9; margin: 4px 0 10px; }
+.row.you .q { color: var(--mint); margin-right: 9px; }
+/* mark and tool name hold their columns; everything else wraps under itself
+   rather than back into the gutter */
+.row.tool { display: flex; align-items: baseline; color: var(--screen-dim); }
+.row.tool .tn { flex: 0 0 auto; min-width: 54px; margin-left: 6px; color: var(--mint); }
+.row.tool .rest { min-width: 0; overflow-wrap: anywhere; }
+.row.tool .arg { color: #c3ccd8; }
+.row.tool .meta { margin-left: 9px; font-size: 13px; color: #59657a; }
+.row.tool .meta.diff { color: #6f9d84; }
+.row.cmd { color: #c3ccd8; margin: 2px 0 2px 5px; }
+.row.cmd .prompt { color: var(--mint); margin-right: 8px; }
+.row.say { display: flex; align-items: baseline; margin: 11px 0 2px; max-width: 78ch; }
+.row.say .mk { flex: 0 0 auto; color: var(--mint); margin-right: 8px; }
+.row.say.cont { margin: 2px 0; padding-left: 22px; }
+.row.done { margin-top: 13px; font-size: 12.5px; color: #59657a; }
+.row.done .ok { color: var(--mint); }
+.spin { color: var(--mint); animation: pulse 1s ease-in-out infinite; }
+.spin.settled { animation: none; color: #59657a; }
+@keyframes pulse { 50% { opacity: .25; } }
+.caret { display: inline-block; width: 7px; height: 14px; vertical-align: -2px; background: var(--mint); animation: caret 1.05s steps(1) infinite; }
+@keyframes caret { 50% { opacity: 0; } }
+
+.term-ask { flex: 0 0 auto; border-top: 1px solid var(--screen-border); padding: 11px 22px 13px; }
+.term-line { display: flex; align-items: center; gap: 10px; }
+.term-line .q { color: var(--mint); }
+.term-line input {
+  flex: 1; min-width: 0; border: 0; background: transparent; outline: none;
+  font-family: var(--mono); font-size: 15px; color: #eef3f9;
+}
+.term-line input::placeholder { color: #4f5b69; }
+.term-line .enter { font-size: 10.5px; letter-spacing: .14em; text-transform: uppercase; color: #4f5b69; }
+.term-chips { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 10px; }
+.term-chip {
+  font-family: var(--mono); font-size: 11.5px; color: var(--screen-dim);
+  background: transparent; border: 1px solid var(--screen-border); border-radius: 20px;
+  padding: 4px 12px; cursor: pointer; transition: color .18s ease, border-color .18s ease;
+}
+.term-chip:hover { color: var(--mint); border-color: rgba(45, 212, 191, .42); }
+
+/* ============================================================ ☰ THE TRIGRAM
+   Small · Fast · Open as three strokes of 三 — one horizontal band each,
+   ruled off by hairlines. The third stroke opens into its own three facets. */
+.trigram { margin-top: 46px; border-top: 1px solid var(--border-2); }
+.stroke {
+  display: grid; grid-template-columns: 168px minmax(0, 1fr); gap: 40px;
+  padding: 46px 0; border-bottom: 1px solid var(--border);
+}
+.stroke .rail { position: relative; }
+.stroke .glyph {
+  display: block; font-family: var(--serif); font-size: 46px; line-height: 1;
+  color: var(--accent); opacity: .9;
+}
+.stroke .name {
+  display: block; margin-top: 12px; font-family: var(--mono); font-size: 11.5px;
+  letter-spacing: .18em; text-transform: uppercase; color: var(--faint);
+}
+.stroke h3 {
+  font-family: var(--serif); font-style: italic; font-weight: 400;
+  font-size: clamp(25px, 2.7vw, 33px); line-height: 1.16; letter-spacing: -.01em;
+}
+.stroke p { color: var(--muted); margin-top: 14px; max-width: 68ch; }
+.stroke p strong { color: var(--text); font-weight: 500; }
+.stroke .more {
+  margin-top: 18px; font-family: var(--mono); font-size: 11.5px;
+  letter-spacing: .1em; text-transform: uppercase;
+}
+.stroke .more a { color: var(--muted); border-bottom: 1px solid var(--border-2); padding-bottom: 2px; }
+.stroke .more a:hover { color: var(--accent-2); border-color: var(--accent-line); }
+
+/* spec rows — mono facts under the prose */
+.rows {
+  display: grid; grid-template-columns: max-content minmax(0, 1fr); gap: 9px 22px;
+  margin-top: 22px; padding-top: 20px; border-top: 1px solid var(--border);
+  font-family: var(--mono); font-size: 12px; line-height: 1.55;
+}
+.rows dt { color: var(--faint); letter-spacing: .1em; text-transform: uppercase; white-space: nowrap; }
+.rows dd { color: var(--text); }
+.rows dd .q { color: var(--accent-2); }
+.rows dd .dim { color: var(--faint); }
+
+/* the third stroke: plug in · write · oversee */
+.trio { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; margin-top: 26px; }
+.facet {
+  display: flex; flex-direction: column;
+  background: var(--card); border: 1px solid var(--border); border-radius: var(--r);
+  padding: 20px 20px 18px; transition: border-color .18s ease;
+}
+.facet:hover { border-color: var(--accent-line); }
+.facet h4 {
+  font-family: var(--mono); font-size: 11px; font-weight: 500;
+  letter-spacing: .14em; text-transform: uppercase; color: var(--accent-2);
+}
+.facet p { color: var(--muted); font-size: 15.5px; margin-top: 10px; }
+.facet .keys {
+  margin-top: auto; padding-top: 16px; display: flex; flex-wrap: wrap; gap: 6px;
+  font-family: var(--mono); font-size: 11.5px;
+}
+.facet .keys span { color: var(--muted); background: var(--card-2); border: 1px solid var(--border); border-radius: 5px; padding: 2px 7px; }
+
+/* inline mono chips inside prose */
+code, code.inline {
+  font-family: var(--mono); font-size: .78em; border-radius: 5px;
+  background: var(--accent-soft); color: var(--accent-2);
+  padding: 2px 6px; white-space: nowrap;
 }
 
-/* ============================================================ FEATURE GRID */
+/* metric strip under the hero copy */
+.metrics {
+  margin-top: 28px; display: flex; flex-wrap: wrap; justify-content: center;
+  gap: 0; font-family: var(--mono); font-size: 12px;
+  letter-spacing: .1em; text-transform: uppercase; color: var(--muted);
+}
+.metrics span { padding: 0 18px; border-left: 1px solid var(--border); }
+.metrics span:first-child { border-left: none; }
+.metrics b { color: var(--text); font-weight: 500; }
+
+/* ============================================================ CARDS (docs index) */
 .grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; margin-top: 44px; }
 .card {
-  background: var(--card); border: 1px solid var(--border);
-  border-radius: 14px; padding: 26px; position: relative; overflow: hidden;
-  transition: transform .22s var(--ease), border-color .22s ease, box-shadow .22s ease;
+  background: var(--card); border: 1px solid var(--border); border-radius: var(--r);
+  padding: 26px 28px; transition: border-color .18s ease;
 }
-.card::after {
-  content: ""; position: absolute; inset: 0; border-radius: 14px; pointer-events: none;
-  box-shadow: inset 0 0 0 1px transparent; transition: box-shadow .22s ease;
-}
-.card:hover {
-  transform: translateY(-4px); border-color: var(--accent-line);
-  box-shadow: 0 24px 44px -28px rgba(13,148,136,.45);
-}
-.card .idx {
-  position: absolute; top: 20px; right: 22px;
-  font-family: var(--mono); font-size: 12px; color: var(--faint);
-  letter-spacing: .05em; transition: color .22s ease;
-}
-.card:hover .idx { color: var(--accent); }
-.card h3 { font-family: var(--sans); font-weight: 600; font-size: 17.5px; display: flex; align-items: center; gap: 12px; letter-spacing: -.01em; }
-.card .ico {
-  font-size: 19px; width: 38px; height: 38px; flex: 0 0 auto;
-  display: inline-flex; align-items: center; justify-content: center;
-  background: var(--bg-soft); border: 1px solid var(--border); border-radius: 10px;
-}
-.card p { color: var(--muted); font-size: 14.5px; margin-top: 12px; }
-.card code {
-  font-family: var(--mono); font-size: 12.5px; background: var(--accent-soft);
-  padding: 1px 6px; border-radius: 5px; color: var(--accent-2);
-}
-.card.wide {
-  grid-column: 1 / -1;
-  background:
-    radial-gradient(120% 140% at 100% 0%, rgba(20,184,166,.10), transparent 55%),
-    var(--card);
-  display: flex; flex-direction: column; gap: 18px;
-}
-.card.wide h3 { font-size: 18.5px; }
-
-/* self-evolving levels track */
-.levels { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; }
-.level {
-  display: inline-flex; align-items: center; gap: 8px;
-  background: var(--card-2); border: 1px solid var(--border);
-  border-radius: 999px; padding: 7px 15px; font-family: var(--mono); font-size: 12.5px; color: var(--muted);
-}
-.level b { color: var(--accent-2); }
-.levels .arrow { color: var(--faint); font-family: var(--mono); }
-.level.live {
-  border-color: var(--accent); background: var(--accent-soft); color: var(--text);
-}
-.level.live::after {
-  content: "live"; font-size: 9.5px; font-weight: 600; letter-spacing: .14em;
-  text-transform: uppercase; color: #fff; background: var(--accent);
-  padding: 2px 7px; border-radius: 999px;
-}
-.soon {
-  font-family: var(--mono); font-size: 10.5px; font-weight: 500;
-  letter-spacing: .12em; text-transform: uppercase; color: var(--amber);
-  background: rgba(194,116,10,.12); border: 1px solid rgba(194,116,10,.3);
-  padding: 3px 10px; border-radius: 999px; vertical-align: middle; margin-left: 4px;
-}
+.card:hover { border-color: var(--accent-line); }
+.card h3 { font-family: var(--serif); font-style: italic; font-weight: 400; font-size: 21px; }
+.card p { color: var(--muted); font-size: 16px; margin-top: 10px; }
 
 /* ============================================================ DEPLOY / PILLS */
-.deploy-targets, .pills { display: flex; flex-wrap: wrap; gap: 11px; justify-content: center; margin-top: 40px; }
+.deploy-targets, .pills { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 26px; }
 .pill {
-  background: var(--card); border: 1px solid var(--border);
-  padding: 9px 16px; border-radius: 999px; font-size: 14px; color: var(--text);
-  display: inline-flex; align-items: center; gap: 8px;
-  transition: border-color .18s ease, transform .18s ease, background .18s ease;
+  border: 1px solid var(--border); border-radius: 999px; background: var(--card); padding: 7px 14px; color: var(--muted);
+  font-family: var(--mono); font-size: 11.5px; letter-spacing: .04em;
+  display: inline-flex; align-items: center; gap: 7px; white-space: nowrap;
+  transition: border-color .18s ease, color .18s ease;
 }
-.pill:hover { border-color: var(--accent-line); transform: translateY(-2px); background: var(--card-2); }
-.deploy-targets .pill code, .pill code {
-  font-family: var(--mono); font-size: 12.5px; background: var(--accent-soft);
-  padding: 1px 6px; border-radius: 5px; color: var(--accent-2);
-}
+.pill:hover { border-color: var(--border-2); color: var(--text); }
+.pill code { background: none; color: inherit; padding: 0; text-transform: none; }
+.pill .ico { font-size: 13px; letter-spacing: 0; line-height: 1; }
 
 /* ============================================================ BENCHMARK */
-.bench-wrap { margin-top: 44px; overflow-x: auto; border: 1px solid var(--border); border-radius: 14px; background: var(--card); }
-table { width: 100%; border-collapse: collapse; font-size: 14px; }
-th, td { padding: 14px 20px; text-align: left; border-bottom: 1px solid var(--border); }
-th {
-  background: var(--bg-soft); color: var(--muted); font-weight: 500;
-  font-family: var(--mono); font-size: 12px; letter-spacing: .08em; text-transform: uppercase;
+.bench-wrap {
+  margin-top: 40px; overflow-x: auto;
+  border: 1px solid var(--border); border-radius: var(--r); background: var(--card);
 }
-td { font-family: var(--mono); font-size: 13px; color: var(--text); }
-td:first-child { font-family: var(--sans); color: var(--muted); }
-tbody tr { transition: background .15s ease; }
-tbody tr:hover { background: var(--accent-soft); }
+table { width: 100%; border-collapse: collapse; }
+th, td { padding: 13px 20px; text-align: left; border-bottom: 1px solid var(--border); }
 tr:last-child td { border-bottom: none; }
-td.adv { color: var(--green); font-weight: 600; }
-.bench-note { color: var(--muted); font-size: 13px; text-align: center; margin-top: 18px; font-family: var(--mono); }
-.bench-note a { color: var(--accent-2); }
+th {
+  color: var(--faint); font-weight: 400;
+  font-family: var(--mono); font-size: 11px; letter-spacing: .13em; text-transform: uppercase;
+}
+td { font-family: var(--mono); font-size: 12.5px; color: var(--text); }
+td:first-child { font-family: var(--serif); font-size: 16.5px; color: var(--muted); }
+th:first-child { color: var(--faint); }
+td.adv { color: var(--accent); }
+.bench-note { color: var(--faint); font-size: 14px; margin-top: 18px; max-width: 720px; }
+.bench-note a { color: var(--muted); border-bottom: 1px solid var(--border-2); }
+.bench-note a:hover { color: var(--accent); }
 
-/* ============================================================ CTA BOX */
+/* ============================================================ CTA BOX (subpages) */
 .cta-box {
-  background:
-    radial-gradient(120% 160% at 50% -30%, rgba(20,184,166,.16), transparent 60%),
-    var(--card);
-  border: 1px solid var(--border-2); border-radius: 20px;
-  padding: 60px 36px; text-align: center; margin-top: 20px; position: relative; overflow: hidden;
+  border: 1px solid var(--border-2); border-radius: 14px; background: var(--card);
+  padding: 54px 36px; text-align: center; position: relative; overflow: hidden;
 }
 .cta-box::before {
-  content: "三"; position: absolute; right: 24px; bottom: -28px;
-  font-family: var(--serif); font-size: 180px; line-height: 1; color: var(--accent);
+  content: "三"; position: absolute; right: 20px; bottom: -34px;
+  font-family: var(--serif); font-size: 170px; line-height: 1; color: var(--accent);
   opacity: .05; pointer-events: none;
 }
-.cta-box h2 { font-family: var(--serif); font-weight: 500; font-size: clamp(26px, 3.4vw, 36px); }
+.cta-box h2 { font-family: var(--serif); font-style: italic; font-weight: 400; font-size: clamp(26px, 3.2vw, 34px); }
 .cta-box p { color: var(--muted); margin-top: 12px; max-width: 520px; margin-left: auto; margin-right: auto; }
-.cta-box .hero-actions { justify-content: center; }
 
 /* ============================================================ COMMUNITY */
-.qr-row {
-  display: flex; flex-wrap: wrap; justify-content: center;
-  gap: 22px; margin-top: 36px;
-}
+.qr-row { display: flex; flex-wrap: wrap; justify-content: center; gap: 20px; margin-top: 36px; }
 .qr-card {
-  flex: 0 1 280px; text-align: center;
-  background: var(--card); border: 1px solid var(--border-2); border-radius: 20px;
-  padding: 26px 24px 20px;
+  flex: 0 1 300px; text-align: center; padding: 26px 24px 20px;
+  background: var(--card); border: 1px solid var(--border); border-radius: 14px;
 }
-.qr-card img {
-  display: block; width: 200px; height: 200px; margin: 0 auto;
-  border-radius: 12px; background: #fff;
-}
-.qr-cap { margin-top: 14px; color: var(--muted); font-size: 13.5px; line-height: 1.5; }
+.qr-card img { display: block; width: 190px; height: 190px; margin: 0 auto; background: #fff; border-radius: 8px; }
+.qr-cap { margin-top: 16px; color: var(--muted); font-size: 15px; line-height: 1.55; }
 .qr-cap .mono { color: var(--text); }
 
 /* ============================================================ FOOTER */
-footer { border-top: 1px solid var(--border); padding: 40px 0; color: var(--muted); font-size: 13.5px; margin-top: 20px; }
-footer .wrap { display: flex; justify-content: space-between; flex-wrap: wrap; gap: 16px; align-items: center; }
-footer .brand { font-family: var(--mono); color: var(--text); }
-footer .brand .san { color: var(--accent); }
-footer a { color: var(--muted); }
-footer a:hover { color: var(--accent-2); }
+footer {
+  border-top: 1px solid var(--border); padding: 32px 0; color: var(--faint);
+  font-family: var(--mono); font-size: 11.5px; letter-spacing: .08em; text-transform: uppercase;
+}
+footer .wrap { display: flex; justify-content: space-between; flex-wrap: wrap; gap: 14px; align-items: center; }
+footer .brand { color: var(--muted); }
+footer .brand .san { color: var(--accent); text-transform: none; letter-spacing: 0; }
+footer a { color: var(--faint); }
+footer a:hover { color: var(--accent); }
 
-/* ============================================================ GETTING STARTED */
-.page-hero { padding: 86px 0 10px; }
-.page-hero .wrap { max-width: 760px; }
-.page-hero h1 { font-family: var(--serif); font-weight: 500; font-size: clamp(34px, 5.2vw, 52px); letter-spacing: -.015em; margin-top: 14px; line-height: 1.06; }
-.page-hero h1 em { font-style: italic; color: var(--accent-2); }
-.page-hero p { color: var(--muted); margin-top: 14px; font-size: 18px; max-width: 560px; }
+/* ============================================================ SUBPAGE HERO + STEPS */
+.page-hero { padding: 84px 0 8px; }
+.page-hero .wrap { max-width: 780px; }
+.page-hero h1 {
+  font-family: var(--serif); font-style: italic; font-weight: 400;
+  font-size: clamp(33px, 4.8vw, 50px); letter-spacing: -.012em; margin-top: 14px; line-height: 1.1;
+}
+.page-hero h1 em { font-style: italic; color: var(--accent); }
+.page-hero p { color: var(--muted); margin-top: 16px; max-width: 600px; }
 
-.steps { counter-reset: step; max-width: 760px; margin: 50px auto 0; display: flex; flex-direction: column; gap: 26px; }
-.step { display: flex; gap: 22px; align-items: flex-start; }
+.steps { max-width: 780px; margin: 46px auto 0; display: flex; flex-direction: column; }
+.step { display: flex; gap: 26px; align-items: flex-start; padding: 30px 0; border-top: 1px solid var(--border); }
+.step:first-child { border-top: none; padding-top: 0; }
 .step .num {
-  flex: 0 0 auto; width: 42px; height: 42px; border-radius: 12px;
-  background: var(--accent); color: #fff; font-weight: 600; font-family: var(--mono);
-  display: flex; align-items: center; justify-content: center; font-size: 17px;
-  box-shadow: 0 12px 24px -12px rgba(13,148,136,.8);
-}
-.step-body { flex: 1; min-width: 0; }
-.step-body h3 { font-family: var(--sans); font-size: 20px; font-weight: 600; }
-.step-body > p { color: var(--muted); margin-top: 7px; }
-.step-body .cmd { margin-top: 14px; }
-.step-body code.inline,
-code.inline { font-family: var(--mono); font-size: 13px; background: var(--accent-soft); padding: 2px 7px; border-radius: 5px; color: var(--accent-2); }
-
-/* light inline command box (subpages) */
-.cmd {
-  display: flex; align-items: center; gap: 12px;
-  background: var(--screen); border: 1px solid var(--screen-border);
-  border-radius: 11px; padding: 14px 16px;
-  font-family: var(--mono); font-size: 13.5px; text-align: left;
-}
-.cmd .prompt { color: var(--mint); user-select: none; }
-.cmd code { flex: 1; color: var(--screen-fg); overflow-x: auto; white-space: nowrap; }
-
-.substeps { margin: 16px 0 0; padding-left: 0; list-style: none; counter-reset: sub; display: flex; flex-direction: column; gap: 12px; }
-.substeps li {
-  position: relative; padding: 14px 16px 14px 48px;
-  background: var(--card); border: 1px solid var(--border); border-radius: 11px;
-  font-size: 14px; color: var(--text);
-}
-.substeps li::before {
-  counter-increment: sub; content: counter(sub, lower-alpha);
-  position: absolute; left: 14px; top: 13px;
-  width: 24px; height: 24px; border-radius: 7px;
-  background: var(--bg); border: 1px solid var(--accent); color: var(--accent-2);
-  font-family: var(--mono); font-size: 12px; font-weight: 600;
+  flex: 0 0 auto; width: 30px; height: 30px; border-radius: 8px;
+  border: 1px solid var(--accent-line); color: var(--accent);
+  font-family: var(--mono); font-size: 12px;
   display: flex; align-items: center; justify-content: center;
 }
-.substeps li b { color: var(--accent-2); }
+.step-body { flex: 1; min-width: 0; }
+.step-body h3 { font-family: var(--serif); font-style: italic; font-weight: 400; font-size: 23px; }
+.step-body > p { color: var(--muted); margin-top: 8px; }
+.step-body .cmd { margin-top: 16px; }
+
+/* command box (subpages) */
+.cmd {
+  display: flex; align-items: center; gap: 12px;
+  background: var(--card); border: 1px solid var(--border-2); border-radius: var(--r);
+  padding: 14px 16px; font-family: var(--mono); font-size: 13px; text-align: left;
+}
+.cmd .prompt { color: var(--accent); user-select: none; }
+.cmd code { flex: 1; background: none; color: var(--text); padding: 0; overflow-x: auto; white-space: nowrap; }
+
+.substeps { margin: 18px 0 0; padding: 0; list-style: none; counter-reset: sub; display: flex; flex-direction: column; gap: 10px; }
+.substeps li {
+  position: relative; padding: 14px 16px 14px 44px; font-size: 16.5px; color: var(--muted);
+  background: var(--card); border: 1px solid var(--border); border-radius: var(--r);
+}
+.substeps li::before {
+  counter-increment: sub; content: counter(sub, lower-alpha) ".";
+  position: absolute; left: 18px; top: 15px;
+  font-family: var(--mono); font-size: 12px; color: var(--accent);
+}
+.substeps li b { color: var(--text); font-weight: 500; }
 
 /* ============================================================ DOCS INDEX */
-.doc-card h3 { font-family: var(--sans); font-size: 16.5px; font-weight: 600; display: flex; align-items: center; gap: 11px; }
-.doc-card ul { list-style: none; margin-top: 16px; display: flex; flex-direction: column; gap: 10px; }
-.doc-card li a {
-  color: var(--text); font-size: 14px; display: inline-flex; align-items: baseline; gap: 8px;
-}
-.doc-card li a::before { content: "›"; color: var(--accent); font-weight: 700; font-family: var(--mono); }
-.doc-card li a:hover { color: var(--accent-2); }
+.doc-card h3 { font-family: var(--serif); font-style: italic; font-weight: 400; font-size: 21px; }
+.doc-card ul { list-style: none; margin-top: 16px; display: flex; flex-direction: column; gap: 9px; }
+.doc-card li a { color: var(--text); font-size: 16.5px; display: inline-flex; align-items: baseline; gap: 8px; }
+.doc-card li a::before { content: "→"; color: var(--accent); font-family: var(--mono); font-size: 12px; }
+.doc-card li a:hover { color: var(--accent); }
 
 /* ============================================================ MOTION */
-.reveal { opacity: 0; transform: translateY(22px); transition: opacity .7s var(--ease), transform .7s var(--ease); }
+.reveal { opacity: 0; transform: translateY(6px); transition: opacity .5s var(--ease), transform .5s var(--ease); }
 .reveal.in { opacity: 1; transform: none; }
-
-/* staggered hero load-in */
-.load-up { opacity: 0; transform: translateY(16px); animation: loadUp .8s var(--ease) forwards; }
+.load-up { opacity: 0; transform: translateY(8px); animation: loadUp .6s var(--ease) forwards; }
 @keyframes loadUp { to { opacity: 1; transform: none; } }
-.d1 { animation-delay: .05s; } .d2 { animation-delay: .15s; } .d3 { animation-delay: .25s; }
-.d4 { animation-delay: .35s; } .d5 { animation-delay: .45s; } .d6 { animation-delay: .55s; }
+.d1 { animation-delay: .04s; } .d2 { animation-delay: .1s; } .d3 { animation-delay: .16s; }
+.d4 { animation-delay: .22s; } .d5 { animation-delay: .28s; } .d6 { animation-delay: .34s; }
 
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }
   .reveal, .load-up { transition: none; animation: none; opacity: 1; transform: none; }
-  .logo::after { animation: none; }
+  .logo::after, .spin, .caret { animation: none; }
   * { transition: none !important; }
 }
 
 /* ============================================================ RESPONSIVE */
+@media (max-width: 980px) {
+  .trio { grid-template-columns: 1fr; }
+}
+@media (max-width: 720px) {
+  .stroke { grid-template-columns: 1fr; gap: 18px; padding: 36px 0; }
+  .stroke .rail { display: flex; align-items: baseline; gap: 14px; }
+  .stroke .glyph { font-size: 32px; }
+  .stroke .name { margin-top: 0; }
+}
 @media (max-width: 860px) {
   .grid { grid-template-columns: 1fr; }
+  /* a 16:9 box gets too shallow to read a turn in — give it a fixed height */
+  .term { aspect-ratio: auto; height: 560px; }
 }
 @media (max-width: 760px) {
   .nav-toggle { display: inline-flex; }
   .nav-links {
-    position: absolute; top: 66px; left: 0; right: 0;
-    flex-direction: column; align-items: stretch; gap: 4px;
-    background: rgba(245,242,234,.97); backdrop-filter: blur(14px);
-    border-bottom: 1px solid var(--border); padding: 12px 18px 18px;
-    box-shadow: 0 20px 30px -20px rgba(27,32,31,.4);
-    transform: translateY(-8px); opacity: 0; pointer-events: none;
+    position: absolute; top: 60px; left: 0; right: 0;
+    flex-direction: column; align-items: stretch; gap: 0;
+    background: rgba(245,243,238,.98); backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--border-2); padding: 6px 22px 16px;
+    transform: translateY(-6px); opacity: 0; pointer-events: none;
     transition: opacity .2s ease, transform .2s ease;
   }
   nav.open .nav-links { transform: none; opacity: 1; pointer-events: auto; }
   .nav-sep { display: none; }
-  .nav-links a { padding: 11px 12px; font-size: 14px; }
-  .nav-links a.active::before { display: none; }
-  .nav-cta { margin: 6px 0 0; text-align: center; justify-content: center; }
+  .nav-links a { padding: 11px 0; border-bottom: 1px solid var(--border); }
+  .nav-links a.active { border-bottom-color: var(--accent); }
+  .nav-cta { margin-top: 10px; text-align: center; justify-content: center; }
 }
 @media (max-width: 640px) {
+  body { font-size: 17px; }
   .wrap { padding: 0 20px; }
-  .hero { padding: 64px 0 44px; }
+  .hero { padding: 64px 0 48px; }
   section { padding: 56px 0; }
+  .metrics { gap: 6px 0; }
+  .metrics span { padding: 0 12px; }
   .step { gap: 16px; }
-  .cta-box { padding: 44px 24px; }
+  .term-out { padding: 16px; font-size: 13px; }
+  .term-ask { padding: 10px 16px 12px; }
+  .term-line input { font-size: 13px; }
+  .row.tool .tn { min-width: 44px; }
+  .cta-box { padding: 40px 22px; }
+  th, td { padding: 11px 14px 11px 0; }
 }


### PR DESCRIPTION
The site still sold the previous positioning ("the open harness for terminal
agents") on a SaaS-shaped page: emoji feature cards, hover lifts, a stack of
teal glows, and no mention of the ~2.3k-token harness number the README now
leads with. This brings the site up to the current README and gives it one
coherent surface.

## Homepage

- **Hero** carries the README line — *Minimal harness. Maximum agent.* — with a
  metric strip and a tabbed installer (curl / powershell / go install).
- **The animated intro** gets its own full-width screen right under the hero,
  wider than the reading column, so it is watchable rather than decorative.
- **Why San** is now the trigram: 一 small, 二 fast, 三 open — one horizontal
  band each, ruled off by hairlines, prose plus mono spec rows. The third
  stroke opens into *plug in · write · oversee*. The six emoji feature cards and
  the level track fold into these three bands.
- **Benchmark** gains the row the README added — harness context ~2.3k vs
  ~20.9k tokens, ~9x leaner — and a one-sentence footnote.
- The filled-teal "try it in 30 seconds" box is gone; the hero installer
  already does that job, and removing it closes the page's largest dead gap.
- Numbers appear once each: prose states the idea, spec rows and the benchmark
  table carry the figures.

## Design system (shared by every page)

- Prose is serif throughout (Newsreader); IBM Plex Mono is reserved for the
  machine voice — nav, buttons, code, data, labels. Spline Sans is dropped, so
  one less font request.
- Parchment and teal now match `intro.html` 1:1, so the page and the embedded
  intro are the same material. The radial glow stack is replaced by the intro's
  own paper grain.
- Hairline rules, soft corners, no hover lifts. Emoji stay only where they help
  scanning: the deployment chips.

## intro.html

- Deploy fan-out: five targets that no longer overlap — laptop/coding,
  container/pr-review, edge device/log-triage, cloud vm/autopilot,
  air-gapped host/offline-audit. It previously showed both "edge device" and
  "edge gateway", and "scratch container" next to "k8s pod".
- The caption answers the question the air-gapped node raises: "anywhere you can
  copy a file, against any model you can reach."
- Fix: `fit()` only recomputed on window resize, so an iframe still sized
  300x150 when the script ran kept a 0.21 scale forever. A ResizeObserver on the
  document element fixes it — this was masked while the embed sat inside a dark
  bezel.
- Embedded runs hide the keyboard-hint HUD; those keys need focus the frame does
  not have.

Subpages (getting started, docs, both languages) inherit the system and their
nav links follow the renamed sections. Checked at 1440px and 390px in Chrome,
both languages, no console errors.