### PR TITLE
fix: keep assistant text visible while a docked modal is up

### DIFF
--- a/internal/app/conv/agent_activity.go
+++ b/internal/app/conv/agent_activity.go
@@ -196,8 +196,9 @@ func isAgentToolLine(line string) bool {
 
 // PendingToolSpinnerParams holds the parameters for rendering a pending tool spinner.
 type PendingToolSpinnerParams struct {
-	// InteractivePromptActive indicates if an interactive prompt is currently active.
-	InteractivePromptActive bool
+	// DockedModalActive indicates a Question / Approval / secret modal owns
+	// the screen, so the turn is parked on the user's answer.
+	DockedModalActive bool
 	// BuildingTool is the tool name being built during streaming.
 	BuildingTool string
 	// PendingCalls are the pending tool calls.
@@ -221,7 +222,7 @@ type PendingToolSpinnerParams struct {
 
 // RenderPendingToolSpinner renders the spinner for a tool being executed.
 func RenderPendingToolSpinner(params PendingToolSpinnerParams) string {
-	if params.InteractivePromptActive {
+	if params.DockedModalActive {
 		return ""
 	}
 

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -194,6 +194,10 @@ type AssistantParams struct {
 	ToolCallsExpanded bool
 	StreamActive      bool
 	IsLast            bool
+	// DockedModalActive freezes the bullet: the stream stays "active" across a
+	// permission gate (it clears only on a text-only Done chunk), so without
+	// this the live tail spins while the turn is parked on the user's answer.
+	DockedModalActive bool
 	SpinnerView       string
 	MDRenderer        *MDRenderer
 	Width             int
@@ -338,7 +342,7 @@ func RenderAssistantMessage(params AssistantParams) string {
 	// committed the bullet is spent and the remainder aligns under a gutter.
 	// While streaming, the active tail shows the spinner in the bullet slot.
 	aiIcon := contentGutter(!params.BulletEmitted)
-	if params.StreamActive && params.IsLast {
+	if params.StreamActive && params.IsLast && !params.DockedModalActive {
 		aiIcon = aiPromptStyle.Render(params.SpinnerView + " ")
 	}
 
@@ -510,6 +514,15 @@ type ToolCallsParams struct {
 	Interactive  bool
 }
 
+// expandHints reports whether "(ctrl+o to expand)" affordances belong on this
+// pass. They ride the live tail only, and not while a docked modal owns the
+// keyboard: routeKeypress hands every key to the active overlay, so ctrl+o
+// reaches the modal (where it toggles a preview, or nothing) and never the row
+// offering the hint.
+func (p ToolCallsParams) expandHints() bool {
+	return p.Interactive && !p.DockedModalActive
+}
+
 // ToolResultData holds the data needed to render a tool result inline.
 type ToolResultData struct {
 	ToolName    string
@@ -552,8 +565,15 @@ func RenderToolCalls(params ToolCallsParams) string {
 			if hasResult {
 				sb.WriteString(renderAgentToolLine(label, params.Width, "●", color) + "\n")
 			} else {
-				sb.WriteString(renderAgentToolLine(label, params.Width, agentIcon(params.Blink), color))
-				if !params.ToolCallsExpanded && params.Interactive {
+				// agentIcon blinks ●/○ off the frame counter; under a docked
+				// modal it would advertise a subagent as working while the
+				// turn waits on the user, same as a spinning tool row.
+				icon := agentIcon(params.Blink)
+				if params.DockedModalActive {
+					icon = "●"
+				}
+				sb.WriteString(renderAgentToolLine(label, params.Width, icon, color))
+				if !params.ToolCallsExpanded && params.expandHints() {
 					sb.WriteString(ThinkingStyle.Render("  (ctrl+o to expand)"))
 				}
 				sb.WriteString("\n")
@@ -579,9 +599,6 @@ func RenderToolCalls(params ToolCallsParams) string {
 			}
 		} else {
 			icon := toolCallIcon(tc, params)
-			if _, hasResult := params.ResultMap[tc.ID]; hasResult {
-				icon = "●"
-			}
 			detail := runningRowDetail(tc, params)
 			var row string
 			if tc.Name == tool.ToolTaskGet && params.TaskOwnerMap != nil {
@@ -599,7 +616,7 @@ func RenderToolCalls(params ToolCallsParams) string {
 
 		if resultData, ok := params.ResultMap[tc.ID]; ok {
 			resultData.ToolInput = tc.Input
-			resultData.Interactive = params.Interactive
+			resultData.Interactive = params.expandHints()
 			resultData.Width = params.Width
 			resultData.Nested = true
 			// Decision sits between the call and its result, mirroring the
@@ -623,12 +640,22 @@ func RenderToolCalls(params ToolCallsParams) string {
 }
 
 // toolCallIcon picks a call's row glyph: the spinner while it is in flight, a
-// static bullet otherwise. Under a docked modal every row is static — the turn
-// is parked on the user's answer. The call the modal is asking about was marked
+// static bullet once it has a result or is not the call being executed.
+//
+// A docked modal freezes every row. The call it is asking about was marked
 // current and stamped as started by its PreToolEvent, which fires *before* the
 // permission request, so it would otherwise spin as if it had been allowed to
-// run; siblings in the same batch are just as stuck behind the same answer.
+// run. Nothing here can tell that call apart from a batch sibling that really
+// is executing (the permission gate lives inside each tool's Execute, and a
+// parallel batch runs one goroutine per call), so the freeze is deliberately
+// blunt: a row that stalls for the length of the decision beats a row that
+// claims a command is running before it was allowed to start. Distinguishing
+// them needs the pending call's identity on the permission request itself —
+// see #440.
 func toolCallIcon(tc core.ToolCall, params ToolCallsParams) string {
+	if _, done := params.ResultMap[tc.ID]; done {
+		return "●"
+	}
 	if params.DockedModalActive {
 		return "●"
 	}

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -486,6 +486,9 @@ type ToolCallsParams struct {
 	ToolCallsExpanded bool
 	ResultMap         map[string]ToolResultData
 	ParallelMode      bool
+	// DockedModalActive marks the frames where a Question / Approval modal
+	// owns the screen; the call it is asking about holds still until answered.
+	DockedModalActive bool
 	TaskActivity      map[int][]string
 	PendingCalls      []core.ToolCall
 	CurrentIdx        int
@@ -575,7 +578,7 @@ func RenderToolCalls(params ToolCallsParams) string {
 				}
 			}
 		} else {
-			icon := toolCallIcon(tc, params.PendingCalls, params.CurrentIdx, params.ParallelMode, params.SpinnerView)
+			icon := toolCallIcon(tc, params)
 			if _, hasResult := params.ResultMap[tc.ID]; hasResult {
 				icon = "●"
 			}
@@ -619,9 +622,19 @@ func RenderToolCalls(params ToolCallsParams) string {
 	return sb.String()
 }
 
-func toolCallIcon(tc core.ToolCall, pendingCalls []core.ToolCall, currentIdx int, parallelMode bool, spinnerView string) string {
+// toolCallIcon picks a call's row glyph: the spinner while it is in flight, a
+// static bullet otherwise. Under a docked modal every row is static — the turn
+// is parked on the user's answer. The call the modal is asking about was marked
+// current and stamped as started by its PreToolEvent, which fires *before* the
+// permission request, so it would otherwise spin as if it had been allowed to
+// run; siblings in the same batch are just as stuck behind the same answer.
+func toolCallIcon(tc core.ToolCall, params ToolCallsParams) string {
+	if params.DockedModalActive {
+		return "●"
+	}
+
 	idx := -1
-	for i, pending := range pendingCalls {
+	for i, pending := range params.PendingCalls {
 		if pending.ID == tc.ID {
 			idx = i
 			break
@@ -633,8 +646,8 @@ func toolCallIcon(tc core.ToolCall, pendingCalls []core.ToolCall, currentIdx int
 
 	// In parallel mode every in-flight call spins; sequentially, only the
 	// current call does.
-	if parallelMode || idx == currentIdx {
-		return spinnerView
+	if params.ParallelMode || idx == params.CurrentIdx {
+		return params.SpinnerView
 	}
 
 	return "●"
@@ -649,6 +662,9 @@ func toolCallIcon(tc core.ToolCall, pendingCalls []core.ToolCall, currentIdx int
 // a not-yet-current sequential call has no entry and shows nothing.
 func runningRowDetail(tc core.ToolCall, params ToolCallsParams) string {
 	if _, done := params.ResultMap[tc.ID]; done {
+		return ""
+	}
+	if params.DockedModalActive {
 		return ""
 	}
 	started, ok := params.ToolStartedAt[tc.ID]

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/tool"
 	"github.com/genai-io/san/internal/tool/toolresult"
 )
 
@@ -1368,5 +1369,45 @@ func TestRenderDecision(t *testing.T) {
 	bare := stripANSI(renderDecision(&core.ReviewDecision{Approved: true}))
 	if strings.Contains(bare, "·") {
 		t.Errorf("blank reason should not render a separator: %q", bare)
+	}
+}
+
+// A docked modal parks the turn on the user's answer, so an Agent row must
+// hold its glyph instead of blinking ●/○ off the frame counter — a blink reads
+// as a subagent working while the user decides whether to let it start.
+func TestRenderToolCallsFreezesAgentRowUnderDockedModal(t *testing.T) {
+	call := core.ToolCall{ID: "tc-1", Name: tool.ToolAgent, Input: `{"agent":"reviewer","prompt":"review it"}`}
+	params := ToolCallsParams{
+		ToolCalls:    []core.ToolCall{call},
+		ResultMap:    map[string]ToolResultData{},
+		PendingCalls: []core.ToolCall{call},
+		CurrentIdx:   0,
+		SpinnerView:  "⋯",
+		Width:        100,
+		Interactive:  true,
+	}
+
+	// agentIcon flips every agentBlinkTicks frames; both phases must render
+	// the same static bullet once the modal is up.
+	for _, blink := range []int{0, agentBlinkTicks} {
+		params.Blink = blink
+		live := stripANSI(RenderToolCalls(params))
+		if !strings.Contains(live, agentIcon(blink)) {
+			t.Fatalf("blink %d: RenderToolCalls() = %q, want the blinking icon while no modal is up", blink, live)
+		}
+
+		params.DockedModalActive = true
+		frozen := stripANSI(RenderToolCalls(params))
+		params.DockedModalActive = false
+
+		if !strings.Contains(frozen, "●") {
+			t.Fatalf("blink %d: RenderToolCalls() = %q, want a static bullet under the modal", blink, frozen)
+		}
+		if strings.Contains(frozen, "○") {
+			t.Fatalf("blink %d: RenderToolCalls() = %q, agent row still blinks under the modal", blink, frozen)
+		}
+		if strings.Contains(frozen, "ctrl+o") {
+			t.Fatalf("blink %d: RenderToolCalls() = %q, ctrl+o hint is dead while the modal owns the keyboard", blink, frozen)
+		}
 	}
 }

--- a/internal/app/conv/view.go
+++ b/internal/app/conv/view.go
@@ -50,7 +50,11 @@ type RenderContext struct {
 	TaskOwnerMap map[string]string
 
 	// ── Modal interlock — suppress chrome under a tool prompt ───
-	InteractivePromptActive bool
+	// DockedModalActive marks the frames where a Question / Approval / secret
+	// modal owns the screen. The chat tail still renders above it, so anything
+	// that animates has to hold still: the turn is parked on the user's answer,
+	// not making progress.
+	DockedModalActive bool
 
 	// Interactive marks the live render pass (RenderActiveContent): the
 	// uncommitted tail the user can still act on. "(ctrl+o to expand)" hints
@@ -256,6 +260,7 @@ func renderAssistantWithTools(p RenderContext, msg core.ChatMessage, idx int, is
 		ToolCallsExpanded: msg.ToolCallsExpanded,
 		ResultMap:         resultMap,
 		ParallelMode:      len(p.PendingCalls) > 1,
+		DockedModalActive: p.DockedModalActive,
 		TaskActivity:      p.TaskActivity,
 		PendingCalls:      p.PendingCalls,
 		CurrentIdx:        p.CurrentIdx,
@@ -322,15 +327,15 @@ func RenderActiveContent(p RenderContext) string {
 
 func renderPendingToolSpinnerFromParams(p RenderContext, suppressAgentLabel bool) string {
 	return RenderPendingToolSpinner(PendingToolSpinnerParams{
-		InteractivePromptActive: p.InteractivePromptActive,
-		BuildingTool:            p.BuildingTool,
-		PendingCalls:            p.PendingCalls,
-		CurrentIdx:              p.CurrentIdx,
-		TaskActivity:            p.TaskActivity,
-		SpinnerView:             p.SpinnerView,
-		Blink:                   p.Blink,
-		AgentColors:             p.AgentColors,
-		Width:                   p.Width,
-		SuppressAgentLabel:      suppressAgentLabel,
+		DockedModalActive:  p.DockedModalActive,
+		BuildingTool:       p.BuildingTool,
+		PendingCalls:       p.PendingCalls,
+		CurrentIdx:         p.CurrentIdx,
+		TaskActivity:       p.TaskActivity,
+		SpinnerView:        p.SpinnerView,
+		Blink:              p.Blink,
+		AgentColors:        p.AgentColors,
+		Width:              p.Width,
+		SuppressAgentLabel: suppressAgentLabel,
 	})
 }

--- a/internal/app/conv/view.go
+++ b/internal/app/conv/view.go
@@ -229,6 +229,7 @@ func renderAssistantWithTools(p RenderContext, msg core.ChatMessage, idx int, is
 		ToolCalls:            msg.ToolCalls,
 		StreamActive:         p.StreamActive,
 		IsLast:               isLast,
+		DockedModalActive:    p.DockedModalActive,
 		SpinnerView:          p.SpinnerView,
 		MDRenderer:           p.MDRenderer,
 		Width:                p.Width,

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -55,13 +55,29 @@ func (m *model) viewString() (string, *tea.Cursor) {
 	trackerView := m.renderTrackerList()
 
 	if hasOverlay { // docked modal (Question / Approval)
-		trackerPrefix := ""
-		if trackerView != "" {
-			trackerPrefix = "\n" + strings.TrimSuffix(trackerView, "\n") + "\n"
-		}
-		return trackerPrefix + separator + "\n" + ov.Render(), nil
+		return m.renderDockedModalView(ov, separator, trackerView), nil
 	}
 	return m.renderNormalView(separator, trackerView)
+}
+
+// renderDockedModalView composes a docked modal with the live chat tail still
+// visible above it. The assistant text that streams in right before a tool call
+// is the rationale for the permission being requested, so dropping it while the
+// modal is up hides the reasoning at exactly the moment the user has to act on
+// it.
+//
+// The modal claims its rows first and the chat tail gets what is left: rendering
+// the tail unbounded would push the modal's answer options off the bottom of the
+// screen, which is worse than showing no text at all.
+func (m *model) renderDockedModalView(ov overlayPanel, separator, trackerView string) string {
+	modal := "\n" + separator + "\n" + ov.Render()
+
+	params := m.messageRenderParams()
+	// Only this branch renders under a modal, so it is the one place that knows
+	// the turn is parked on an answer — everything animated holds still.
+	params.DockedModalActive = true
+
+	return m.chatTailAbove(modal, params, trackerView) + modal
 }
 
 // isDockedModal reports whether the active overlay docks above the input area
@@ -87,19 +103,30 @@ func isDockedModal(ov overlayPanel) bool {
 // shown and earlier lines scroll off — the full message lands in native
 // scrollback at turn end, which the terminal scrolls back through natively.
 func (m *model) renderNormalView(separator, trackerView string) (string, *tea.Cursor) {
-	// Render the footer first so we can measure how many lines it consumes
-	// and cap the chat section to the remaining terminal height.
+	// Render the footer first so the chat section can be capped to whatever
+	// height it leaves free.
 	footer, inputRow := m.renderFooter(separator)
-	// A non-positive result means the footer already fills the screen; tailLines
-	// reads that as "no room" and drops the chat section entirely.
-	maxContentHeight := m.env.Height - strings.Count(footer, "\n")
-
-	activeContent := conv.RenderActiveContent(m.messageRenderParams())
-	chatSection := tailLines(m.renderChatSection(activeContent, trackerView), maxContentHeight)
+	chatSection := m.chatTailAbove(footer, m.messageRenderParams(), trackerView)
 
 	// The footer's row offsets are relative to its own first line; the chat
 	// section above it shifts them all down.
 	return chatSection + footer, m.inputCursor(strings.Count(chatSection, "\n") + inputRow)
+}
+
+// chatTailAbove renders the live chat tail to fill the rows the bottom-anchored
+// block leaves free — the footer in the normal layout, the modal in the docked
+// one. Both layouts anchor to the bottom of the screen, so this is the single
+// place the height budget is decided: the tail is capped to what is left, and
+// its earliest lines are the ones that scroll off.
+func (m *model) chatTailAbove(bottom string, params conv.RenderContext, trackerView string) string {
+	// A non-positive budget means the bottom block already fills the screen.
+	// Bail before rendering: whatever came back would be dropped whole, and
+	// letting it through would push the block off the bottom of the frame.
+	maxContentHeight := m.env.Height - strings.Count(bottom, "\n")
+	if maxContentHeight <= 0 {
+		return ""
+	}
+	return tailLines(m.renderChatSection(conv.RenderActiveContent(params), trackerView), maxContentHeight)
 }
 
 // inputCursor returns where the terminal cursor belongs inside the composer.
@@ -374,8 +401,8 @@ func (m model) messageRenderParams() conv.RenderContext {
 		TaskActivity: m.conv.TaskActivity,
 		TaskOwnerMap: buildTaskOwnerMap(m.services.Tracker.List()),
 
-		// Modal interlock
-		InteractivePromptActive: m.conv.Modal.Question != nil && m.conv.Modal.Question.IsActive(),
+		// Modal interlock is left false here and set by
+		// renderDockedModalView, the only caller rendering under a modal.
 	}
 }
 

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -119,9 +119,9 @@ func (m *model) renderNormalView(separator, trackerView string) (string, *tea.Cu
 // place the height budget is decided: the tail is capped to what is left, and
 // its earliest lines are the ones that scroll off.
 func (m *model) chatTailAbove(bottom string, params conv.RenderContext, trackerView string) string {
-	// A non-positive budget means the bottom block already fills the screen.
-	// Bail before rendering: whatever came back would be dropped whole, and
-	// letting it through would push the block off the bottom of the frame.
+	// A non-positive budget means the bottom block is taller than the screen on
+	// its own. tailLines would drop the tail anyway; bailing here skips the
+	// render that produced it, which is the whole cost on a short terminal.
 	maxContentHeight := m.env.Height - strings.Count(bottom, "\n")
 	if maxContentHeight <= 0 {
 		return ""

--- a/internal/app/view_test.go
+++ b/internal/app/view_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/subagent"
 	"github.com/genai-io/san/internal/todo"
+	"github.com/genai-io/san/internal/tool"
 	"github.com/genai-io/san/internal/tool/perm"
 )
 
@@ -84,6 +85,15 @@ const (
 func dockedModalModel(t *testing.T, rationale string) *model {
 	t.Helper()
 
+	return dockedModalModelWithCalls(t, rationale, []core.ToolCall{
+		{ID: "bash-1", Name: "Bash", Input: `{"command":"df -h","description":"check disk"}`},
+		{ID: "bash-2", Name: "Bash", Input: `{"command":"date","description":"check clock"}`},
+	})
+}
+
+func dockedModalModelWithCalls(t *testing.T, rationale string, batch []core.ToolCall) *model {
+	t.Helper()
+
 	const width, height = modalTestWidth, modalTestHeight
 	m := &model{
 		env:       env{Width: width, Height: height, Ready: true},
@@ -91,10 +101,9 @@ func dockedModalModel(t *testing.T, rationale string) *model {
 		userInput: input.New("", width, nil, input.SelectorDeps{}),
 		services:  services{Tracker: todo.NewStore(), Subagent: subagent.NewRegistry()},
 	}
-	batch := []core.ToolCall{
-		{ID: "bash-1", Name: "Bash", Input: `{"command":"df -h","description":"check disk"}`},
-		{ID: "bash-2", Name: "Bash", Input: `{"command":"date","description":"check clock"}`},
-	}
+	// The stream is still open across a permission gate — it clears only on a
+	// text-only final chunk — so the live tail believes it is mid-turn.
+	m.conv.Stream.Active = true
 	m.conv.Messages = append(m.conv.Messages, core.ChatMessage{
 		Role:      core.RoleAssistant,
 		Content:   rationale,
@@ -181,6 +190,38 @@ func TestDockedModalDoesNotShowPendingCallsAsRunning(t *testing.T) {
 		if strings.Contains(row, spinnerGlyph) {
 			t.Fatalf("tool row %q spins while the batch waits on the approval modal", row)
 		}
+	}
+}
+
+// The stream stays open across a permission gate, so the assistant message
+// carrying the rationale still counts as the live tail. Its bullet must not
+// spin either — the turn is parked on the modal, not producing text.
+func TestDockedModalFreezesAssistantBullet(t *testing.T) {
+	m := dockedModalModel(t, "RATIONALE_SENTINEL about to check the disk")
+	spinnerGlyph := ansi.Strip(m.conv.Spinner.View())
+
+	frame, _ := m.viewString()
+
+	for line := range strings.SplitSeq(ansi.Strip(frame), "\n") {
+		if strings.Contains(line, "RATIONALE_SENTINEL") && strings.Contains(line, spinnerGlyph) {
+			t.Fatalf("assistant row %q spins while the turn waits on the modal", line)
+		}
+	}
+}
+
+// An Agent row is drawn by its own branch, which blinks its icon off the frame
+// counter instead of using the shared spinner and offers "(ctrl+o to expand)".
+// Both are wrong under a modal — the row is not working, and the modal owns
+// ctrl+o. (The glyph freeze itself is pinned in conv; this covers the wiring.)
+func TestDockedModalDropsDeadExpandHint(t *testing.T) {
+	m := dockedModalModelWithCalls(t, "spawning a reviewer", []core.ToolCall{
+		{ID: "agent-1", Name: tool.ToolAgent, Input: `{"agent":"reviewer","prompt":"review the diff"}`},
+	})
+
+	frame, _ := m.viewString()
+
+	if strings.Contains(ansi.Strip(frame), "ctrl+o") {
+		t.Fatalf("modal frame offers ctrl+o while the modal owns the keyboard:\n%s", frame)
 	}
 }
 

--- a/internal/app/view_test.go
+++ b/internal/app/view_test.go
@@ -9,6 +9,10 @@ import (
 
 	"github.com/genai-io/san/internal/app/conv"
 	"github.com/genai-io/san/internal/app/input"
+	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/subagent"
+	"github.com/genai-io/san/internal/todo"
+	"github.com/genai-io/san/internal/tool/perm"
 )
 
 // The composer prints the "❭ " prompt once, on the first row, while inputCursor
@@ -63,6 +67,120 @@ func TestComposerCursorAlignsWithEveryRow(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// The terminal the docked-modal tests render into.
+const (
+	modalTestWidth  = 80
+	modalTestHeight = 24
+)
+
+// dockedModalModel builds a model whose approval modal is asking about the
+// first of two parallel Bash calls the assistant has just explained, with that
+// explanation still live (not yet committed to scrollback). The batch is what
+// makes the fixture realistic: both calls get a PreTool event, so the "current"
+// call is the *last* one tracked, not the one the modal is asking about.
+func dockedModalModel(t *testing.T, rationale string) *model {
+	t.Helper()
+
+	const width, height = modalTestWidth, modalTestHeight
+	m := &model{
+		env:       env{Width: width, Height: height, Ready: true},
+		conv:      conv.NewModel(width),
+		userInput: input.New("", width, nil, input.SelectorDeps{}),
+		services:  services{Tracker: todo.NewStore(), Subagent: subagent.NewRegistry()},
+	}
+	batch := []core.ToolCall{
+		{ID: "bash-1", Name: "Bash", Input: `{"command":"df -h","description":"check disk"}`},
+		{ID: "bash-2", Name: "Bash", Input: `{"command":"date","description":"check clock"}`},
+	}
+	m.conv.Messages = append(m.conv.Messages, core.ChatMessage{
+		Role:      core.RoleAssistant,
+		Content:   rationale,
+		ToolCalls: batch,
+	})
+	// PreTool fires before the permission request, so both calls are already
+	// tracked as in flight by the time the modal goes up.
+	m.conv.Tool.Track(batch)
+	for _, call := range batch {
+		m.conv.Tool.MarkCurrent(call.ID)
+		m.conv.Tool.MarkStarted(call.ID)
+	}
+
+	m.userInput.Approval.Show(&perm.PermissionRequest{
+		ID:          "req-1",
+		ToolName:    "Bash",
+		Description: "check disk",
+		BashMeta:    &perm.BashMetadata{Command: "df -h", Description: "check disk"},
+	}, width, height)
+
+	return m
+}
+
+// The text streamed right before a tool call is the rationale for the
+// permission being requested, so the approval modal has to render on top of it
+// rather than in place of it — otherwise the reasoning disappears at exactly
+// the moment the user has to act on it (issue #436).
+func TestDockedModalKeepsPrecedingAssistantText(t *testing.T) {
+	const rationale = "RATIONALE_SENTINEL: this is not a timeout, it is a kernel-level failure"
+
+	m := dockedModalModel(t, rationale)
+	frame, _ := m.viewString()
+
+	plain := ansi.Strip(frame)
+	if !strings.Contains(plain, "RATIONALE_SENTINEL") {
+		t.Fatalf("modal frame dropped the assistant text preceding the tool call:\n%s", frame)
+	}
+	if !strings.Contains(plain, "df -h") {
+		t.Fatalf("modal frame is missing the approval prompt itself:\n%s", frame)
+	}
+}
+
+// The chat tail above a docked modal is capped: rendering it in full would push
+// the modal's answer options off the bottom of the screen, which is worse than
+// showing no text at all.
+func TestDockedModalStaysWithinTerminalHeight(t *testing.T) {
+	rationale := strings.TrimSpace(strings.Repeat("wall of reasoning text that wraps and wraps ", 60))
+	m := dockedModalModel(t, rationale)
+	frame, _ := m.viewString()
+
+	if rows := strings.Count(frame, "\n") + 1; rows > modalTestHeight {
+		t.Fatalf("modal frame is %d rows tall, exceeds terminal height %d", rows, modalTestHeight)
+	}
+	// The options are the last thing in the modal: if they survived the cap,
+	// nothing below the chat tail was pushed off screen.
+	if !strings.Contains(ansi.Strip(frame), "Do you want to proceed?") {
+		t.Fatalf("modal frame lost its question to the chat tail:\n%s", frame)
+	}
+}
+
+// PreTool stamps a call before the permission request, so the in-flight state
+// is live while the user decides. No row may spin: the call being approved has
+// not been allowed to start, and its batch siblings are stuck behind the same
+// answer.
+func TestDockedModalDoesNotShowPendingCallsAsRunning(t *testing.T) {
+	m := dockedModalModel(t, "about to check the disk")
+	spinnerGlyph := ansi.Strip(m.conv.Spinner.View())
+
+	frame, _ := m.viewString()
+
+	rows := map[string]string{}
+	for line := range strings.SplitSeq(ansi.Strip(frame), "\n") {
+		for _, cmd := range []string{"df -h", "date"} {
+			if strings.Contains(line, "Bash("+cmd+")") {
+				rows[cmd] = line
+			}
+		}
+	}
+	for _, cmd := range []string{"df -h", "date"} {
+		row, ok := rows[cmd]
+		if !ok {
+			t.Fatalf("modal frame has no row for %q:\n%s", cmd, frame)
+		}
+		if strings.Contains(row, spinnerGlyph) {
+			t.Fatalf("tool row %q spins while the batch waits on the approval modal", row)
+		}
 	}
 }
 


### PR DESCRIPTION
The docked-modal branch of `viewString` rendered only the modal, so the assistant text streamed right before a tool call — the rationale for the permission being requested — was hidden until the modal closed. Fixes #436.

- The live chat tail now renders above the modal, capped to the rows the modal leaves free, so a long explanation can never push the answer options off screen.
- Rendering the tail exposed a second problem: `PreToolEvent` stamps a call as started *before* the permission request, so its row spun with a ticking timer while the user was still deciding. `RenderContext.DockedModalActive` (the widened, renamed successor to `InteractivePromptActive`) now holds every in-flight row still until the modal is answered — a parallel batch is stuck behind the same answer.
- Both layouts budget their height through one helper, `chatTailAbove`, which also skips the render outright when the bottom block already fills the screen.

Manually verified in a real session: approve, Esc-reject, a 60-sentence explanation (frame stays exactly at terminal height, truncated from the top), a parallel Bash batch, and the AskUserQuestion modal — which had the same hidden-text bug and is fixed by the same change.
