### PR TITLE
fix: a PreToolUse hook's allow no longer bypasses the permission gate

### DIFF
--- a/internal/agent/build.go
+++ b/internal/agent/build.go
@@ -50,12 +50,17 @@ type BuildParams struct {
 	// PermissionRules and PermissionReview are the two stages of the
 	// pre-execution permission gate: the rules stage applies the static rules
 	// (permit/reject/prompt); the review stage is the LLM auto-review consulted
-	// only on a gray-zone prompt (AutoPilot.Permission).
-	PermissionRules  PermDecisionFunc
-	PermissionReview PermReviewFunc
-	HookEngine       hook.Handler
-	AskUser          tool.AskUserFunc
-	ToolActivity     func(toolCallID string, msg string)
+	// only on a gray-zone prompt (AutoPilot.Permission). HookAllowResolver
+	// guards the way past both: it vets a PreToolUse hook's "allow" against the
+	// settings, so a hook cannot waive a deny rule, the circuit breaker, a
+	// confirmation tier or an explicit ask rule. Nil fails closed.
+	PermissionRules   PermDecisionFunc
+	PermissionReview  PermReviewFunc
+	HookAllowResolver PermHookAllowFunc
+
+	HookEngine   hook.Handler
+	AskUser      tool.AskUserFunc
+	ToolActivity func(toolCallID string, msg string)
 	// BashPromptResponder answers prompts a command raises *while it runs*
 	// (AutoPilot.BashPrompt plus the masked secret input) — a separate concern
 	// from the pre-execution gate above.
@@ -102,6 +107,7 @@ func buildAgent(p BuildParams) (core.Agent, *PermissionGate, error) {
 	}
 	pg := NewPermissionGate(p.PermissionRules)
 	pg.SetReviewer(p.PermissionReview)
+	pg.SetHookAllowResolver(p.HookAllowResolver)
 	var ag core.Agent
 	adaptOpts = append(adaptOpts, tool.WithMessagesGetterProvider(func() []core.Message {
 		if ag == nil {

--- a/internal/agent/hook_allow_test.go
+++ b/internal/agent/hook_allow_test.go
@@ -1,0 +1,127 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/hook"
+	"github.com/genai-io/san/internal/setting"
+	"github.com/genai-io/san/internal/tool"
+)
+
+// These tests drive the whole hook → gate → settings path the main agent is
+// built with, because the bypass they guard against lived in the seam between
+// those three: a PreToolUse hook answering "allow" used to skip the gate
+// outright, so the call never reached HasPermissionToUseTool.
+
+type recordingTool struct{ ran bool }
+
+func (r *recordingTool) Name() string            { return "Bash" }
+func (r *recordingTool) Description() string     { return "" }
+func (r *recordingTool) Schema() core.ToolSchema { return core.ToolSchema{Name: "Bash"} }
+func (r *recordingTool) Execute(context.Context, map[string]any) (string, error) {
+	r.ran = true
+	return "executed", nil
+}
+
+// allowingHook answers every PreToolUse with "allow", the way a permissive user
+// hook does.
+type allowingHook struct{}
+
+func (allowingHook) HasHooks(hook.EventType) bool                { return true }
+func (allowingHook) ExecuteAsync(hook.EventType, hook.HookInput) {}
+func (allowingHook) StopHookActive() *bool                       { return nil }
+func (allowingHook) Execute(context.Context, hook.EventType, hook.HookInput) hook.HookOutcome {
+	return hook.HookOutcome{ShouldContinue: true, PermissionAllow: true, HookSource: "PreToolUse"}
+}
+
+// gatedTools wires a tool behind the same hook + gate stack buildAgent uses.
+func gatedTools(t *testing.T, data *setting.Data, inner core.Tool) (core.Tools, *PermissionGate) {
+	t.Helper()
+	gate := NewPermissionGate(func(name string, args map[string]any) PermDecisionResult {
+		decision := data.HasPermissionToUseTool(name, args, nil)
+		return PermDecisionResult{Decision: decision.Behavior, Reason: decision.Reason}
+	})
+	gate.SetHookAllowResolver(func(name string, args map[string]any) bool {
+		return data.ResolveHookAllow(name, args, nil)
+	})
+	t.Cleanup(gate.Close)
+	return tool.WithPreToolUseAndPermission(core.NewTools(inner), allowingHook{}, gate), gate
+}
+
+// runBash executes one command through the stack and reports whether the gate
+// prompted on the way. Racing the prompt against the call's own return is what
+// keeps every regression a clean failure: a bypass returns with prompted=false
+// instead of parking the test on a prompt that never arrives, and a prompt is
+// answered (deny) instead of parking the call on an answer that never comes.
+func runBash(t *testing.T, tools core.Tools, gate *PermissionGate, command string) (prompted bool, err error) {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() {
+		_, execErr := tools.Get("Bash").Execute(context.Background(), map[string]any{"command": command})
+		done <- execErr
+	}()
+	prompts := make(chan *PermGateRequest, 1)
+	go func() {
+		if req, ok := gate.Recv(); ok {
+			prompts <- req
+		}
+	}()
+
+	select {
+	case err = <-done:
+		return false, err
+	case req := <-prompts:
+		req.Response <- PermGateResponse{Allow: false, Reason: "denied by test"}
+		return true, <-done
+	}
+}
+
+func TestHookAllowCannotWaiveDenyRule(t *testing.T) {
+	data := &setting.Data{Permissions: setting.PermissionSettings{Deny: []string{"Bash(rm:*)"}}}
+	inner := &recordingTool{}
+	tools, gate := gatedTools(t, data, inner)
+
+	_, err := runBash(t, tools, gate, "rm -rf important/")
+	if err == nil {
+		t.Error("expected the deny rule to block the call despite the hook allow")
+	}
+	if inner.ran {
+		t.Error("hook allow executed a command covered by an explicit deny rule")
+	}
+}
+
+func TestHookAllowCannotWaiveCircuitBreaker(t *testing.T) {
+	inner := &recordingTool{}
+	tools, gate := gatedTools(t, &setting.Data{}, inner)
+
+	prompted, err := runBash(t, tools, gate, "rm -rf ~")
+	if !prompted {
+		t.Error("hook allow skipped the gate: the circuit breaker never reached the user")
+	}
+	if err == nil {
+		t.Error("expected the refused prompt to block the call")
+	}
+	if inner.ran {
+		t.Error("hook allow executed a command the circuit breaker holds")
+	}
+}
+
+// The hook stays useful: on a call no rule and no safety check speaks to, its
+// allow still waives the routine "do you want to run this?" prompt.
+func TestHookAllowWaivesRoutinePrompt(t *testing.T) {
+	inner := &recordingTool{}
+	tools, gate := gatedTools(t, &setting.Data{}, inner)
+
+	prompted, err := runBash(t, tools, gate, "git status")
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if prompted {
+		t.Error("hook allow should have waived the routine prompt")
+	}
+	if !inner.ran {
+		t.Error("the waived call should have run")
+	}
+}

--- a/internal/agent/hook_allow_test.go
+++ b/internal/agent/hook_allow_test.go
@@ -51,10 +51,11 @@ func gatedTools(t *testing.T, data *setting.Data, inner core.Tool) (core.Tools, 
 }
 
 // runBash executes one command through the stack and reports whether the gate
-// prompted on the way. Racing the prompt against the call's own return is what
-// keeps every regression a clean failure: a bypass returns with prompted=false
-// instead of parking the test on a prompt that never arrives, and a prompt is
-// answered (deny) instead of parking the call on an answer that never comes.
+// prompted on the way. Racing the gate's request channel against the call's own
+// return is what keeps every regression a clean failure: a bypass returns with
+// prompted=false instead of parking the test on a prompt that never arrives,
+// and a prompt is answered (deny) instead of parking the call on an answer that
+// never comes.
 func runBash(t *testing.T, tools core.Tools, gate *PermissionGate, command string) (prompted bool, err error) {
 	t.Helper()
 	done := make(chan error, 1)
@@ -62,17 +63,11 @@ func runBash(t *testing.T, tools core.Tools, gate *PermissionGate, command strin
 		_, execErr := tools.Get("Bash").Execute(context.Background(), map[string]any{"command": command})
 		done <- execErr
 	}()
-	prompts := make(chan *PermGateRequest, 1)
-	go func() {
-		if req, ok := gate.Recv(); ok {
-			prompts <- req
-		}
-	}()
 
 	select {
 	case err = <-done:
 		return false, err
-	case req := <-prompts:
+	case req := <-gate.requests:
 		req.Response <- PermGateResponse{Allow: false, Reason: "denied by test"}
 		return true, <-done
 	}

--- a/internal/agent/hook_allow_test.go
+++ b/internal/agent/hook_allow_test.go
@@ -109,12 +109,14 @@ func TestHookAllowCannotWaiveCircuitBreaker(t *testing.T) {
 }
 
 // The hook stays useful: on a call no rule and no safety check speaks to, its
-// allow still waives the routine "do you want to run this?" prompt.
+// allow still waives the routine "do you want to run this?" prompt. The command
+// has to be one the gate would really prompt on — a read-only one is permitted
+// by the mode default whether or not the waiver works, so it would pin nothing.
 func TestHookAllowWaivesRoutinePrompt(t *testing.T) {
 	inner := &recordingTool{}
 	tools, gate := gatedTools(t, &setting.Data{}, inner)
 
-	prompted, err := runBash(t, tools, gate, "git status")
+	prompted, err := runBash(t, tools, gate, "touch marker")
 	if err != nil {
 		t.Fatalf("Execute returned error: %v", err)
 	}

--- a/internal/agent/permission.go
+++ b/internal/agent/permission.go
@@ -41,8 +41,11 @@ type PermReviewFunc func(ctx context.Context, name string, input map[string]any,
 
 // PermHookAllowFunc reports whether a PreToolUse hook's "allow" may stand for
 // this call. It backs the safety invariant deny rules > safety checks > ask
-// rules > hook allow: a hook can waive the routine prompt, but it cannot vouch
-// for a call the user or the breaker has already ruled on.
+// rules > hook allow: the hook can waive the routine prompt, but a deny rule,
+// the circuit breaker, either confirmation tier or an explicit ask rule
+// outranks it, and the call goes through the gate as if the hook had said
+// nothing. A hook cannot vouch for a call the user or the breaker has already
+// ruled on.
 type PermHookAllowFunc func(name string, args map[string]any) bool
 
 // PermGateRequest is a pending permission request sent to the TUI for approval.
@@ -102,9 +105,8 @@ func (pg *PermissionGate) SetHookAllowResolver(fn PermHookAllowFunc) {
 }
 
 // HonorsHookAllow reports whether a PreToolUse hook's "allow" is enough to skip
-// the gate for this call. A deny rule, the circuit breaker, either confirmation
-// tier or an explicit ask rule outranks the hook, and the call goes through the
-// gate as if the hook had said nothing.
+// the gate for this call, on the precedence PermHookAllowFunc documents. A gate
+// with no resolver answers no.
 func (pg *PermissionGate) HonorsHookAllow(name string, input map[string]any) bool {
 	if pg.hookAllowFn == nil {
 		return false

--- a/internal/agent/permission.go
+++ b/internal/agent/permission.go
@@ -39,6 +39,12 @@ type PermReviewResult struct {
 // broken or slow judge can never silently approve.
 type PermReviewFunc func(ctx context.Context, name string, input map[string]any, reason string) PermReviewResult
 
+// PermHookAllowFunc reports whether a PreToolUse hook's "allow" may stand for
+// this call. It backs the safety invariant deny rules > safety checks > ask
+// rules > hook allow: a hook can waive the routine prompt, but it cannot vouch
+// for a call the user or the breaker has already ruled on.
+type PermHookAllowFunc func(name string, args map[string]any) bool
+
 // PermGateRequest is a pending permission request sent to the TUI for approval.
 //
 // RequestID carries the correlation token the decider stamped so the TUI
@@ -68,9 +74,10 @@ type PermGateResponse struct {
 // through a channel pair. The agent side blocks on the response; the TUI
 // side receives requests and sends back decisions.
 type PermissionGate struct {
-	requests chan *PermGateRequest
-	decideFn PermDecisionFunc
-	reviewFn PermReviewFunc // optional; judges reviewable gray-zone prompts
+	requests    chan *PermGateRequest
+	decideFn    PermDecisionFunc
+	reviewFn    PermReviewFunc    // optional; judges reviewable gray-zone prompts
+	hookAllowFn PermHookAllowFunc // optional; vets a PreToolUse hook's "allow"
 }
 
 func NewPermissionGate(decideFn PermDecisionFunc) *PermissionGate {
@@ -84,6 +91,25 @@ func NewPermissionGate(decideFn PermDecisionFunc) *PermissionGate {
 // offered to it before falling back to the user. A nil fn disables review.
 func (pg *PermissionGate) SetReviewer(fn PermReviewFunc) {
 	pg.reviewFn = fn
+}
+
+// SetHookAllowResolver installs the resolver that vets a PreToolUse hook's
+// "allow" against the settings. A nil fn fails closed: a gate with no resolver
+// has no rules to check the hook against, so it cannot certify the waiver and
+// every call goes through the gate.
+func (pg *PermissionGate) SetHookAllowResolver(fn PermHookAllowFunc) {
+	pg.hookAllowFn = fn
+}
+
+// HonorsHookAllow reports whether a PreToolUse hook's "allow" is enough to skip
+// the gate for this call. A deny rule, the circuit breaker, either confirmation
+// tier or an explicit ask rule outranks the hook, and the call goes through the
+// gate as if the hook had said nothing.
+func (pg *PermissionGate) HonorsHookAllow(name string, input map[string]any) bool {
+	if pg.hookAllowFn == nil {
+		return false
+	}
+	return pg.hookAllowFn(name, input)
 }
 
 func (pg *PermissionGate) PermissionFunc() perm.PermissionFunc {

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -268,6 +268,10 @@ func (m *model) buildAgentParams() agent.BuildParams {
 			return agent.PermReviewResult{Allow: true, Reason: "autopilot: " + verdict.Reason}
 		},
 
+		HookAllowResolver: func(name string, args map[string]any) bool {
+			return m.services.Setting.ResolveHookAllow(name, args, m.env.SessionPermissions)
+		},
+
 		StreamFirstChunkTimeout: streamFirstChunk,
 		StreamIdleTimeout:       streamIdle,
 	}

--- a/internal/setting/permission_test.go
+++ b/internal/setting/permission_test.go
@@ -1127,6 +1127,22 @@ func TestResolveHookAllow(t *testing.T) {
 	}
 }
 
+// A handle with no settings loaded — the package default before Initialize runs,
+// and what ResetDefaultSettings restores — has no rules to weigh the hook's
+// allow against, so it cannot certify the waiver. Failing open here would hand a
+// permissive hook a gate-free path on exactly the call HasPermissionToUseTool
+// would have prompted on.
+func TestSettingsResolveHookAllowFailsClosedWithoutData(t *testing.T) {
+	settings := &Settings{}
+
+	if settings.ResolveHookAllow("Bash", map[string]any{"command": "rm -rf /tmp/test"}, nil) {
+		t.Error("no settings loaded: the hook allow was honored, bypassing the gate")
+	}
+	if got := settings.HasPermissionToUseTool("Bash", map[string]any{"command": "rm -rf /tmp/test"}, nil); got.Behavior != perm.Prompt {
+		t.Errorf("the same call without a hook = %v, want Prompt", got.Behavior)
+	}
+}
+
 func TestOperationModeNext(t *testing.T) {
 	// Normal → AutoAccept → AutoPilot → Normal
 	if ModeNormal.Next() != ModeAutoAccept {

--- a/internal/setting/service.go
+++ b/internal/setting/service.go
@@ -212,7 +212,11 @@ func (s *Settings) ResolveHookAllow(toolName string, args map[string]any, sessio
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.data == nil {
-		return true
+		// No settings loaded means no deny rules, no ask rules and no
+		// confirmation tiers to check the hook's allow against, so the waiver
+		// cannot be certified: refuse it and let the call reach the gate, which
+		// prompts for the same reason.
+		return false
 	}
 	return s.data.ResolveHookAllow(toolName, args, session)
 }

--- a/internal/tool/pretool_hook.go
+++ b/internal/tool/pretool_hook.go
@@ -17,6 +17,9 @@ func WithPreToolUseHooks(inner core.Tools, hooks hook.Handler) core.Tools {
 
 type PreToolPermissionChecker interface {
 	Check(ctx context.Context, name string, input map[string]any, forcePrompt bool, reason string) (bool, string)
+	// HonorsHookAllow reports whether a PreToolUse hook's "allow" is enough to
+	// skip Check for this call. False sends the call through the gate anyway.
+	HonorsHookAllow(name string, input map[string]any) bool
 }
 
 func WithPreToolUseAndPermission(inner core.Tools, hooks hook.Handler, check PreToolPermissionChecker) core.Tools {
@@ -94,11 +97,17 @@ func (pt *preToolHookTool) Execute(ctx context.Context, input map[string]any) (s
 		permissionReason = outcome.PermissionReason
 	}
 
-	// A hook "ask" always reaches the user, even if another hook also
-	// answered "allow": prompting is the safe resolution of the conflict.
-	if pt.check != nil && (!allowByHook || forceAsk) {
-		if allow, reason := pt.check.Check(ctx, pt.inner.Name(), input, forceAsk, permissionReason); !allow {
-			return "", fmt.Errorf("blocked: %s", reason)
+	if pt.check != nil {
+		// A hook "allow" waives the routine prompt and nothing more. A hook
+		// "ask" outranks it, because prompting is the safe resolution when two
+		// hooks disagree; so does a deny rule, the circuit breaker, either
+		// confirmation tier or an explicit ask rule, which is what
+		// HonorsHookAllow reports on.
+		waived := allowByHook && !forceAsk && pt.check.HonorsHookAllow(pt.inner.Name(), input)
+		if !waived {
+			if allow, reason := pt.check.Check(ctx, pt.inner.Name(), input, forceAsk, permissionReason); !allow {
+				return "", fmt.Errorf("blocked: %s", reason)
+			}
 		}
 	}
 	return pt.inner.Execute(ctx, input)

--- a/internal/tool/pretool_hook_test.go
+++ b/internal/tool/pretool_hook_test.go
@@ -61,6 +61,10 @@ type fakePreToolPermissionChecker struct {
 	forcePrompt bool
 	reason      string
 	allow       bool
+	// refuseHookAllow makes the checker answer HonorsHookAllow with false, the
+	// way the real gate does for a deny rule, the circuit breaker, a
+	// confirmation tier or an explicit ask rule.
+	refuseHookAllow bool
 }
 
 func (c *fakePreToolPermissionChecker) Check(ctx context.Context, name string, input map[string]any, forcePrompt bool, reason string) (bool, string) {
@@ -71,6 +75,10 @@ func (c *fakePreToolPermissionChecker) Check(ctx context.Context, name string, i
 		return true, ""
 	}
 	return false, "should not be used"
+}
+
+func (c *fakePreToolPermissionChecker) HonorsHookAllow(name string, input map[string]any) bool {
+	return !c.refuseHookAllow
 }
 
 func TestPreToolUseAllowOverridesPermissionPrompt(t *testing.T) {
@@ -85,6 +93,27 @@ func TestPreToolUseAllowOverridesPermissionPrompt(t *testing.T) {
 	}
 	if checker.called {
 		t.Fatal("permission checker should not run after PreToolUse allow")
+	}
+}
+
+// A hook allow waives the routine prompt, not the rules. When the checker says
+// the waiver does not hold — a deny rule, the circuit breaker, a confirmation
+// tier or an explicit ask rule — the call is gated as if no hook had spoken.
+func TestPreToolUseAllowStillGatedWhenNotHonored(t *testing.T) {
+	inner := &captureCoreTool{}
+	hooks := &fakeHookHandler{outcome: hook.HookOutcome{PermissionAllow: true}}
+	checker := &fakePreToolPermissionChecker{refuseHookAllow: true}
+	tools := WithPreToolUseAndPermission(core.NewTools(inner), hooks, checker)
+
+	_, err := tools.Get("Bash").Execute(context.Background(), map[string]any{"command": "rm -rf important/"})
+	if err == nil {
+		t.Fatal("expected the gate to block the call")
+	}
+	if !checker.called {
+		t.Fatal("permission checker should run when the hook allow is not honored")
+	}
+	if inner.input != nil {
+		t.Fatalf("tool ran despite the gate refusing the call, input %#v", inner.input)
 	}
 }
 


### PR DESCRIPTION
## Problem

A `PreToolUse` hook answering `permissionDecision: "allow"` skipped `pt.check`
entirely, and `pt.check` is the only route to `HasPermissionToUseTool`. A hook
could therefore run a command covered by an explicit deny rule, and get past
the circuit breaker, both confirmation tiers, and explicit ask rules.

`setting.ResolveHookAllow` already documented and implemented the intended
invariant — deny rules > safety checks > ask rules > hook allow — but nothing
ever called it.

Reproduced on `main` before the fix, driving the real hook + gate + settings
stack:

```
deny rule Bash(rm:*)     -> ran=true out="EXECUTED" err=<nil>
circuit breaker rm -rf ~ -> ran=true out="EXECUTED" err=<nil>
```

## Fix

- `PermissionGate` gains `HonorsHookAllow`, backed by a `PermHookAllowFunc` set
  from `BuildParams.HookAllowResolver`; the app supplies
  `Settings.ResolveHookAllow`.
- `preToolHookTool.Execute` consults it, so a hook allow waives only the routine
  prompt — a deny rule, the circuit breaker, either confirmation tier or an
  explicit ask rule still sends the call through the gate.

The waiver fails closed wherever there is nothing to certify it with:

- a nil resolver — a gate with no rules to check the hook against cannot certify
  the waiver, so every call is gated;
- a `Settings` handle with no data loaded — the package default before
  `Initialize` runs, and what `ResetDefaultSettings` restores. It used to return
  `true`, which was the one state where the hook waived the gate with *zero*
  checks behind it, while the same call without a hook would have reached the
  user (`HasPermissionToUseTool` reads nil data as `Prompt`).

Forgetting to wire the resolver, or asking before settings load, costs a
redundant prompt — not a bypass.

## Where the invariant holds

`WithPreToolUseAndPermission` has one call site — the main agent's tool registry — and MCP tools are registered into that same registry before it is wrapped, so they get identical protection. Subagents (`tool.WithPermission`) and the self-learning fork never reach this code: they fire `SubagentStart`/`SubagentStop` but never `PreToolUse` for a tool call, so there is no hook verdict to bypass anything with. Worth stating precisely — on those paths the bug class is absent rather than defended, so wiring `PreToolUse` into them later would need this check wired too.

## Deliberately unchanged

`ResolveHookAllow` does not consider `ModeReadOnly` / `ModeDontAsk`, so a hook
allow still waives those. That matches the invariant the function documents;
widening it is a separate decision, tracked in #452.

`ResolveHookAllow` also keeps its own copies of the deny-rule and ask-rule loops
rather than sharing them with `HasPermissionToUseTool`. That duplication is
pre-existing, but this PR is what puts it on the enforcement path — a tier added
to one and not the other would silently reopen this bug class. Folding the two
into a single pipeline needs a new parameter threaded through `Check`, so it is
tracked separately in #454.

## Tests

- `TestPreToolUseAllowOverridesPermissionPrompt` pinned the bypass. It now covers
  the honored case, with `TestPreToolUseAllowStillGatedWhenNotHonored` for the
  refused one.
- `internal/agent/hook_allow_test.go` covers the seam the bypass lived in: the
  deny rule, the circuit breaker (which now reaches the prompt and is refused),
  and the case that must keep working — a routine call where the hook allow
  still skips the prompt. That last one drives `touch marker`: a read-only
  command like `git status` is permitted by the mode default whether or not the
  waiver works, so it would pin nothing.
- `TestSettingsResolveHookAllowFailsClosedWithoutData` covers the nil-data
  handle, alongside the `HasPermissionToUseTool` result it now agrees with.
- `go build ./...`, `go test ./...` and `make lint` (vet + format + layercheck)
  are clean.

Fixes #441
