### PR TITLE
docs: correct the slot table, the mode table and dead source references

### DIFF
--- a/docs/concepts/harness-channels.md
+++ b/docs/concepts/harness-channels.md
@@ -42,18 +42,20 @@ The harness optimizes:
 
 The system prompt is composed of **Sections**, each owning a numbered
 **Slot**. Slots define ordering. Sections within the same slot use
-insertion order, so several sections can stack inside one slot (e.g.
-`identity` + `output` + `engineering` all live in slot 0). Mutations to a
-section trigger `Refresh` (lazy re-render).
+insertion order, so several sections can stack inside one slot (a
+subagent's injected charter lands in slot 0 alongside the identity).
+Mutations to a section trigger `Refresh` (lazy re-render).
 
 ```
-slot 0   identity        built-in or custom persona; output and
-                         engineering sections stack here too
-slot 1   provider        optional provider-specific quirks
-slot 2   policy          safety contract — never overridden
-slot 3   guidelines      tool-usage, task-workflow, when-to-ask,
-                         git-safety (filtered by Scope and isGit)
-slot 4   environment     cwd, git, date, platform, model — volatile,
+slot 0   identity        who you are — built-in or custom persona, and
+                         a subagent's injected charter
+slot 1   behavior        how you communicate and work: tone and updates
+                         merged with the engineering defaults
+                         (main agent only — a subagent carries its
+                         working style in its charter)
+slot 2   rules           safety contract plus the tool / task / git
+                         protocols
+slot 3   environment     date, cwd, git branch, platform — volatile,
                          placed last so daily/cwd changes don't bust
                          the cache prefix above
 ```
@@ -94,10 +96,9 @@ Reminders wrap their body in:
 
 The LLM is instructed to treat the `<system-reminder>` tag as a system
 instruction even though it appears inside a user message. That directive
-lives in the system prompt as `<guidelines name="system-reminders">`
-(source: `internal/core/system/prompts/guidelines/system-reminders.txt`),
-applied to both
-main and subagent scopes — subagents receive reminders too (the skills
+is the "System reminders" part of the `<rules>` section (source:
+`internal/core/system/prompts/rules.txt`), applied to both main and
+subagent scopes — subagents receive reminders too (the skills
 directory). It also tells the model to act on the most recent reminder
 values (they refresh and re-inject after compaction) and not to echo the
 tags back to the user.

--- a/docs/concepts/permission-model.md
+++ b/docs/concepts/permission-model.md
@@ -2,7 +2,7 @@
 
 Every tool call passes through one gate: `setting.HasPermissionToUseTool`.
 This page documents the inputs, the decision pipeline, and how the
-foreground TUI, subagents, and plan-mode differ.
+foreground TUI and subagents differ.
 
 For the Claude-Code-compatible rule syntax see
 [`reference/claude-permission-compat.md`](../reference/claude-permission-compat.md).
@@ -13,24 +13,61 @@ For the Claude-Code-compatible rule syntax see
 |---|---|
 | **Behavior** | The intent: `allow`, `deny`, or `ask`. |
 | **Decision** | Behavior + reason + suggested rule edits. The runtime returns one of these per call. |
-| **Mode** | Session-wide policy: `default`, `acceptEdits`, `bypassPermissions`, `plan`. |
+| **Mode** | Session-wide policy. See the mode table below. |
 | **Rule** | A pattern matched against `toolName + args`. E.g. `Bash(git status:*)`, `Write(./src/**)`. |
 | **Session permissions** | Per-session rules accumulated from hook responses and approval modals. Reset on session end. |
+| **Confirmation tier** | Why a call needs a human: *unrecoverable* (real destruction, sensitive paths, data exfiltration) or *recoverable* (work-discarding git, out-of-working-dir writes). Only the recoverable tier may be delegated to the judge. |
 
-## Sources of Authority
+## Modes
 
-Five sources are consulted in this order; the first to produce a
-non-`ask` behavior wins:
+`setting.OperationMode` (`internal/setting/settings.go`) has six values:
 
-1. **Settings rules** — `settings.json` `permissions.allow / deny / ask`,
-   merged across user and project tiers.
-2. **Session permissions** — rules added during the run (via approval
-   modals or hook updates).
-3. **Hook responses** — `PermissionRequest` hook (if any) may force
-   `allow` or `deny`, or rewrite the request.
-4. **Mode policy** — `bypassPermissions` forces allow; `plan` forces deny
-   for any write-class tool.
-5. **Default** — `ask`.
+| Mode | `String()` | Behavior |
+|---|---|---|
+| `ModeNormal` | `normal` | Safe tools auto-allow; everything else prompts. |
+| `ModeAutoAccept` | `accept edits` | Edit/Write auto-allow; other gated tools prompt. |
+| `ModeAutoPilot` | `autopilot` | Edits auto-allow; every other gated call becomes a **reviewable** prompt the judge may answer. |
+| `ModeBypassPermissions` | `bypass permissions` | Allow everything except deny rules and the circuit breaker. |
+| `ModeDontAsk` | `don't ask` | Coerce `ask` → `deny`; never prompt. |
+| `ModeReadOnly` | `read-only` | Safe tools only; everything else denied. |
+
+The first four make up the user-facing cycle: `cycleModes` steps through
+normal / accept-edits / autopilot, and `cycleModesWithBypass` adds bypass
+when it is explicitly enabled. `ModeDontAsk` and `ModeReadOnly` are
+entered programmatically (headless runs, the subagent explore mode), not
+by cycling.
+
+## Decision Pipeline
+
+`HasPermissionToUseTool` walks nine steps in order; the first to produce a
+decision wins. The step list here mirrors the comment block above the
+function in `internal/setting/permission.go` — keep the two in sync.
+
+1. **Deny rules** — `permissions.deny`, merged across user and project tiers.
+2. **Circuit breaker** — a recursive removal of the filesystem root or the
+   home directory. The one check no mode may skip, bypass included.
+3. **BypassPermissions mode** — allow everything that got past 1 and 2.
+4. **Confirmation checks** (skipped by bypass) — the unrecoverable tier
+   (destructive bash, sensitive paths, data exfiltration; never
+   judge-reviewable) and the recoverable tier (work-discarding git,
+   out-of-working-dir writes; the AutoPilot judge may weigh the git case).
+5. **Session permissions** — rules accumulated during the run from approval
+   modals and hook updates.
+6. **Ask rules** — `permissions.ask`.
+7. **Allow rules** — `permissions.allow`.
+8. **Mode default** — `setting.ModeDefault`, the mode table above. This is
+   where AutoPilot marks a prompt `Reviewable`.
+9. **Headless / DontAsk coercion** — `ask` becomes `deny` when nobody can
+   answer.
+
+Hooks sit on either side of this gate rather than inside it:
+
+- A **`PreToolUse`** hook runs before the gate. It can block the call,
+  rewrite the input, force a prompt, or answer `allow`. An `allow` only
+  waives the routine prompt — `setting.ResolveHookAllow` re-checks it, so a
+  deny rule, the circuit breaker, either confirmation tier or an explicit
+  ask rule still sends the call through the gate.
+- A **`PermissionRequest`** hook fires when a call has reached a prompt.
 
 The pipeline lives in `internal/setting/permission.go`. Bash gets special
 treatment: `bash_ast.go` parses the command and matches per-argv patterns
@@ -57,7 +94,7 @@ foreground requests may use settings, session rules, hooks, and the approval
 bridge, while subagents apply their `deny_tools`/`allow_tools` rules and deny
 requests that would require a user prompt.
 
-- Foreground: yes. `agent.PermissionBridge` synchronously waits for the
+- Foreground: yes. `agent.PermissionGate` synchronously waits for the
   TUI approval, then routes the answer back into the running tool call.
 - Subagent: no. There's no user attached to the subagent's loop, so `ask`
   collapses to `deny`. What remains is the mode's own auto-allow surface:
@@ -79,15 +116,29 @@ One subagent-specific rule composes with the pipeline:
   running subagent) follows the ordinary mode pipeline like any other tool.
   See [`packages/broker.md`](../packages/2-feature/broker.md).
 
-## Plan Mode
+## The Gray Zone: Auto-Review
 
-A read-only conversation. Write-class tools (`Write`, `Edit`,
-`NotebookEdit`, certain Bash patterns) are auto-denied with a synthetic
-reason `"plan mode: read-only"`. The user can exit plan mode with
-`/plan-off` or by approving an `ExitPlanMode` tool call.
+In `ModeAutoPilot`, a call that would prompt is offered to a review agent
+before it is offered to the user. One flag decides which calls those are,
+and the reviewer has no say in it:
 
-Plan mode is a **policy filter**, not a separate code path. The same
-`HasPermissionToUseTool` returns `deny(plan-mode)` early.
+- `PermissionDecision.Reviewable` (`internal/setting/permission.go`) marks a
+  prompt the judge may weigh.
+- `setting.ModeDefault` sets it **only** for the AutoPilot non-edit default
+  (step 8). Nothing else in the pipeline sets it.
+- `PermissionGate.Check` (`internal/agent/permission.go`) offers a reviewable
+  prompt to the judge; `allow` short-circuits, anything else falls through to
+  the human prompt.
+- The judge fails closed: `PermReviewFunc` must return the zero value on any
+  error, so a broken or slow reviewer escalates rather than approves.
+
+The load-bearing safety property is which prompts never reach the judge.
+`ConfirmationTier` splits the confirmation reasons in two, and only the
+**recoverable** tier is reviewable. The unrecoverable tier — real
+destruction, sensitive paths, data exfiltration — and the circuit breaker
+stay the human's call in every mode.
+
+The reviewer itself lives in `internal/reviewer/`.
 
 ## Hooks Can Mutate Permissions
 
@@ -108,9 +159,12 @@ mutation payload.
 
 - Decision gate: `internal/setting/permission.go` → `HasPermissionToUseTool`.
 - Rule parser + Bash AST: `internal/setting/bash_ast.go`.
-- Approval modal flow: `internal/agent/permission.go` (`PermissionBridge`).
+- Approval modal flow: `internal/agent/permission.go` (`PermissionGate`).
+- Gray-zone judge: `internal/reviewer/`.
+- Hook-allow invariant: `internal/setting/permission.go` → `ResolveHookAllow`,
+  applied in `internal/tool/pretool_hook.go`.
 - Subagent permission resolution: `internal/subagent/executor.go`.
-- Hook integration: `internal/hook/engine.go` → `getPermissionRequestOutcome`.
+- Hook integration: `internal/hook/executor.go` → `applyPermissionDecision`.
 
 ## See Also
 

--- a/docs/concepts/rendering.md
+++ b/docs/concepts/rendering.md
@@ -389,7 +389,7 @@ in [`internal/app/update_resize.go`](../../internal/app/update_resize.go):
 | User / assistant / notice rendering | [`internal/app/conv/message.go`](../../internal/app/conv/message.go) |
 | Markdown rendering | [`internal/app/conv/markdown.go`](../../internal/app/conv/markdown.go) |
 | Tool call / result rendering | [`internal/app/conv/tool_render.go`](../../internal/app/conv/tool_render.go) |
-| Compact / progress / tracker | [`internal/app/conv/compact.go`](../../internal/app/conv/compact.go), [`progress.go`](../../internal/app/conv/progress.go), [`tracker_view.go`](../../internal/app/conv/tracker_view.go) |
+| Compact / agent activity / tracker | [`internal/app/conv/compact.go`](../../internal/app/conv/compact.go), [`agent_to_ui.go`](../../internal/app/conv/agent_to_ui.go), [`tracker_view.go`](../../internal/app/conv/tracker_view.go) |
 | `MDRenderer` lifecycle | [`internal/app/conv/model.go`](../../internal/app/conv/model.go) |
 | Scrollback commit | [`internal/app/model_scrollback.go`](../../internal/app/model_scrollback.go) |
 | Resize + reflow | [`internal/app/update_resize.go`](../../internal/app/update_resize.go) |

--- a/docs/concepts/rendering.zh.md
+++ b/docs/concepts/rendering.zh.md
@@ -372,7 +372,7 @@ CommittedCount = 3                           // 追上
 | User / Assistant / Notice 渲染 | [`internal/app/conv/message.go`](../../internal/app/conv/message.go) |
 | Markdown 渲染 | [`internal/app/conv/markdown.go`](../../internal/app/conv/markdown.go) |
 | 工具调用 / 结果渲染 | [`internal/app/conv/tool_render.go`](../../internal/app/conv/tool_render.go) |
-| Compact / 进度 / tracker | [`internal/app/conv/compact.go`](../../internal/app/conv/compact.go)、[`progress.go`](../../internal/app/conv/progress.go)、[`tracker_view.go`](../../internal/app/conv/tracker_view.go) |
+| Compact / 智能体活动 / tracker | [`internal/app/conv/compact.go`](../../internal/app/conv/compact.go)、[`agent_to_ui.go`](../../internal/app/conv/agent_to_ui.go)、[`tracker_view.go`](../../internal/app/conv/tracker_view.go) |
 | `MDRenderer` 生命周期 | [`internal/app/conv/model.go`](../../internal/app/conv/model.go) |
 | Scrollback commit | [`internal/app/model_scrollback.go`](../../internal/app/model_scrollback.go) |
 | Resize + reflow | [`internal/app/update_resize.go`](../../internal/app/update_resize.go) |

--- a/docs/packages/2-feature/tool.md
+++ b/docs/packages/2-feature/tool.md
@@ -70,7 +70,8 @@ func ResetDefaultRegistry()           // test-only
 
 ```
 internal/tool/execute_test.go         — dispatch and not-found behavior.
-internal/tool/schema_agent_test.go    — schema generation for the Agent tool.
+internal/tool/schema_registry_test.go — schema generation, including the Agent tool.
+internal/tool/pretool_hook_test.go    — PreToolUse hook outcomes and the permission gate.
 ```
 
 ## See Also


### PR DESCRIPTION
Three docs issues in one commit — they overlap, since the dead
`prompts/guidelines/` path is counted under both #442 and #444.

## `docs/concepts/harness-channels.md` (#442)

The slot table described five pre-refactor slots. The code has four
(`internal/core/section.go`): identity, behavior, rules, environment. `provider`
is gone, `policy` + `guidelines` collapsed into `rules`, and `behavior` was
introduced — so every index from 1 onward was off by one.

The system-reminder directive no longer lives at
`internal/core/system/prompts/guidelines/system-reminders.txt` (neither the file
nor the directory exists). It is the "System reminders" part of
`internal/core/system/prompts/rules.txt`.

## `docs/concepts/permission-model.md` (#443)

- Deleted the `## Plan Mode` section and both `plan` references. `ModePlan`,
  `ExitPlanMode` and `/plan-off` exist nowhere in the tree.
- Replaced the mode table with the six real `OperationMode` values, noting which
  are user-cyclable (`cycleModes` / `cycleModesWithBypass`) and which are entered
  programmatically (`ModeDontAsk`, `ModeReadOnly`).
- Renumbered "Sources of Authority" (five entries) into the nine steps
  enumerated above `HasPermissionToUseTool`, and placed the two hook events
  relative to the gate rather than inside it.
- Added the gray-zone section: `Reviewable` is set only by the AutoPilot
  non-edit default, the judge fails closed, and only the recoverable
  confirmation tier is reviewable — never the unrecoverable one or the circuit
  breaker.
- Fixed two dead references not named in any issue: `agent.PermissionBridge`
  (now `agent.PermissionGate`) and `internal/hook/engine.go →
  getPermissionRequestOutcome` (now `internal/hook/executor.go →
  applyPermissionDecision`).

## Dead source references (#444)

- `docs/packages/2-feature/tool.md`: `schema_agent_test.go` →
  `schema_registry_test.go`
- `docs/concepts/rendering.md` and `rendering.zh.md`: `conv/progress.go` →
  `conv/agent_to_ui.go`, the successor transport (`ProgressUpdateMsg` became
  `AgentActivityMsg`)

**One row of that issue's table is a false positive.** `cmd/cmd.md` resolves to
`docs/packages/0-cmd/cmd.md`, which exists — the detection regex
`(internal|cmd|pkg)/…` matched the tail of `0-cmd/cmd.md`. Three real dead
references, not four.

## Not included

The suggestion to run that one-liner in CI is left out on purpose: as written it
reports the `0-cmd/cmd.md` false positive, and a checker worth keeping should
validate markdown link targets rather than regex-scrape prose — closer to
`tools/layercheck` than to a grep. Worth its own change.

`docs/reference/slash-commands.md` and `docs/reference/cli-startup.md` also
document the nonexistent plan mode (`/plan`, `san --plan`, `[PLAN MODE]` in the
status bar). Out of scope for #443, which names only `permission-model.md`;
happy to follow up.

Fixes #442
Fixes #443
Fixes #444
