### PR TITLE
feat: inline image paths for text-only models instead of blocking

### DIFF
--- a/internal/app/model_turn_queue.go
+++ b/internal/app/model_turn_queue.go
@@ -48,8 +48,8 @@ func (m *model) handleStopHookResult(msg stopHookResultMsg) tea.Cmd {
 // releaseQueuedMessage hands the next queued user message to the running agent
 // and returns (cmd, true) when one was released, or (nil, false) when the queue
 // is empty or its head is under edit (SelectIdx 0 — dispatching would send
-// pre-edit text and orphan the user's changes). An image-blocked item is diverted
-// back to the textarea with a notice instead of sent.
+// pre-edit text and orphan the user's changes). A text-only model receives the
+// queued images' paths inlined into the content instead of the attachments.
 //
 // The message is shown in the conversation now, at release time, so it never
 // vanishes between the queue and the flow; the agent addresses it once it ingests
@@ -64,14 +64,11 @@ func (m *model) releaseQueuedMessage() (tea.Cmd, bool) {
 	if !ok {
 		return nil, false
 	}
-	if m.imagesBlockedForModel(item.Images) {
-		// Hand the message back instead of dropping it — the notice tells the
-		// user to remove the image or switch models.
-		m.userInput.ReturnToTextarea(item.Content, item.Images)
-		return tea.Batch(m.CommitMessages()...), true
-	}
-	m.conv.Append(core.ChatMessage{Role: core.RoleUser, Content: item.Content, Images: item.Images})
-	svc, content, images := m.services.Agent, item.Content, item.Images
+	// Text-only models can't receive image parts; inline each image's path so
+	// the model can decide how to use it (e.g. via an MCP tool).
+	content, images := m.adaptImagesForModel(item.Content, item.Images)
+	m.conv.Append(core.ChatMessage{Role: core.RoleUser, Content: content, Images: images})
+	svc := m.services.Agent
 	send := func() tea.Msg {
 		svc.Send(content, images)
 		return nil

--- a/internal/app/update_submit.go
+++ b/internal/app/update_submit.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/genai-io/san/internal/app/input"
 	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/image"
 	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/log"
 )
@@ -107,11 +108,10 @@ func (m *model) dispatchSubmission(raw string) tea.Cmd {
 	if !ok {
 		return tea.Batch(m.CommitMessages()...)
 	}
-	// Hold the turn (keeping the input) if it carries images the active model
-	// can't accept, rather than letting the provider reject the request.
-	if m.imagesBlockedForModel(msg.Images) {
-		return tea.Batch(m.CommitMessages()...)
-	}
+	// Text-only models can't receive image parts, so inline each image's path
+	// into the content and let the model decide how to use it (e.g. call an
+	// MCP tool to inspect the file) instead of refusing the turn.
+	msg.Content, msg.Images = m.adaptImagesForModel(msg.Content, msg.Images)
 	msg.AutopilotNote = autopilotNote
 	m.conv.Append(msg)
 	m.userInput.Reset()
@@ -148,16 +148,29 @@ func (m *model) buildUserMessage(raw string) (core.ChatMessage, bool) {
 	}, true
 }
 
-// imagesBlockedForModel reports whether a turn carrying images must be held back
-// because the active model is text-only. It adds a user-facing notice when it
-// blocks; callers must not send the turn and should preserve the input so the
-// user can remove the image or switch to a vision-capable model.
-func (m *model) imagesBlockedForModel(images []core.Image) bool {
+// adaptImagesForModel adapts a user turn to the active model's image
+// capability. Vision-capable models receive the binary attachments unchanged.
+// Text-only models cannot receive image parts, so each image's path is inlined
+// into the content instead — the model then decides how to use it (e.g. call
+// an MCP image-description tool) rather than the app refusing the turn.
+func (m *model) adaptImagesForModel(content string, images []core.Image) (string, []core.Image) {
 	if len(images) == 0 || llm.SupportsImages(m.env.LLMProvider, m.env.GetModelID()) {
-		return false
+		return content, images
 	}
-	m.conv.AddNotice("The current model doesn't support images — remove the image or switch to a vision-capable model.")
-	return true
+	var sb strings.Builder
+	if content != "" {
+		sb.WriteString(content)
+		sb.WriteString("\n\n")
+	}
+	sb.WriteString("[Attached image(s) — this model cannot view images directly. The files are on disk; use an available tool (e.g. an MCP image-description tool) to inspect them if you need their contents.]\n")
+	for i, img := range images {
+		path, err := image.ResolvePath(img)
+		if err != nil {
+			path = img.FileName
+		}
+		fmt.Fprintf(&sb, "[Image #%d: %s]\n", i+1, path)
+	}
+	return strings.TrimSpace(sb.String()), nil
 }
 
 // drainInputQueueWhileIdle pops one queued item (if any) and runs it
@@ -170,12 +183,6 @@ func (m *model) drainInputQueueWhileIdle() tea.Cmd {
 	item, ok := m.userInput.Queue.Dequeue()
 	if !ok {
 		return nil
-	}
-	if m.imagesBlockedForModel(item.Images) {
-		// Hand the message back instead of dropping it — the notice tells
-		// the user to remove the image or switch models.
-		m.userInput.ReturnToTextarea(item.Content, item.Images)
-		return tea.Batch(m.CommitMessages()...)
 	}
 	m.conv.Compact.ClearResult()
 

--- a/internal/core/message.go
+++ b/internal/core/message.go
@@ -196,7 +196,10 @@ type Image struct {
 	MediaType string `json:"media_type"`
 	Data      string `json:"data"`
 	FileName  string `json:"file_name"`
-	Size      int    `json:"size"`
+	// Path is the absolute source path on disk, when the image came from a
+	// file. Empty for images that have no backing file (e.g. clipboard pastes).
+	Path string `json:"path,omitempty"`
+	Size int    `json:"size"`
 }
 
 // ToolCall represents a tool call from the model.

--- a/internal/image/clipboard.go
+++ b/internal/image/clipboard.go
@@ -22,7 +22,7 @@ func newClipboardImage(data []byte) (*core.Image, error) {
 		return nil, fmt.Errorf("clipboard image too large: %d bytes (max %d)", len(data), maxImageSize)
 	}
 	fileName := fmt.Sprintf("clipboard_%s.png", time.Now().Format("150405"))
-	img := newImage("image/png", fileName, data)
+	img := newImage("image/png", fileName, "", data)
 	return &img, nil
 }
 

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -67,15 +67,51 @@ func Load(path string) (core.Image, error) {
 		return core.Image{}, fmt.Errorf("file is not a valid image")
 	}
 
-	return newImage(mediaType, filepath.Base(absPath), data), nil
+	return newImage(mediaType, filepath.Base(absPath), absPath, data), nil
 }
 
 // newImage builds a core.Image from raw bytes, base64-encoding the data.
-func newImage(mediaType, fileName string, data []byte) core.Image {
+func newImage(mediaType, fileName, path string, data []byte) core.Image {
 	return core.Image{
 		MediaType: mediaType,
 		Data:      base64.StdEncoding.EncodeToString(data),
 		FileName:  fileName,
+		Path:      path,
 		Size:      len(data),
 	}
+}
+
+// ResolvePath returns a filesystem path for an image. Images loaded from a
+// file keep their original path; images without a backing file (e.g.
+// clipboard pastes) are materialized to a temporary file so tools such as MCP
+// image describers can read them.
+func ResolvePath(img core.Image) (string, error) {
+	if img.Path != "" {
+		return img.Path, nil
+	}
+	if img.Data == "" {
+		return img.FileName, nil
+	}
+	data, err := base64.StdEncoding.DecodeString(img.Data)
+	if err != nil {
+		return "", fmt.Errorf("decoding image data: %w", err)
+	}
+	f, err := os.CreateTemp("", "san-image-*"+extForMediaType(img.MediaType))
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	if _, err := f.Write(data); err != nil {
+		return "", err
+	}
+	return f.Name(), nil
+}
+
+func extForMediaType(mediaType string) string {
+	for ext, mt := range supportedTypes {
+		if mt == mediaType {
+			return ext
+		}
+	}
+	return ".png"
 }


### PR DESCRIPTION
## Summary

When the active model is text-only (e.g. DeepSeek), a turn carrying image attachments was previously held back with the notice *"The current model doesn't support images — remove the image or switch to a vision-capable model."*

Instead of blocking, the image's **absolute path** is now inlined into the message content and the binary attachment is dropped, letting the model itself decide what to do — e.g. call an MCP image-description tool with the path (see the explain-image style servers) — rather than the app refusing the turn.

Vision-capable models are unaffected and still receive the binary attachments.

## Changes

- `core.Image` gains a `Path` field (absolute source path; empty for clipboard pastes).
- `image.Load` records the absolute path; new `image.ResolvePath` returns it, or materializes clipboard data to a temp file so text-only models always get a usable path.
- Replaces `imagesBlockedForModel` (notice + hold-back) with `adaptImagesForModel`, applied on the direct submit, input-queue drain, and turn-boundary release paths.
- Removes the blocking notice entirely.

## Test plan

- `CGO_ENABLED=0 go build ./...` / `go vet ./...` — clean
- `CGO_ENABLED=0 go test ./...` — all 67 packages pass