### PR TITLE
feat: deliver background task results as soon as the conversation can take them

### DIFF
--- a/docs/concepts/data-flow.md
+++ b/docs/concepts/data-flow.md
@@ -463,7 +463,7 @@ Update → routeToSubModel                update.go
         │
         ▼
    PostInfer                            applyPostInfer
-       ├─ rt.OnTokenUsage(resp)         model_agent_events.go
+       ├─ rt.OnInference(resp)         model_agent_events.go
        └─ if tool calls: track them
         │
         ▼
@@ -480,7 +480,7 @@ Update → routeToSubModel                update.go
         └─ fire idle hooks
 
    rt.OnAgentStop(err)                  turn ended (or canceled)
-   rt.OnAutoCompact / OnCompactResult / OnTokenLimitResult ...
+   rt.HandlePermGate / HandleCompactResult / HandleTokenLimitResult ...
 ```
 
 ### Where the user sees streaming text

--- a/docs/concepts/data-flow.zh.md
+++ b/docs/concepts/data-flow.zh.md
@@ -440,7 +440,7 @@ Update → routeToSubModel                update.go
         │
         ▼
    PostInfer                            applyPostInfer
-       ├─ rt.OnTokenUsage(resp)         model_agent_events.go
+       ├─ rt.OnInference(resp)         model_agent_events.go
        └─ 如果有工具调用：track 它们
         │
         ▼
@@ -457,7 +457,7 @@ Update → routeToSubModel                update.go
         └─ 触发 idle hooks
 
    rt.OnAgentStop(err)                  本轮结束（或被取消）
-   rt.OnAutoCompact / OnCompactResult / OnTokenLimitResult ……
+   rt.HandlePermGate / HandleCompactResult / HandleTokenLimitResult ……
 ```
 
 ### 流式文字到底渲染在哪里

--- a/docs/concepts/rendering.md
+++ b/docs/concepts/rendering.md
@@ -249,7 +249,7 @@ non-empty content and `MDRenderer.Render` styles it. Repaint zone:
 
 ```
 event:           core.PostInfer{Response: {ToolCalls: [{ID:"tc-1", Name:"Bash", Input:{cmd:"ls"}}]}}
-applyPostInfer:  rt.OnTokenUsage(resp)
+applyPostInfer:  rt.OnInference(resp)
                  m.SetLastToolCalls(resp.ToolCalls)
                  m.Tool.Track(resp.ToolCalls)
 

--- a/docs/concepts/rendering.zh.md
+++ b/docs/concepts/rendering.zh.md
@@ -235,7 +235,7 @@ Stream.Active:   仍然 true（Done=false）
 
 ```
 event:           core.PostInfer{Response: {ToolCalls: [{ID:"tc-1", Name:"Bash", Input:{cmd:"ls"}}]}}
-applyPostInfer:  rt.OnTokenUsage(resp)
+applyPostInfer:  rt.OnInference(resp)
                  m.SetLastToolCalls(resp.ToolCalls)
                  m.Tool.Track(resp.ToolCalls)
 

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -293,7 +293,7 @@ func (m *model) resolveReviewerModel(ref string) (llm.Provider, string) {
 
 // recordDecision tallies one auto-review decision for the status-bar count and
 // stashes it for the renderer, keyed by the tool call ID carried in ctx and
-// consumed (load + delete) in TakeDecision — so the handoff map only ever
+// consumed (load + delete) in TakeReviewDecision — so the handoff map only ever
 // holds calls whose result has not arrived yet. The approved flag
 // picks the counter, so the count and the inline annotations can never drift.
 // The count is bumped even when ctx carries no tool call ID; only the stash
@@ -309,12 +309,12 @@ func (m *model) recordDecision(ctx context.Context, approved bool, reason string
 	}
 }
 
-// TakeDecision consumes the decision stashed for a tool call (load + delete),
+// TakeReviewDecision consumes the decision stashed for a tool call (load + delete),
 // so it stamps exactly one rendered result and the handoff map holds only
 // in-flight calls. Returns nil when the call was not auto-reviewed. Mirrors the
 // tool side-effect handoff (Tool.PopSideEffect), consumed at the same point in
 // OnToolResult.
-func (m *model) TakeDecision(callID string) *core.ReviewDecision {
+func (m *model) TakeReviewDecision(callID string) *core.ReviewDecision {
 	// No empty-callID guard: recordDecision never stores under an empty key, so
 	// LoadAndDelete("") already misses and returns nil.
 	v, ok := m.pendingDecisions.LoadAndDelete(callID)
@@ -570,7 +570,7 @@ func (m *model) ContinueOutbox() tea.Cmd {
 	return conv.DrainAgentOutbox(m.services.Agent.Outbox())
 }
 
-func (m *model) OnPermGateRequest(req *conv.PermGateRequest) tea.Cmd {
+func (m *model) HandlePermGate(req *conv.PermGateRequest) tea.Cmd {
 	m.services.Agent.SetPendingPermission(req)
 	if req == nil {
 		return nil

--- a/internal/app/conv/conversation.go
+++ b/internal/app/conv/conversation.go
@@ -55,17 +55,17 @@ func (m *ConversationModel) AddAgentNotice(content string) {
 	m.Messages = append(m.Messages, core.ChatMessage{Role: core.RoleNotice, Content: content, AgentNotice: true})
 }
 
-// StreamingTail reports whether the conversation ends in an assistant message
-// the stream is still writing into. That message is addressed by position, not
-// by ID: AppendToLast, SetLastToolCalls and SetLastThinkingSignature all reach
-// for the last message and bail on anything else, and renderAndCommit holds a
-// streaming last message back from scrollback. So while this holds, nothing may
-// be appended — the next chunk would be dropped, and the half-streamed message
-// would freeze into scrollback.
+// LastMessageIsStreaming reports whether the stream is still writing into the
+// last message. Everything that feeds a live message finds it by position rather
+// than by ID — AppendToLast, SetLastToolCalls and SetLastThinkingSignature all
+// reach for the last message and bail on anything else, and renderAndCommit
+// holds a streaming last message back from scrollback. So while this holds, an
+// append takes the slot the stream is using: the next chunk lands on the wrong
+// message, and the half-streamed one freezes into scrollback.
 //
-// Tool execution does not hold it: a completed call appends its result, leaving
-// the tail a tool-result row that is safe to append after.
-func (m *ConversationModel) StreamingTail() bool {
+// Tool execution does not hold it. A completed call appends its result, so the
+// last message is a tool-result row that anything may append after.
+func (m *ConversationModel) LastMessageIsStreaming() bool {
 	if !m.Stream.Active || len(m.Messages) == 0 {
 		return false
 	}

--- a/internal/app/conv/conversation.go
+++ b/internal/app/conv/conversation.go
@@ -55,6 +55,23 @@ func (m *ConversationModel) AddAgentNotice(content string) {
 	m.Messages = append(m.Messages, core.ChatMessage{Role: core.RoleNotice, Content: content, AgentNotice: true})
 }
 
+// StreamingTail reports whether the conversation ends in an assistant message
+// the stream is still writing into. That message is addressed by position, not
+// by ID: AppendToLast, SetLastToolCalls and SetLastThinkingSignature all reach
+// for the last message and bail on anything else, and renderAndCommit holds a
+// streaming last message back from scrollback. So while this holds, nothing may
+// be appended — the next chunk would be dropped, and the half-streamed message
+// would freeze into scrollback.
+//
+// Tool execution does not hold it: a completed call appends its result, leaving
+// the tail a tool-result row that is safe to append after.
+func (m *ConversationModel) StreamingTail() bool {
+	if !m.Stream.Active || len(m.Messages) == 0 {
+		return false
+	}
+	return m.Messages[len(m.Messages)-1].Role == core.RoleAssistant
+}
+
 func (m *ConversationModel) AppendToLast(text, thinking string) {
 	if len(m.Messages) == 0 {
 		return

--- a/internal/app/conv/runtime.go
+++ b/internal/app/conv/runtime.go
@@ -27,9 +27,10 @@ type Runtime interface {
 	// call (nil if it was not auto-reviewed), to stamp onto its rendered result.
 	TakeDecision(callID string) *core.ReviewDecision
 	OnTurnEnd(result core.Result) tea.Cmd
-	// DrainQueuedAtStep releases one queued user message to the agent at a step
-	// boundary (a continuing turn), so it is ingested before the next step.
-	DrainQueuedAtStep() tea.Cmd
+	// DrainStepQueues releases pending work — parked notices, one queued user
+	// message — to the agent at a step boundary (a continuing turn), so the next
+	// step reads it.
+	DrainStepQueues() tea.Cmd
 	OnAgentStop(err error) tea.Cmd
 	OnPermGateRequest(req *PermGateRequest) tea.Cmd
 	OnCompactStart(count int) tea.Cmd

--- a/internal/app/conv/runtime.go
+++ b/internal/app/conv/runtime.go
@@ -13,31 +13,52 @@ type AgentOutboxMsg struct {
 	Closed bool
 }
 
-// Runtime defines callbacks that the conv event handlers need from the root
-// model. Each method represents a coherent operation (not a fine-grained
-// primitive), keeping the interface small and each implementation substantial.
+// Runtime defines what the conv event handlers need from the root model. Each
+// method represents a coherent operation (not a fine-grained primitive),
+// keeping the interface small and each implementation substantial.
+//
+// The prefix says where a member comes from:
+//
+//   - On*     — the agent did something. One per agent event, and they arrive
+//     in the outbox's order, so they have a fixed place on the turn's timeline.
+//   - Handle* — a system message arrived: a background command's result, a
+//     timer, a side channel. No place on that timeline; it can land any time.
+//   - a verb  — not a callback at all, but a service conv calls on the host.
 type Runtime interface {
-	CommitMessages() []tea.Cmd
-	FlushStreamingBlocks() []tea.Cmd
-	ContinueOutbox() tea.Cmd
-	OnTokenUsage(resp *core.InferResponse)
-	OnAgentMessage(msg core.Message) tea.Cmd
+	// ── On*: agent lifecycle ────────────────────────────────────
+	OnInference(resp *core.InferResponse) // PostInfer
 	OnToolResult(tr core.ToolResult) *core.ToolResult
-	// TakeDecision consumes the auto-review decision stashed for a tool
-	// call (nil if it was not auto-reviewed), to stamp onto its rendered result.
-	TakeDecision(callID string) *core.ReviewDecision
+	// OnStepEnd fires when a tool batch completes and the turn continues, so
+	// pending work (parked notices, one queued user message) can reach the
+	// agent in time for its next step.
+	OnStepEnd() tea.Cmd
 	OnTurnEnd(result core.Result) tea.Cmd
-	// DrainStepQueues releases pending work — parked notices, one queued user
-	// message — to the agent at a step boundary (a continuing turn), so the next
-	// step reads it.
-	DrainStepQueues() tea.Cmd
 	OnAgentStop(err error) tea.Cmd
-	OnPermGateRequest(req *PermGateRequest) tea.Cmd
 	OnCompactStart(count int) tea.Cmd
 	OnCompacted(info core.CompactInfo) tea.Cmd
-	OnCompactResult(msg CompactResultMsg) tea.Cmd
-	OnTokenLimitResult(msg kit.TokenLimitResultMsg) tea.Cmd
+
+	// ── Handle*: system messages ────────────────────────────────
+	HandlePermGate(req *PermGateRequest) tea.Cmd
+	HandleCompactResult(msg CompactResultMsg) tea.Cmd
+	HandleTokenLimitResult(msg kit.TokenLimitResultMsg) tea.Cmd
+
+	// ── Services conv calls on the host ─────────────────────────
+	CommitMessages() []tea.Cmd
+	FlushStreamingBlocks() []tea.Cmd
+	// TakeReviewDecision consumes the auto-review decision stashed for a tool
+	// call (nil if it was not auto-reviewed), to stamp onto its rendered result.
+	TakeReviewDecision(callID string) *core.ReviewDecision
 	HasRunningTasks() bool
+
+	// ── Transport lifetime ──────────────────────────────────────
+	// ContinueOutbox re-arms the one-shot outbox listener. Not a service but an
+	// obligation, and a divided one: conv re-arms itself after every
+	// non-terminal event, while a terminal event (OnTurn / OnStop / OnCompact)
+	// hands the decision to the host — which re-arms in OnTurnEnd and
+	// OnCompacted, and deliberately does not in OnAgentStop. Miss it on any one
+	// path and the UI stops receiving agent events with no error at all: the
+	// session simply looks frozen.
+	ContinueOutbox() tea.Cmd
 }
 
 // DrainAgentOutbox blocks until at least one event is available, then greedily

--- a/internal/app/conv/update.go
+++ b/internal/app/conv/update.go
@@ -292,7 +292,7 @@ func applyPostTool(rt Runtime, m *Model, ev core.Event) tea.Cmd {
 	// message between sibling tool rows; waiting preserves the visible order:
 	// complete tool output first, then the pending message.
 	if batchComplete {
-		return rt.DrainQueuedAtStep()
+		return rt.DrainStepQueues()
 	}
 	return nil
 }

--- a/internal/app/conv/update.go
+++ b/internal/app/conv/update.go
@@ -24,11 +24,11 @@ func Update(rt Runtime, m *Model, msg tea.Msg) (tea.Cmd, bool) {
 		}
 		return handleAgentEvent(rt, m, msg.Event), true
 	case PermGateMsg:
-		return rt.OnPermGateRequest(msg.Request), true
+		return rt.HandlePermGate(msg.Request), true
 	case CompactResultMsg:
-		return rt.OnCompactResult(msg), true
+		return rt.HandleCompactResult(msg), true
 	case kit.TokenLimitResultMsg:
-		return rt.OnTokenLimitResult(msg), true
+		return rt.HandleTokenLimitResult(msg), true
 	case AgentActivityMsg:
 		if msg.Index < 0 && msg.ToolCallID != "" {
 			msg.Index = m.Tool.IndexOf(msg.ToolCallID)
@@ -151,11 +151,11 @@ func applyAgentEvent(rt Runtime, m *Model, ev core.Event) tea.Cmd {
 		cs, _ := ev.CompactStart()
 		return rt.OnCompactStart(cs.Count)
 	case core.OnMessage:
-		msg, ok := ev.Message()
-		if !ok {
-			return nil
-		}
-		return rt.OnAgentMessage(msg)
+		// Nothing to do: every path that hands a user message to the agent —
+		// idle submit, queue release, cron prompt, async hook, a notice
+		// delivered mid-turn — appends it to the conversation at the call site,
+		// so acting on the agent's echo here would double-display it.
+		return nil
 	case core.PreInfer:
 		return applyPreInfer(rt, m)
 	case core.OnChunk:
@@ -228,7 +228,7 @@ func applyPostInfer(rt Runtime, m *Model, ev core.Event) tea.Cmd {
 	if !ok {
 		return nil
 	}
-	rt.OnTokenUsage(resp)
+	rt.OnInference(resp)
 	m.Compact.WarningSuppressed = false
 	// No Stream.Active guard: SetLastThinkingSignature / SetLastToolCalls
 	// already bail on non-assistant tails, which is the only way a late
@@ -285,14 +285,14 @@ func applyPostTool(rt Runtime, m *Model, ev core.Event) tea.Cmd {
 		// Stamp the auto-review decision (if this call was judged) onto the
 		// result message so it renders inline under the tool call. Consumed
 		// here — the handoff map keeps only in-flight calls.
-		Decision: rt.TakeDecision(tr.ToolCallID),
+		Decision: rt.TakeReviewDecision(tr.ToolCallID),
 	})
 	// Release queued input only after every tool call in this response has
 	// completed. Releasing after the first result inserts the user's pending
 	// message between sibling tool rows; waiting preserves the visible order:
 	// complete tool output first, then the pending message.
 	if batchComplete {
-		return rt.DrainStepQueues()
+		return rt.OnStepEnd()
 	}
 	return nil
 }

--- a/internal/app/conv/update_test.go
+++ b/internal/app/conv/update_test.go
@@ -15,7 +15,7 @@ type postToolRuntime struct {
 
 func (r *postToolRuntime) OnToolResult(tr core.ToolResult) *core.ToolResult { return &tr }
 func (r *postToolRuntime) TakeDecision(string) *core.ReviewDecision         { return nil }
-func (r *postToolRuntime) DrainQueuedAtStep() tea.Cmd {
+func (r *postToolRuntime) DrainStepQueues() tea.Cmd {
 	r.drainCalls++
 	return nil
 }

--- a/internal/app/conv/update_test.go
+++ b/internal/app/conv/update_test.go
@@ -14,8 +14,8 @@ type postToolRuntime struct {
 }
 
 func (r *postToolRuntime) OnToolResult(tr core.ToolResult) *core.ToolResult { return &tr }
-func (r *postToolRuntime) TakeDecision(string) *core.ReviewDecision         { return nil }
-func (r *postToolRuntime) DrainStepQueues() tea.Cmd {
+func (r *postToolRuntime) TakeReviewDecision(string) *core.ReviewDecision   { return nil }
+func (r *postToolRuntime) OnStepEnd() tea.Cmd {
 	r.drainCalls++
 	return nil
 }

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -42,12 +42,14 @@ type model struct {
 	userInput input.Model // Source 1: user keyboard input
 	// mainNotices is the TUI's notice-staging channel (Source 2) — NOT the main
 	// agent's inbox. Broker messages routed to "main" (subagent completions,
-	// interim messages) and self-learn notices land here; they drain at turn
-	// boundaries, show as a notice, then go through SubmitToAgent into the main
-	// agent's real core.Agent inbox. See notify.go.
-	mainNotices    chan mainNotice
-	pendingNotices []mainNotice // notices that arrived mid-stream, drained at OnTurnEnd
-	// drainedThisStep caps DrainQueuedAtStep to one queued message per step
+	// interim messages) and self-learn notices land here; they show as a notice
+	// and then reach the main agent's real core.Agent inbox. See notify.go.
+	mainNotices chan mainNotice
+	// pendingNotices holds notices that arrived mid-stream, where appending to
+	// the conversation is unsafe. Released at the next completed tool batch
+	// (DrainStepQueues), or at OnTurnEnd if the turn ends first.
+	pendingNotices []mainNotice
+	// drainedThisStep caps DrainStepQueues to one queued message per step
 	// (PostTool fires once per tool). Reset each step in OnTokenUsage (PostInfer).
 	drainedThisStep bool
 	selfLearnStarts chan struct{}        // fork goroutine → Update loop: a review started (start the spinner)

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -47,10 +47,10 @@ type model struct {
 	mainNotices chan mainNotice
 	// pendingNotices holds notices that arrived mid-stream, where appending to
 	// the conversation is unsafe. Released at the next completed tool batch
-	// (DrainStepQueues), or at OnTurnEnd if the turn ends first.
+	// (OnStepEnd), or at OnTurnEnd if the turn ends first.
 	pendingNotices []mainNotice
-	// drainedThisStep caps DrainStepQueues to one queued message per step
-	// (PostTool fires once per tool). Reset each step in OnTokenUsage (PostInfer).
+	// drainedThisStep caps OnStepEnd to one queued message per step
+	// (PostTool fires once per tool). Reset each step in OnInference (PostInfer).
 	drainedThisStep bool
 	selfLearnStarts chan struct{}        // fork goroutine → Update loop: a review started (start the spinner)
 	systemInput     trigger.Model        // Source 3: system events (cron/hooks/watcher)

--- a/internal/app/model_agent_events.go
+++ b/internal/app/model_agent_events.go
@@ -19,12 +19,12 @@ import (
 	"github.com/genai-io/san/internal/tool"
 )
 
-func (m *model) OnTokenUsage(resp *core.InferResponse) {
+func (m *model) OnInference(resp *core.InferResponse) {
 	if resp == nil {
 		return
 	}
 	// PostInfer starts a new step: re-arm the one-per-step queue release that
-	// this step's PostTool events will use (see DrainStepQueues).
+	// this step's PostTool events will use (see OnStepEnd).
 	m.drainedThisStep = false
 
 	if m.userInput.Provider.StatusMessage == "compacted" {
@@ -55,21 +55,12 @@ func (m *model) OnTokenUsage(resp *core.InferResponse) {
 // needsSpinner it reads live runtime state, not persisted tracker status.
 func (m *model) HasRunningTasks() bool { return m.hasRunningBackgroundTask() }
 
-// OnAgentMessage observes the agent's MessageEvent echoes only. Every path that
-// hands a user message to the agent — idle submit, queue release
-// (releaseQueuedMessage), cron prompt, async hook — appends it to m.conv at the
-// call site, so the echo has nothing to do here: appending again would
-// double-display.
-func (m *model) OnAgentMessage(core.Message) tea.Cmd {
-	return nil
-}
-
-// DrainStepQueues releases pending work into a still-running turn at a step
-// boundary (a PostTool, where the turn continues): notices a streaming tail
-// held back, plus one queued user message — the cap is what keeps the queue
+// OnStepEnd releases pending work into a still-running turn at a step
+// boundary (a PostTool, where the turn continues): notices the stream held
+// back, plus one queued user message — the cap is what keeps the queue
 // editable until release. Counterpart to drainTurnQueues, which runs once the
 // turn has ended.
-func (m *model) DrainStepQueues() tea.Cmd {
+func (m *model) OnStepEnd() tea.Cmd {
 	if !m.services.Agent.Active() {
 		return nil
 	}

--- a/internal/app/model_agent_events.go
+++ b/internal/app/model_agent_events.go
@@ -24,7 +24,7 @@ func (m *model) OnTokenUsage(resp *core.InferResponse) {
 		return
 	}
 	// PostInfer starts a new step: re-arm the one-per-step queue release that
-	// this step's PostTool events will use (see DrainQueuedAtStep).
+	// this step's PostTool events will use (see DrainStepQueues).
 	m.drainedThisStep = false
 
 	if m.userInput.Provider.StatusMessage == "compacted" {
@@ -64,20 +64,22 @@ func (m *model) OnAgentMessage(core.Message) tea.Cmd {
 	return nil
 }
 
-// DrainQueuedAtStep releases one queued user message to the running agent at a
-// step boundary (a PostTool, where the turn continues), so a following LLM
-// response addresses it — the message stays editable in the queue right up to
-// this release. One release per step (drainedThisStep). The shared release
-// mechanics live in releaseQueuedMessage, shared with the turn-boundary drain.
-func (m *model) DrainQueuedAtStep() tea.Cmd {
-	if m.drainedThisStep || !m.services.Agent.Active() {
+// DrainStepQueues releases pending work into a still-running turn at a step
+// boundary (a PostTool, where the turn continues): notices a streaming tail
+// held back, plus one queued user message — the cap is what keeps the queue
+// editable until release. Counterpart to drainTurnQueues, which runs once the
+// turn has ended.
+func (m *model) DrainStepQueues() tea.Cmd {
+	if !m.services.Agent.Active() {
 		return nil
 	}
-	cmd, released := m.releaseQueuedMessage()
-	if released {
-		m.drainedThisStep = true
+	notices := m.releaseParkedNotices()
+	if m.drainedThisStep {
+		return notices
 	}
-	return cmd
+	queued, released := m.releaseQueuedMessage()
+	m.drainedThisStep = released
+	return tea.Batch(notices, queued)
 }
 
 func (m *model) OnToolResult(tr core.ToolResult) *core.ToolResult {

--- a/internal/app/model_compact.go
+++ b/internal/app/model_compact.go
@@ -107,13 +107,13 @@ func (m *model) OnCompacted(info core.CompactInfo) tea.Cmd {
 	return tea.Batch(scrollPart, m.ContinueOutbox(), kit.StatusTimer(3*time.Second, token))
 }
 
-// OnCompactResult applies a manual /compact result. It does not reset the UI
+// HandleCompactResult applies a manual /compact result. It does not reset the UI
 // itself: it asks the running agent to compact in place (which records the
 // summary + boundary and emits CompactEvent), and that event drives
 // OnCompacted — the same path auto-compaction takes, with no agent rebuild.
 // Only when there is no active agent does it drive OnCompacted directly so the
 // next session start still seeds the summary.
-func (m *model) OnCompactResult(msg conv.CompactResultMsg) tea.Cmd {
+func (m *model) HandleCompactResult(msg conv.CompactResultMsg) tea.Cmd {
 	if msg.Err != nil {
 		m.conv.Compact.Complete(fmt.Sprintf("Compaction could not be completed: %v", msg.Err), true)
 		return tea.Batch(m.CommitMessages()...)
@@ -133,7 +133,7 @@ func (m *model) OnCompactResult(msg conv.CompactResultMsg) tea.Cmd {
 	})
 }
 
-func (m *model) OnTokenLimitResult(msg kit.TokenLimitResultMsg) tea.Cmd {
+func (m *model) HandleTokenLimitResult(msg kit.TokenLimitResultMsg) tea.Cmd {
 	m.userInput.Provider.FetchingLimits = false
 	var content string
 	if msg.Err != nil {

--- a/internal/app/model_lifecycle.go
+++ b/internal/app/model_lifecycle.go
@@ -26,7 +26,7 @@ func newModel(opts setting.RunOptions) (*model, error) {
 
 	// The main conversation registers the "main" address with the broker;
 	// messages routed to it (subagent completions, interim messages) land on
-	// mainNotices and are drained at turn boundaries.
+	// mainNotices and are injected at the next safe seam — see notify.go.
 	broker.Register(broker.Main, func(msg broker.Message) bool {
 		return m.notifyMain(fromBrokerMessage(msg))
 	})

--- a/internal/app/model_token_test.go
+++ b/internal/app/model_token_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/genai-io/san/internal/agent"
 	"github.com/genai-io/san/internal/app/conv"
 	"github.com/genai-io/san/internal/app/input"
 	"github.com/genai-io/san/internal/core"
@@ -13,13 +14,13 @@ import (
 
 // The bottom-right ctx readout must reflect only the most recent infer call's
 // full context, never a running sum across the turn's infer steps. Two
-// consecutive OnTokenUsage calls (as happens around a tool loop): the second
+// consecutive OnInference calls (as happens around a tool loop): the second
 // must fully replace the first, not accumulate on top of it.
-func TestOnTokenUsageUsesLatestCallNotAccumulated(t *testing.T) {
+func TestOnInferenceUsesLatestCallNotAccumulated(t *testing.T) {
 	m := &model{}
 
 	// First infer: a large cached prompt. ctx = full prompt (fresh + cached).
-	m.OnTokenUsage(&core.InferResponse{Usage: core.Usage{
+	m.OnInference(&core.InferResponse{Usage: core.Usage{
 		InputTokens:          500,
 		OutputTokens:         80,
 		CacheReadInputTokens: 140000,
@@ -30,7 +31,7 @@ func TestOnTokenUsageUsesLatestCallNotAccumulated(t *testing.T) {
 
 	// Second infer in the same turn: ctx must become THIS call's full context,
 	// not the sum of both calls (which would be 281800).
-	m.OnTokenUsage(&core.InferResponse{Usage: core.Usage{
+	m.OnInference(&core.InferResponse{Usage: core.Usage{
 		InputTokens:          300,
 		OutputTokens:         25,
 		CacheReadInputTokens: 141000,
@@ -43,10 +44,10 @@ func TestOnTokenUsageUsesLatestCallNotAccumulated(t *testing.T) {
 // The ctx readout must count the cached prompt (reported separately in
 // Anthropic-style usage) so it reflects real window occupancy: the full prompt
 // is fresh + cache read + cache creation.
-func TestOnTokenUsageCountsCachedPromptInContext(t *testing.T) {
+func TestOnInferenceCountsCachedPromptInContext(t *testing.T) {
 	m := &model{}
 
-	m.OnTokenUsage(&core.InferResponse{Usage: core.Usage{
+	m.OnInference(&core.InferResponse{Usage: core.Usage{
 		InputTokens:              500,
 		OutputTokens:             80,
 		CacheReadInputTokens:     140000,
@@ -74,11 +75,11 @@ func TestResumeCommandForSessionRequiresPersistedTranscript(t *testing.T) {
 	}
 }
 
-func TestOnTokenUsageClearsCompactedStatusOnNextInfer(t *testing.T) {
+func TestOnInferenceClearsCompactedStatusOnNextInfer(t *testing.T) {
 	m := &model{}
 	m.userInput.Provider.StatusMessage = "compacted"
 
-	m.OnTokenUsage(&core.InferResponse{Usage: core.Usage{InputTokens: 400, OutputTokens: 25}})
+	m.OnInference(&core.InferResponse{Usage: core.Usage{InputTokens: 400, OutputTokens: 25}})
 
 	if m.userInput.Provider.StatusMessage != "" {
 		t.Fatalf("StatusMessage = %q, want compacted badge cleared on next infer", m.userInput.Provider.StatusMessage)
@@ -100,19 +101,26 @@ func TestResetContextDisplayZeroesContextReadout(t *testing.T) {
 	}
 }
 
-// OnAgentMessage observes the agent's MessageEvent echoes only — every path
-// that hands a user message to the agent (idle submit, queue release, cron
-// prompt, async hook) appends to m.conv at the call site. The echo must be a
-// strict no-op or the conversation double-displays.
-func TestOnAgentMessageIsNoOpForUserEcho(t *testing.T) {
+// The agent's echo of a user message must not reach the conversation: every
+// path that hands one to the agent (idle submit, queue release, cron prompt,
+// async hook, a notice delivered mid-turn) appends it at the call site, so
+// acting on the echo would double-display it.
+func TestAgentMessageEchoIsIgnored(t *testing.T) {
 	m := &model{
 		userInput: input.Model{Queue: input.NewQueue()},
 		conv:      conv.NewModel(80),
-		services:  services{Tracker: todo.NewStore()},
+		services:  services{Tracker: todo.NewStore(), Agent: &agent.Session{}},
 	}
 
-	_ = m.OnAgentMessage(core.UserMessage("anything", nil))
+	echo := core.MessageEvent("agent-1", core.UserMessage("anything", nil))
+	cmd, handled := conv.Update(m, &m.conv, conv.AgentOutboxMsg{Event: echo})
 
+	if !handled {
+		t.Fatal("conv.Update did not handle an agent outbox message")
+	}
+	if cmd != nil {
+		t.Fatal("an echoed user message produced work")
+	}
 	if len(m.conv.Messages) != 0 {
 		t.Fatalf("conv messages = %d, want 0 (echo must not append)", len(m.conv.Messages))
 	}

--- a/internal/app/model_turn_queue.go
+++ b/internal/app/model_turn_queue.go
@@ -54,8 +54,8 @@ func (m *model) handleStopHookResult(msg stopHookResultMsg) tea.Cmd {
 //
 // The message is shown in the conversation now, at release time, so it never
 // vanishes between the queue and the flow; the agent addresses it once it ingests
-// it a step or a turn later, and its ingest echo is a no-op (see OnAgentMessage).
-// Shared by the step-boundary (DrainStepQueues) and turn-boundary
+// it a step or a turn later, and the agent's echo of it is ignored (see conv.applyAgentEvent).
+// Shared by the step-boundary (OnStepEnd) and turn-boundary
 // (drainTurnQueues) drains.
 func (m *model) releaseQueuedMessage() (tea.Cmd, bool) {
 	if m.userInput.Queue.SelectIdx == 0 {
@@ -107,7 +107,7 @@ func (m *model) drainTurnQueues() (tea.Cmd, bool) {
 	// Whatever releaseParkedNotices did not get to: a task that finished during
 	// the turn's last step, or during a turn that never ran a tool.
 	if notices := m.takeParkedNotices(); len(notices) > 0 {
-		return m.injectNotices(notices), true
+		return m.injectAsNewTurn(mergeNotices(notices)), true
 	}
 
 	return nil, false
@@ -128,23 +128,23 @@ func (m *model) takeParkedNotices() []mainNotice {
 	return notices
 }
 
-// releaseParkedNotices delivers what a streaming tail held back, at the step
-// boundary where the conversation can take it again.
+// releaseParkedNotices injects what LastMessageIsStreaming held back, at the step
+// boundary where the tail is free again.
 func (m *model) releaseParkedNotices() tea.Cmd {
 	notices := m.takeParkedNotices()
 	if len(notices) == 0 {
 		return nil
 	}
 	log.QueueLog("releaseParkedNotices: releasing %d notice(s) mid-turn", len(notices))
-	return m.deliverToRunningTurn(mergeNotices(notices))
+	return m.injectIntoRunningTurn(mergeNotices(notices))
 }
 
-// deliverToRunningTurn hands a notice to the agent partway through a turn it is
+// injectIntoRunningTurn hands a notice to the agent partway through a turn it is
 // already running: sendToAgent reaches its inbox, which it drains between steps,
-// so the content is in the conversation the next inference reads. SubmitToAgent
-// is the idle path (injectNotice) and must not be used here — it can rebuild the
-// agent session, which would tear down the running turn.
-func (m *model) deliverToRunningTurn(n mainNotice) tea.Cmd {
+// so the content is in the conversation the next inference reads. Its pair is
+// injectAsNewTurn, whose SubmitToAgent must not be used here — that path can
+// rebuild the agent session, which would tear down the running turn.
+func (m *model) injectIntoRunningTurn(n mainNotice) tea.Cmd {
 	m.showNoticeLine(n)
 	cmds := m.CommitMessages()
 	if n.Content != "" { // display-only notices have nothing for the model to read
@@ -153,9 +153,9 @@ func (m *model) deliverToRunningTurn(n mainNotice) tea.Cmd {
 	return tea.Batch(cmds...)
 }
 
-// injectNotice delivers a notice with no turn running: the line is shown and the
+// injectAsNewTurn delivers a notice with no turn running: the line is shown and the
 // body, if any, starts a fresh turn.
-func (m *model) injectNotice(n mainNotice) tea.Cmd {
+func (m *model) injectAsNewTurn(n mainNotice) tea.Cmd {
 	m.showNoticeLine(n)
 	if n.Content == "" {
 		return tea.Batch(m.CommitMessages()...)
@@ -199,26 +199,22 @@ func awaitMainNotice(ch <-chan mainNotice) tea.Cmd {
 	}
 }
 
-// onMainNotice routes an arriving notice to the earliest delivery the
-// conversation can take: straight into a running turn, a fresh turn when idle,
-// or parked when a streaming tail blocks appends (see notify.go). Re-arming is
+// onMainNotice routes an arriving notice to the earliest injection the
+// conversation can take: into a running turn, as a fresh turn when idle, or
+// parked while the stream owns the tail (see notify.go). Re-arming is
 // unconditional: after the read the chan is empty, so the next firing waits for
 // the next message.
 func (m *model) onMainNotice(n mainNotice) tea.Cmd {
 	next := awaitMainNotice(m.mainNotices)
 	switch {
-	case m.conv.StreamingTail():
+	case m.conv.LastMessageIsStreaming():
 		m.pendingNotices = append(m.pendingNotices, n)
 		return next
 	case m.conv.Stream.Active:
-		return tea.Batch(m.deliverToRunningTurn(n), next)
+		return tea.Batch(m.injectIntoRunningTurn(n), next)
 	default:
-		return tea.Batch(m.injectNotice(n), next)
+		return tea.Batch(m.injectAsNewTurn(n), next)
 	}
-}
-
-func (m *model) injectNotices(notices []mainNotice) tea.Cmd {
-	return m.injectNotice(mergeNotices(notices))
 }
 
 // injectCronPrompt fires a scheduled cron prompt as if the user had just

--- a/internal/app/model_turn_queue.go
+++ b/internal/app/model_turn_queue.go
@@ -1,8 +1,9 @@
-// Turn-boundary inbox drain and prompt injection. After every agent turn
-// ends we drain (in priority order) queued user messages, cron-fired
-// prompts, async-hook continuations, and the main-loop notice buffer (broker
-// messages routed to "main"). Each drained item is converted to a notice +
-// optional re-send to the agent. Also handles the Stop hook result that gates
+// Inbox drain and prompt injection. After every agent turn ends we drain (in
+// priority order) queued user messages, cron-fired prompts, async-hook
+// continuations, and the main-loop notice buffer (broker messages routed to
+// "main"). Each drained item is converted to a notice + optional re-send to the
+// agent. Notice delivery is not limited to the turn boundary — see notify.go
+// for when each seam applies. Also handles the Stop hook result that gates
 // session persistence.
 package app
 
@@ -54,7 +55,7 @@ func (m *model) handleStopHookResult(msg stopHookResultMsg) tea.Cmd {
 // The message is shown in the conversation now, at release time, so it never
 // vanishes between the queue and the flow; the agent addresses it once it ingests
 // it a step or a turn later, and its ingest echo is a no-op (see OnAgentMessage).
-// Shared by the step-boundary (DrainQueuedAtStep) and turn-boundary
+// Shared by the step-boundary (DrainStepQueues) and turn-boundary
 // (drainTurnQueues) drains.
 func (m *model) releaseQueuedMessage() (tea.Cmd, bool) {
 	if m.userInput.Queue.SelectIdx == 0 {
@@ -103,35 +104,74 @@ func (m *model) drainTurnQueues() (tea.Cmd, bool) {
 		}
 	}
 
-	if len(m.pendingNotices) > 0 {
-		events := m.pendingNotices
-		m.pendingNotices = nil
-		// Listener may have just re-armed during OnTurnEnd processing;
-		// catch any chan events that landed in that window too.
-		if extra := drainNotices(m.mainNotices, maxNoticesPerDrain-len(events)); len(extra) > 0 {
-			events = append(events, extra...)
-		}
-		return m.injectNotices(events), true
+	// Whatever releaseParkedNotices did not get to: a task that finished during
+	// the turn's last step, or during a turn that never ran a tool.
+	if notices := m.takeParkedNotices(); len(notices) > 0 {
+		return m.injectNotices(notices), true
 	}
 
 	return nil, false
 }
 
-// injectNotice surfaces merged main-loop notices (subagent completions,
-// interim messages) into the live conversation: the notice line is shown, the
-// body (if any) is submitted to the main agent as a fresh turn.
-func (m *model) injectNotice(n mainNotice) tea.Cmd {
-	if n.Display != "" {
-		if n.FromAgent {
-			m.conv.AddAgentNotice(n.Display)
-		} else {
-			m.conv.AddNotice(n.Display)
-		}
+// takeParkedNotices removes everything parked during the running turn, topped
+// up from the channel so notices that landed since the last read ride along in
+// the same injection rather than trickling in one step apart.
+func (m *model) takeParkedNotices() []mainNotice {
+	if len(m.pendingNotices) == 0 {
+		return nil
 	}
+	notices := m.pendingNotices
+	m.pendingNotices = nil
+	if extra := drainNotices(m.mainNotices, maxNoticesPerDrain-len(notices)); len(extra) > 0 {
+		notices = append(notices, extra...)
+	}
+	return notices
+}
+
+// releaseParkedNotices delivers what a streaming tail held back, at the step
+// boundary where the conversation can take it again.
+func (m *model) releaseParkedNotices() tea.Cmd {
+	notices := m.takeParkedNotices()
+	if len(notices) == 0 {
+		return nil
+	}
+	log.QueueLog("releaseParkedNotices: releasing %d notice(s) mid-turn", len(notices))
+	return m.deliverToRunningTurn(mergeNotices(notices))
+}
+
+// deliverToRunningTurn hands a notice to the agent partway through a turn it is
+// already running: sendToAgent reaches its inbox, which it drains between steps,
+// so the content is in the conversation the next inference reads. SubmitToAgent
+// is the idle path (injectNotice) and must not be used here — it can rebuild the
+// agent session, which would tear down the running turn.
+func (m *model) deliverToRunningTurn(n mainNotice) tea.Cmd {
+	m.showNoticeLine(n)
+	cmds := m.CommitMessages()
+	if n.Content != "" { // display-only notices have nothing for the model to read
+		cmds = append(cmds, m.sendToAgent(n.Content, nil))
+	}
+	return tea.Batch(cmds...)
+}
+
+// injectNotice delivers a notice with no turn running: the line is shown and the
+// body, if any, starts a fresh turn.
+func (m *model) injectNotice(n mainNotice) tea.Cmd {
+	m.showNoticeLine(n)
 	if n.Content == "" {
 		return tea.Batch(m.CommitMessages()...)
 	}
 	return m.SubmitToAgent(n.Content, nil)
+}
+
+func (m *model) showNoticeLine(n mainNotice) {
+	if n.Display == "" {
+		return
+	}
+	if n.FromAgent {
+		m.conv.AddAgentNotice(n.Display)
+	} else {
+		m.conv.AddNotice(n.Display)
+	}
 }
 
 func drainNotices(ch <-chan mainNotice, max int) []mainNotice {
@@ -159,17 +199,22 @@ func awaitMainNotice(ch <-chan mainNotice) tea.Cmd {
 	}
 }
 
-// onMainNotice injects a message now when idle, or parks it in pendingNotices
-// for the next turn boundary when a stream is in flight. Re-arming is
+// onMainNotice routes an arriving notice to the earliest delivery the
+// conversation can take: straight into a running turn, a fresh turn when idle,
+// or parked when a streaming tail blocks appends (see notify.go). Re-arming is
 // unconditional: after the read the chan is empty, so the next firing waits for
 // the next message.
 func (m *model) onMainNotice(n mainNotice) tea.Cmd {
 	next := awaitMainNotice(m.mainNotices)
-	if m.conv.Stream.Active {
+	switch {
+	case m.conv.StreamingTail():
 		m.pendingNotices = append(m.pendingNotices, n)
 		return next
+	case m.conv.Stream.Active:
+		return tea.Batch(m.deliverToRunningTurn(n), next)
+	default:
+		return tea.Batch(m.injectNotice(n), next)
 	}
-	return tea.Batch(m.injectNotices([]mainNotice{n}), next)
 }
 
 func (m *model) injectNotices(notices []mainNotice) tea.Cmd {

--- a/internal/app/notice_step_inject_test.go
+++ b/internal/app/notice_step_inject_test.go
@@ -1,0 +1,157 @@
+package app
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/genai-io/san/internal/agent"
+	"github.com/genai-io/san/internal/app/conv"
+	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/reminder"
+	"github.com/genai-io/san/internal/subagent"
+	"github.com/genai-io/san/internal/todo"
+)
+
+// runCmd executes cmd, flattening tea.Batch so the leaf commands (the ones that
+// actually reach the agent) run too. Never hand it onMainNotice's result: that
+// batch carries the listener re-arm, which blocks until the next notice.
+func runCmd(cmd tea.Cmd) {
+	if cmd == nil {
+		return
+	}
+	if batch, ok := cmd().(tea.BatchMsg); ok {
+		for _, sub := range batch {
+			runCmd(sub)
+		}
+	}
+}
+
+// noticeDeliveryModel returns a model whose agent session is live, plus the
+// provider that records the message chain of its next inference — which is how
+// these tests see what the model actually got to read.
+func noticeDeliveryModel(t *testing.T) (*model, *restartStubProvider) {
+	t.Helper()
+
+	provider := &restartStubProvider{requests: make(chan []core.Message, 2)}
+	sess := &agent.Session{}
+	if err := sess.Start(agent.BuildParams{Provider: provider, ModelID: "m"}, nil); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(sess.Stop)
+
+	return &model{
+		services: services{
+			Agent:    sess,
+			Tracker:  todo.NewStore(),
+			Subagent: subagent.NewRegistry(),
+			Reminder: reminder.NewService(),
+		},
+		conv: conv.NewModel(80),
+	}, provider
+}
+
+func taskNotice() mainNotice {
+	return mainNotice{
+		Display:   "Backend: research completed",
+		Content:   `<task-notification task-id="t1" status="completed">done</task-notification>`,
+		FromAgent: true,
+	}
+}
+
+// assertNoticeShown fails unless the notice's display line is in the
+// conversation.
+func assertNoticeShown(t *testing.T, m *model) {
+	t.Helper()
+	for _, msg := range m.conv.Messages {
+		if msg.Role == core.RoleNotice && strings.Contains(msg.Content, "research completed") {
+			return
+		}
+	}
+	t.Fatalf("notice line was not shown in the conversation: %+v", m.conv.Messages)
+}
+
+// assertAgentRead fails unless the agent's next inference carried the task
+// notification.
+func assertAgentRead(t *testing.T, provider *restartStubProvider) {
+	t.Helper()
+	select {
+	case chain := <-provider.requests:
+		for _, msg := range chain {
+			if strings.Contains(msg.Content, "task-notification") {
+				return
+			}
+		}
+		t.Fatalf("agent inference carried no task notification: %+v", chain)
+	case <-time.After(2 * time.Second):
+		t.Fatal("notice never reached the agent")
+	}
+}
+
+// A task finishing while a tool runs must not be parked: the conversation tail
+// is a tool-result row then, so the notice can be appended and handed to the
+// running turn on arrival.
+func TestNoticeDuringToolExecutionIsNotParked(t *testing.T) {
+	m, _ := noticeDeliveryModel(t)
+	m.conv.Stream.Active = true
+	m.conv.Append(core.ChatMessage{Role: core.RoleUser, ToolResult: &core.ToolResult{ToolCallID: "c1"}})
+
+	m.onMainNotice(taskNotice()) // cmds unused: the routing decision is synchronous
+
+	if len(m.pendingNotices) != 0 {
+		t.Fatalf("notice was parked even though the tail was not streaming: %+v", m.pendingNotices)
+	}
+	assertNoticeShown(t, m)
+}
+
+// Delivery into a running turn goes through the agent's inbox, which it drains
+// between steps — so the content is in the conversation its next inference
+// reads, without starting a turn of its own.
+func TestDeliveryToRunningTurnReachesTheNextInference(t *testing.T) {
+	m, provider := noticeDeliveryModel(t)
+	m.conv.Stream.Active = true
+
+	runCmd(m.deliverToRunningTurn(taskNotice()))
+
+	assertAgentRead(t, provider)
+}
+
+// A streaming assistant tail is addressed by position, so a notice cannot be
+// appended there — it parks, and the next completed tool batch releases it into
+// the same turn rather than holding it until the turn ends.
+func TestNoticeParkedByStreamingTailIsReleasedAtTheNextStep(t *testing.T) {
+	m, provider := noticeDeliveryModel(t)
+	m.conv.Stream.Active = true
+	m.conv.Append(core.ChatMessage{Role: core.RoleAssistant, Content: "thinking out loud"})
+
+	m.onMainNotice(taskNotice()) // cmds unused: the routing decision is synchronous
+	if len(m.pendingNotices) != 1 {
+		t.Fatalf("notice was appended into a streaming tail: %+v", m.conv.Messages)
+	}
+
+	// The tool batch completes: its result lands, leaving an appendable tail.
+	m.conv.Append(core.ChatMessage{Role: core.RoleUser, ToolResult: &core.ToolResult{ToolCallID: "c1"}})
+	runCmd(m.DrainStepQueues())
+
+	if len(m.pendingNotices) != 0 {
+		t.Fatalf("notice still parked after a step boundary: %+v", m.pendingNotices)
+	}
+	assertNoticeShown(t, m)
+	assertAgentRead(t, provider)
+}
+
+// With nothing parked and nothing queued, a step boundary must not disturb the
+// running turn: no command at all.
+func TestStepDrainWithNothingPendingIsInert(t *testing.T) {
+	m, _ := noticeDeliveryModel(t)
+	m.conv.Stream.Active = true
+
+	if cmd := m.DrainStepQueues(); cmd != nil {
+		t.Fatal("step drain produced work with nothing to release")
+	}
+	if len(m.conv.Messages) != 0 {
+		t.Fatalf("step drain added messages with nothing to release: %+v", m.conv.Messages)
+	}
+}

--- a/internal/app/notice_step_inject_test.go
+++ b/internal/app/notice_step_inject_test.go
@@ -113,27 +113,27 @@ func TestDeliveryToRunningTurnReachesTheNextInference(t *testing.T) {
 	m, provider := noticeDeliveryModel(t)
 	m.conv.Stream.Active = true
 
-	runCmd(m.deliverToRunningTurn(taskNotice()))
+	runCmd(m.injectIntoRunningTurn(taskNotice()))
 
 	assertAgentRead(t, provider)
 }
 
-// A streaming assistant tail is addressed by position, so a notice cannot be
-// appended there — it parks, and the next completed tool batch releases it into
-// the same turn rather than holding it until the turn ends.
-func TestNoticeParkedByStreamingTailIsReleasedAtTheNextStep(t *testing.T) {
+// The stream finds its message by position, so a notice cannot be appended while
+// it is writing — the notice parks, and the next completed tool batch releases it
+// into the same turn rather than holding it until the turn ends.
+func TestNoticeParkedWhileStreamingIsReleasedAtTheNextStep(t *testing.T) {
 	m, provider := noticeDeliveryModel(t)
 	m.conv.Stream.Active = true
 	m.conv.Append(core.ChatMessage{Role: core.RoleAssistant, Content: "thinking out loud"})
 
 	m.onMainNotice(taskNotice()) // cmds unused: the routing decision is synchronous
 	if len(m.pendingNotices) != 1 {
-		t.Fatalf("notice was appended into a streaming tail: %+v", m.conv.Messages)
+		t.Fatalf("notice was appended while the stream was writing: %+v", m.conv.Messages)
 	}
 
 	// The tool batch completes: its result lands, leaving an appendable tail.
 	m.conv.Append(core.ChatMessage{Role: core.RoleUser, ToolResult: &core.ToolResult{ToolCallID: "c1"}})
-	runCmd(m.DrainStepQueues())
+	runCmd(m.OnStepEnd())
 
 	if len(m.pendingNotices) != 0 {
 		t.Fatalf("notice still parked after a step boundary: %+v", m.pendingNotices)
@@ -148,7 +148,7 @@ func TestStepDrainWithNothingPendingIsInert(t *testing.T) {
 	m, _ := noticeDeliveryModel(t)
 	m.conv.Stream.Active = true
 
-	if cmd := m.DrainStepQueues(); cmd != nil {
+	if cmd := m.OnStepEnd(); cmd != nil {
 		t.Fatal("step drain produced work with nothing to release")
 	}
 	if len(m.conv.Messages) != 0 {

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -1,14 +1,23 @@
-// Main-loop notifications: the small events that wake the TUI's Update loop
-// between turns — a finished background subagent, an interim message from a
-// running one, a self-learn review tick. They arrive on m.mainNotices and are
-// drained at turn boundaries (see model_turn_queue.go).
+// Main-loop notifications: the small events that wake the TUI's Update loop —
+// a finished background subagent, an interim message from a running one, a
+// self-learn review tick. They arrive on m.mainNotices, and this is where their
+// delivery timing is defined; the mechanics live in model_turn_queue.go.
+//
+// A notice shows a line in the conversation, so it can only be delivered where
+// appending is safe — anywhere except into a streaming assistant tail, which is
+// addressed by position (conv.StreamingTail). onMainNotice takes the earliest
+// of three:
+//
+//   - no turn running: injected now, starting a fresh turn;
+//   - turn running, tail not streaming (a tool is executing): handed to that
+//     turn's agent, which reads it at its next step;
+//   - streaming tail: parked in pendingNotices, released at the next completed
+//     tool batch (DrainStepQueues) or, failing that, at OnTurnEnd.
 //
 // m.mainNotices is a TUI staging channel, not the main agent's inbox: unlike a
-// subagent (whose broker delivery goes straight into its core.Agent inbox),
-// the main conversation is UI-attached, so a message must first surface as a
-// notice and wait for a turn boundary before SubmitToAgent forwards it into
-// the main agent's real inbox. That extra hop is why this channel carries
-// mainNotice (a notice) rather than a raw message.
+// subagent, whose broker delivery goes straight into its core.Agent inbox, the
+// main conversation is UI-attached and has this display half to place. That is
+// why the channel carries a mainNotice rather than a raw message.
 package app
 
 import (

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -4,15 +4,15 @@
 // delivery timing is defined; the mechanics live in model_turn_queue.go.
 //
 // A notice shows a line in the conversation, so it can only be delivered where
-// appending is safe — anywhere except into a streaming assistant tail, which is
-// addressed by position (conv.StreamingTail). onMainNotice takes the earliest
-// of three:
+// appending is safe — anywhere except the last slot while the stream is still
+// writing into it (conv.LastMessageIsStreaming). onMainNotice takes the earliest of
+// three:
 //
 //   - no turn running: injected now, starting a fresh turn;
-//   - turn running, tail not streaming (a tool is executing): handed to that
-//     turn's agent, which reads it at its next step;
-//   - streaming tail: parked in pendingNotices, released at the next completed
-//     tool batch (DrainStepQueues) or, failing that, at OnTurnEnd.
+//   - turn running, tail free (a tool is executing): injected into that turn,
+//     whose agent reads it at its next step;
+//   - stream owns the tail: parked in pendingNotices, released at the next
+//     completed tool batch (OnStepEnd) or, failing that, at OnTurnEnd.
 //
 // m.mainNotices is a TUI staging channel, not the main agent's inbox: unlike a
 // subagent, whose broker delivery goes straight into its core.Agent inbox, the

--- a/internal/app/update_input_effects.go
+++ b/internal/app/update_input_effects.go
@@ -55,7 +55,7 @@ func (m *model) cancelPendingToolCalls() {
 	}
 	m.conv.AppendCancelledToolResults(toolCalls, func(tc core.ToolCall) string {
 		return "Tool execution interrupted because the user sent a new message."
-	}, m.TakeDecision)
+	}, m.TakeReviewDecision)
 }
 
 func (m *model) pasteImageFromClipboard() (tea.Cmd, bool) {


### PR DESCRIPTION
Two commits: a delivery-timing fix, then the naming cleanup it exposed. Review them separately — the second is mechanical.

### 1. Deliver background task results as soon as the conversation can take them

A finished background task reached the main conversation only at the turn boundary: any notice arriving while a turn ran was parked and injected by `OnTurnEnd` as a fresh turn. A task that completed during step 3 of a 10-step turn sat unread for seven steps.

The parking rule was `Stream.Active`, which stays true across the whole turn — including tool execution, where the conversation tail is a tool-result row and appending is perfectly safe. Park on the narrower condition that actually blocks an append (`conv.StreamingTail`: the tail is an assistant message the stream is still writing into, addressed by position) and deliver otherwise:

- no turn running → inject now, starting a fresh turn;
- turn running, tail not streaming → hand to that turn's agent, which reads it at its next step;
- streaming tail → park, released at the next completed tool batch (`OnStepEnd`) or at `OnTurnEnd`.

Delivery into a running turn goes through the agent's inbox, which it drains between steps — not `SubmitToAgent`, which can rebuild the session.

Verified against a real session (background `sleep 20`, six foreground commands in the same turn): the completion notice lands between tool rows while the turn is still running, and the model's own summary in that same turn accounts for it. Before, it appeared only after the final summary, ~30s later.

### 2. Name `conv.Runtime` members by where they come from

The interface mixed three kinds of member behind one `On*` prefix, and nothing in a signature told them apart — `OnCompactStart`/`OnCompacted` are agent events while `OnCompactResult` was a background command's return value. One prefix per origin:

| prefix | meaning |
|---|---|
| `On*` | the agent did something; one per agent event, in stream order |
| `Handle*` | a system message arrived: background result, timer, side channel |
| a verb | not a callback — a service conv calls on the host |

`OnTokenUsage` → `OnInference` (it handles PostInfer), `DrainQueuedAtStep` → `OnStepEnd` (next to `OnTurnEnd`), `TakeDecision` → `TakeReviewDecision`, and the three system handlers take the `Handle*` prefix the codebase already uses (`HandleActivity`, `handleStopHookResult`, `handleFlushResult`). `ContinueOutbox` gets its own group: it is an obligation rather than a service, divided between conv and the host, and missing it on any one path silently stops the UI from receiving agent events.

Drops `OnAgentMessage`, which every implementation returned nil from. No behavior change; docs updated to match.
