### PR TITLE
feat: detect bare image paths on drag-drop to terminal

### DIFF
--- a/internal/app/input/on_textarea.go
+++ b/internal/app/input/on_textarea.go
@@ -275,52 +275,29 @@ func (m *Model) HistoryDown() {
 // from input. Returns the cleaned text content and any loaded images.
 // Only processes references where the file actually exists on disk;
 // non-existent file references are left in the text as-is.
+//
+// @-prefixed references are removed from the content after loading, and a
+// failed load aborts the entire send — both are right because the user
+// deliberately typed @. Bare paths (drag-drop, absolute paths) are treated
+// more leniently: the text stays in the message, and a failed load is
+// silently skipped so a mere mention of a path doesn't block the send.
 func ProcessImageRefs(cwd, input string) (string, []core.Image, error) {
 	content := input
 	var images []core.Image
 
-	// Step 1: Process @-prefixed image references
-	content, imgList, err := processRefs(cwd, content, imageRefPattern, true)
-	if err != nil {
-		return "", nil, err
-	}
-	images = append(images, imgList...)
-
-	// Step 2: Process bare image file paths (drag-drop, absolute paths, etc.)
-	content, imgList, err = processRefs(cwd, content, bareImagePathRe, false)
-	if err != nil {
-		return "", nil, err
-	}
-	images = append(images, imgList...)
-
-	return strings.TrimSpace(content), images, nil
-}
-
-// processRefs finds all matches for pattern in content, loads matching image
-// files, and removes the matched text from the content. If hasPrefix is true,
-// the capture group is group 1 (after the @ prefix); otherwise it's group 0
-// (the full match for bare paths).
-func processRefs(cwd, content string, pattern *regexp.Regexp, hasPrefix bool) (string, []core.Image, error) {
-	matches := pattern.FindAllStringSubmatch(content, -1)
-	if len(matches) == 0 {
-		return content, nil, nil
-	}
-
-	var images []core.Image
-	var loadedRefs []string // full matched text to remove from content
-
+	// Step 1: Process @-prefixed image references — remove from text,
+	// abort on load failure.
+	matches := imageRefPattern.FindAllStringSubmatch(content, -1)
+	var loadedRefs []string
 	for _, match := range matches {
 		path := match[1]
 		absPath := path
 		if !filepath.IsAbs(absPath) {
 			absPath = filepath.Join(cwd, absPath)
 		}
-
-		// Skip references to files that don't exist
 		if _, err := os.Stat(absPath); os.IsNotExist(err) {
 			continue
 		}
-
 		img, err := image.Load(absPath)
 		if err != nil {
 			return "", nil, fmt.Errorf("loading image %s: %w", absPath, err)
@@ -328,10 +305,29 @@ func processRefs(cwd, content string, pattern *regexp.Regexp, hasPrefix bool) (s
 		images = append(images, img)
 		loadedRefs = append(loadedRefs, match[0])
 	}
-
-	// Only remove references that were successfully loaded
 	for _, ref := range loadedRefs {
 		content = strings.ReplaceAll(content, ref, "")
+	}
+
+	// Step 2: Process bare image file paths (drag-drop, absolute paths, etc.)
+	// Keep the text in the message, skip silently on load failure.
+	bareMatches := bareImagePathRe.FindAllStringSubmatch(content, -1)
+	for _, match := range bareMatches {
+		path := match[1]
+		absPath := path
+		if !filepath.IsAbs(absPath) {
+			absPath = filepath.Join(cwd, absPath)
+		}
+		if _, err := os.Stat(absPath); os.IsNotExist(err) {
+			continue
+		}
+		img, err := image.Load(absPath)
+		if err != nil {
+			// Bare paths are more lenient: skip silently instead of aborting,
+			// since the user may have just mentioned a path in a sentence.
+			continue
+		}
+		images = append(images, img)
 	}
 
 	return strings.TrimSpace(content), images, nil

--- a/internal/app/input/on_textarea.go
+++ b/internal/app/input/on_textarea.go
@@ -26,6 +26,12 @@ const (
 // imageRefPattern matches @path/to/image.ext references (case-insensitive extension).
 var imageRefPattern = regexp.MustCompile(`(?i)@([^\s]+\.(png|jpg|jpeg|gif|webp))`)
 
+// bareImagePathRe matches standalone image file paths (absolute or relative with a
+// directory separator) that are NOT prefixed with @. This catches drag-drop paste
+// of an image path into the terminal. Only paths containing a separator (/ or \)
+// are matched to avoid treating bare filenames or coincidental text as images.
+var bareImagePathRe = regexp.MustCompile(`(?i)((?:/[^\s]+|[^\s]+[/\\][^\s]*)\.(png|jpg|jpeg|gif|webp))`)
+
 // ImageTokenMatch describes an inline image token found in the textarea value.
 type ImageTokenMatch struct {
 	PendingIdx int
@@ -265,18 +271,44 @@ func (m *Model) HistoryDown() {
 	m.Textarea.CursorEnd()
 }
 
-// ProcessImageRefs extracts @image.png references from input.
-// Returns the cleaned text content and any loaded images.
+// ProcessImageRefs extracts @image.png references and bare image file paths
+// from input. Returns the cleaned text content and any loaded images.
 // Only processes references where the file actually exists on disk;
 // non-existent file references are left in the text as-is.
 func ProcessImageRefs(cwd, input string) (string, []core.Image, error) {
-	matches := imageRefPattern.FindAllStringSubmatch(input, -1)
+	content := input
+	var images []core.Image
+
+	// Step 1: Process @-prefixed image references
+	content, imgList, err := processRefs(cwd, content, imageRefPattern, true)
+	if err != nil {
+		return "", nil, err
+	}
+	images = append(images, imgList...)
+
+	// Step 2: Process bare image file paths (drag-drop, absolute paths, etc.)
+	content, imgList, err = processRefs(cwd, content, bareImagePathRe, false)
+	if err != nil {
+		return "", nil, err
+	}
+	images = append(images, imgList...)
+
+	return strings.TrimSpace(content), images, nil
+}
+
+// processRefs finds all matches for pattern in content, loads matching image
+// files, and removes the matched text from the content. If hasPrefix is true,
+// the capture group is group 1 (after the @ prefix); otherwise it's group 0
+// (the full match for bare paths).
+func processRefs(cwd, content string, pattern *regexp.Regexp, hasPrefix bool) (string, []core.Image, error) {
+	matches := pattern.FindAllStringSubmatch(content, -1)
 	if len(matches) == 0 {
-		return input, nil, nil
+		return content, nil, nil
 	}
 
 	var images []core.Image
-	var loadedRefs []string // track which @references were successfully loaded
+	var loadedRefs []string // full matched text to remove from content
+
 	for _, match := range matches {
 		path := match[1]
 		absPath := path
@@ -294,17 +326,15 @@ func ProcessImageRefs(cwd, input string) (string, []core.Image, error) {
 			return "", nil, fmt.Errorf("loading image %s: %w", absPath, err)
 		}
 		images = append(images, img)
-		loadedRefs = append(loadedRefs, match[0]) // full match including @
+		loadedRefs = append(loadedRefs, match[0])
 	}
 
 	// Only remove references that were successfully loaded
-	content := input
 	for _, ref := range loadedRefs {
 		content = strings.ReplaceAll(content, ref, "")
 	}
-	content = strings.TrimSpace(content)
 
-	return content, images, nil
+	return strings.TrimSpace(content), images, nil
 }
 
 // PastePlaceholder returns the placeholder text displayed in the textarea for a pasted chunk.

--- a/internal/app/input/on_textarea_test.go
+++ b/internal/app/input/on_textarea_test.go
@@ -1,6 +1,7 @@
 package input
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -239,6 +240,95 @@ func Test_bareImagePathRe(t *testing.T) {
 				if match[2] != tt.expected[i][2] {
 					t.Errorf("match[%d][2] = %q, want %q", i, match[2], tt.expected[i][2])
 				}
+			}
+		})
+	}
+}
+
+func TestProcessImageRefs(t *testing.T) {
+	// Create a real image file for testing (1x1 transparent PNG)
+	tmpDir := t.TempDir()
+	pngData := []byte{
+		0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG header
+		0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, // IHDR chunk
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+		0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, // IDAT chunk
+		0x54, 0x08, 0xD7, 0x63, 0x60, 0x60, 0x00, 0x00,
+		0x00, 0x02, 0x00, 0x01, 0xE2, 0x21, 0xBC, 0x33, // IEND chunk
+		0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44,
+		0xAE, 0x42, 0x60, 0x82,
+	}
+	pngPath := tmpDir + "/test.png"
+	if err := os.WriteFile(pngPath, pngData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	badPath := tmpDir + "/corrupt.png"
+	if err := os.WriteFile(badPath, []byte("not an image"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		input     string
+		wantText  string // expected output text
+		wantImage int    // expected number of images loaded
+		wantErr   bool
+	}{
+		{
+			name:      "@-prefixed path loads image and strips text",
+			input:     "describe @" + pngPath,
+			wantText:  "describe",
+			wantImage: 1,
+		},
+		{
+			name:      "bare absolute path loads image and keeps text",
+			input:     "check " + pngPath + " for details",
+			wantText:  "check " + pngPath + " for details",
+			wantImage: 1,
+		},
+		{
+			name:      "bare path with corrupt image skips silently",
+			input:     "see " + badPath,
+			wantText:  "see " + badPath,
+			wantImage: 0,
+			wantErr:   false,
+		},
+		{
+			name:      "non-existent bare path is left as-is",
+			input:     "missing /nonexistent/image.png file",
+			wantText:  "missing /nonexistent/image.png file",
+			wantImage: 0,
+		},
+		{
+			name:      "@ with corrupt image returns error",
+			input:     "@" + badPath,
+			wantText:  "",
+			wantImage: 0,
+			wantErr:   true,
+		},
+		{
+			name:      "no image references",
+			input:     "just text no images",
+			wantText:  "just text no images",
+			wantImage: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, images, err := ProcessImageRefs(tmpDir, tt.input)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.wantText {
+				t.Errorf("ProcessImageRefs() text = %q, want %q", got, tt.wantText)
+			}
+			if len(images) != tt.wantImage {
+				t.Errorf("ProcessImageRefs() got %d images, want %d", len(images), tt.wantImage)
 			}
 		})
 	}

--- a/internal/app/input/on_textarea_test.go
+++ b/internal/app/input/on_textarea_test.go
@@ -171,6 +171,79 @@ func Test_imageRefPattern(t *testing.T) {
 	}
 }
 
+func Test_bareImagePathRe(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected [][]string // nil means no match
+	}{
+		{
+			input:    "check /home/user/image.png",
+			expected: [][]string{{"/home/user/image.png", "/home/user/image.png", "png"}},
+		},
+		{
+			input:    "/absolute/path/photo.jpg analyze this",
+			expected: [][]string{{"/absolute/path/photo.jpg", "/absolute/path/photo.jpg", "jpg"}},
+		},
+		{
+			input:    "compare relative/path/a.png with ../other/b.jpeg",
+			expected: [][]string{{"relative/path/a.png", "relative/path/a.png", "png"}, {"../other/b.jpeg", "../other/b.jpeg", "jpeg"}},
+		},
+		{
+			input:    "no images here",
+			expected: nil,
+		},
+		{
+			input:    "just a bare name.png with no path",
+			expected: nil, // no path separator
+		},
+		{
+			input:    "image.png at start",
+			expected: nil, // no path separator
+		},
+		{
+			input:    "/path/to/image.webp end",
+			expected: [][]string{{"/path/to/image.webp", "/path/to/image.webp", "webp"}},
+		},
+		{
+			input:    "./animated.gif nearby",
+			expected: [][]string{{"./animated.gif", "./animated.gif", "gif"}},
+		},
+		{
+			input:    "C:\\Users\\me\\photo.jpeg here",
+			expected: [][]string{{"C:\\Users\\me\\photo.jpeg", "C:\\Users\\me\\photo.jpeg", "jpeg"}},
+		},
+		{
+			input:    "@prefix.png has no path separator",
+			expected: nil, // @ at start but no / in rest of path
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			matches := bareImagePathRe.FindAllStringSubmatch(tt.input, -1)
+			if len(matches) != len(tt.expected) {
+				t.Errorf("FindAllStringSubmatch(%q) got %d matches, want %d", tt.input, len(matches), len(tt.expected))
+				return
+			}
+			for i, match := range matches {
+				if len(match) < 3 {
+					t.Errorf("match[%d] has %d groups, want 3", i, len(match))
+					continue
+				}
+				if match[0] != tt.expected[i][0] {
+					t.Errorf("match[%d][0] = %q, want %q", i, match[0], tt.expected[i][0])
+				}
+				if match[1] != tt.expected[i][1] {
+					t.Errorf("match[%d][1] = %q, want %q", i, match[1], tt.expected[i][1])
+				}
+				if match[2] != tt.expected[i][2] {
+					t.Errorf("match[%d][2] = %q, want %q", i, match[2], tt.expected[i][2])
+				}
+			}
+		})
+	}
+}
+
 func TestPendingImageMatchesAndExtractInlineImages(t *testing.T) {
 	m := New("", 80, nil, SelectorDeps{})
 	first := m.AddPendingImage(core.Image{FileName: "a.png"})


### PR DESCRIPTION
When a user drags an image into the terminal, the absolute path is pasted as plain text. This PR:

- Adds `bareImagePathRe` regex matching image paths containing a directory separator
- Extends `ProcessImageRefs` to detect bare paths alongside the existing `@`-prefixed syntax
- Refactors the function into a two-step pipeline for clarity
- Only matches paths with `/` or `\\` to avoid treating bare filenames as images
- Non-existent files are left as-is in the text