### PR TITLE
fix: report a call waiting on a permission prompt as waiting, not running

### DIFF
--- a/internal/agent/permission.go
+++ b/internal/agent/permission.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 
+	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/tool/perm"
 )
 
@@ -43,8 +44,14 @@ type PermReviewFunc func(ctx context.Context, name string, input map[string]any,
 // RequestID carries the correlation token the decider stamped so the TUI
 // can reference the prior permission.required record when emitting
 // permission.decided.
+//
+// ToolCallID names the call this request gates. The TUI needs it because a
+// call is already stamped as started by its PreToolEvent, which fires before
+// the request goes out: without the ID no view can tell the call waiting on
+// the user apart from a batch sibling that really is executing.
 type PermGateRequest struct {
 	RequestID   string
+	ToolCallID  string
 	ToolName    string
 	Description string
 	Input       map[string]any
@@ -127,7 +134,12 @@ func (pg *PermissionGate) Check(ctx context.Context, name string, input map[stri
 
 // prompt sends a permission request to the resolver (TUI) and blocks until
 // it responds or ctx is cancelled.
+//
+// The tool call ID is taken from the context the agent stamps before Execute
+// (core.WithToolCallID), the only place that knows which call this check runs
+// for — the permission func signature carries the tool name, not the call.
 func (pg *PermissionGate) prompt(ctx context.Context, req *PermGateRequest) (bool, string) {
+	req.ToolCallID = core.ToolCallIDFromContext(ctx)
 	req.Response = make(chan PermGateResponse, 1)
 
 	select {

--- a/internal/agent/permission_test.go
+++ b/internal/agent/permission_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/tool/perm"
 )
 
@@ -128,4 +129,56 @@ func TestPermissionGateReviewerEscalatesToHuman(t *testing.T) {
 	if !<-done {
 		t.Fatal("expected the human's approval to permit")
 	}
+}
+
+// The TUI keys its "waiting on approval" row state by tool call, so a prompt
+// has to carry the ID of the call it gates. Only the execution context knows
+// it: the permission func signature carries the tool name, not the call.
+func TestPermissionGateStampsToolCallIDFromContext(t *testing.T) {
+	gate := NewPermissionGate(func(name string, args map[string]any) PermDecisionResult {
+		return PermDecisionResult{Decision: perm.Prompt, Reason: "mode: confirm writes"}
+	})
+	defer gate.Close()
+
+	ctx := core.WithToolCallID(context.Background(), "toolu_42")
+	done := make(chan bool, 1)
+	go func() {
+		allow, _ := gate.Check(ctx, "Bash", map[string]any{"command": "rm -rf build"}, false, "")
+		done <- allow
+	}()
+
+	req, ok := gate.Recv()
+	if !ok {
+		t.Fatal("permission gate closed unexpectedly")
+	}
+	if req.ToolCallID != "toolu_42" {
+		t.Fatalf("request tool call ID = %q, want the ID stamped on the execution context", req.ToolCallID)
+	}
+	req.Response <- PermGateResponse{Allow: true, Reason: "user approved"}
+	if !<-done {
+		t.Fatal("expected the approval to permit")
+	}
+}
+
+// A hook-forced prompt bypasses the decider but goes through the same gate, so
+// it must name its call too — the row it stops is stopped the same way.
+func TestPermissionGateStampsToolCallIDOnForcedPrompt(t *testing.T) {
+	gate := NewPermissionGate(func(name string, args map[string]any) PermDecisionResult {
+		return PermDecisionResult{Decision: perm.Permit, Reason: "allowed by settings"}
+	})
+	defer gate.Close()
+
+	ctx := core.WithToolCallID(context.Background(), "toolu_7")
+	go func() {
+		gate.Check(ctx, "Bash", map[string]any{"command": "git push"}, true, "explain this command")
+	}()
+
+	req, ok := gate.Recv()
+	if !ok {
+		t.Fatal("permission gate closed unexpectedly")
+	}
+	if req.ToolCallID != "toolu_7" {
+		t.Fatalf("forced prompt tool call ID = %q, want the ID stamped on the execution context", req.ToolCallID)
+	}
+	req.Response <- PermGateResponse{Allow: true, Reason: "user approved"}
 }

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -573,8 +573,13 @@ func (m *model) ContinueOutbox() tea.Cmd {
 func (m *model) HandlePermGate(req *conv.PermGateRequest) tea.Cmd {
 	m.services.Agent.SetPendingPermission(req)
 	if req == nil {
+		m.conv.Tool.ClearAwaitingApproval()
 		return nil
 	}
+	// The call was stamped as started by its PreToolEvent, which fired before
+	// this request: name it so its row reports waiting on the user while its
+	// batch siblings keep reporting the work they really are doing.
+	m.conv.Tool.MarkAwaitingApproval(req.ToolCallID)
 
 	permReq := m.preparePermissionRequest(req)
 	// Emit permission.required with the metadata about to be rendered to the

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -578,7 +578,15 @@ func (m *model) HandlePermGate(req *conv.PermGateRequest) tea.Cmd {
 	}
 	// The call was stamped as started by its PreToolEvent, which fired before
 	// this request: name it so its row reports waiting on the user while its
-	// batch siblings keep reporting the work they really are doing.
+	// batch siblings keep reporting the work they really are doing. A request
+	// with no ID names nothing, which leaves the rows on the blunt freeze the
+	// modal already forces (see conv.modalNamesNoCall) — correct, but only
+	// because it degrades, so say so rather than let a future caller lose the
+	// per-call state without a trace.
+	if req.ToolCallID == "" {
+		log.Logger().Warn("permission request carries no tool call ID; every in-flight row falls back to the docked-modal freeze",
+			zap.String("tool", req.ToolName))
+	}
 	m.conv.Tool.MarkAwaitingApproval(req.ToolCallID)
 
 	permReq := m.preparePermissionRequest(req)

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -502,16 +502,19 @@ type ToolCallsParams struct {
 	// ToolProgress maps a running command's ID to its latest output counter,
 	// shown next to the timer. Empty for calls that have produced no output.
 	ToolProgress map[string]string
-	ModelName    string
-	InputTokens  int
-	OutputTokens int
-	Blink        int
-	AgentColors  map[string]string
-	SpinnerView  string
-	TaskOwnerMap map[string]string
-	MDRenderer   *MDRenderer
-	Width        int
-	Interactive  bool
+	// AwaitingApprovalID is the call parked on a permission prompt: started by
+	// its PreToolEvent, but not allowed to run yet.
+	AwaitingApprovalID string
+	ModelName          string
+	InputTokens        int
+	OutputTokens       int
+	Blink              int
+	AgentColors        map[string]string
+	SpinnerView        string
+	TaskOwnerMap       map[string]string
+	MDRenderer         *MDRenderer
+	Width              int
+	Interactive        bool
 }
 
 // expandHints reports whether "(ctrl+o to expand)" affordances belong on this
@@ -521,6 +524,12 @@ type ToolCallsParams struct {
 // offering the hint.
 func (p ToolCallsParams) expandHints() bool {
 	return p.Interactive && !p.DockedModalActive
+}
+
+// awaitsApproval reports whether this call is the one a permission prompt is
+// asking about — started on paper, but not allowed to run yet.
+func (p ToolCallsParams) awaitsApproval(toolCallID string) bool {
+	return p.AwaitingApprovalID != "" && p.AwaitingApprovalID == toolCallID
 }
 
 // ToolResultData holds the data needed to render a tool result inline.
@@ -565,11 +574,11 @@ func RenderToolCalls(params ToolCallsParams) string {
 			if hasResult {
 				sb.WriteString(renderAgentToolLine(label, params.Width, "●", color) + "\n")
 			} else {
-				// agentIcon blinks ●/○ off the frame counter; under a docked
-				// modal it would advertise a subagent as working while the
-				// turn waits on the user, same as a spinning tool row.
+				// agentIcon blinks ●/○ off the frame counter; on the call a
+				// permission prompt is asking about that would advertise a
+				// subagent as working before it was allowed to spawn.
 				icon := agentIcon(params.Blink)
-				if params.DockedModalActive {
+				if params.awaitsApproval(tc.ID) {
 					icon = "●"
 				}
 				sb.WriteString(renderAgentToolLine(label, params.Width, icon, color))
@@ -642,21 +651,17 @@ func RenderToolCalls(params ToolCallsParams) string {
 // toolCallIcon picks a call's row glyph: the spinner while it is in flight, a
 // static bullet once it has a result or is not the call being executed.
 //
-// A docked modal freezes every row. The call it is asking about was marked
-// current and stamped as started by its PreToolEvent, which fires *before* the
-// permission request, so it would otherwise spin as if it had been allowed to
-// run. Nothing here can tell that call apart from a batch sibling that really
-// is executing (the permission gate lives inside each tool's Execute, and a
-// parallel batch runs one goroutine per call), so the freeze is deliberately
-// blunt: a row that stalls for the length of the decision beats a row that
-// claims a command is running before it was allowed to start. Distinguishing
-// them needs the pending call's identity on the permission request itself —
-// see #440.
+// The call a permission prompt is asking about was marked current and stamped
+// as started by its PreToolEvent, which fires *before* the request goes out, so
+// it holds a static bullet until it is allowed to run. Its batch siblings keep
+// spinning: the gate lives inside each tool's Execute and a parallel batch runs
+// one goroutine per call, so an allow-listed sibling really is executing while
+// the user decides.
 func toolCallIcon(tc core.ToolCall, params ToolCallsParams) string {
 	if _, done := params.ResultMap[tc.ID]; done {
 		return "●"
 	}
-	if params.DockedModalActive {
+	if params.awaitsApproval(tc.ID) {
 		return "●"
 	}
 
@@ -687,12 +692,16 @@ func toolCallIcon(tc core.ToolCall, params ToolCallsParams) string {
 // finished (its result is in) or has not started (no start stamp) gets "".
 // The stamp map only holds in-flight calls, so membership already gates this:
 // a not-yet-current sequential call has no entry and shows nothing.
+//
+// The call a permission prompt is asking about says so instead of counting: its
+// start stamp predates the prompt, so an elapsed timer there would be measuring
+// the user's own deliberation.
 func runningRowDetail(tc core.ToolCall, params ToolCallsParams) string {
 	if _, done := params.ResultMap[tc.ID]; done {
 		return ""
 	}
-	if params.DockedModalActive {
-		return ""
+	if params.awaitsApproval(tc.ID) {
+		return toolResultStyle.Render(" · waiting for approval")
 	}
 	started, ok := params.ToolStartedAt[tc.ID]
 	if !ok {

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -543,6 +543,14 @@ func (p ToolCallsParams) modalNamesNoCall() bool {
 	return p.DockedModalActive && p.AwaitingApprovalID == ""
 }
 
+// parkedOnUser reports whether this row is waiting on an answer rather than
+// doing work, so its glyph must hold instead of animating. runningRowDetail
+// takes the two cases apart rather than calling this, because only a named
+// call can say what it is waiting for.
+func (p ToolCallsParams) parkedOnUser(toolCallID string) bool {
+	return p.awaitsApproval(toolCallID) || p.modalNamesNoCall()
+}
+
 // ToolResultData holds the data needed to render a tool result inline.
 type ToolResultData struct {
 	ToolName    string
@@ -589,7 +597,7 @@ func RenderToolCalls(params ToolCallsParams) string {
 				// permission prompt is asking about that would advertise a
 				// subagent as working before it was allowed to spawn.
 				icon := agentIcon(params.Blink)
-				if params.awaitsApproval(tc.ID) || params.modalNamesNoCall() {
+				if params.parkedOnUser(tc.ID) {
 					icon = "●"
 				}
 				sb.WriteString(renderAgentToolLine(label, params.Width, icon, color))
@@ -673,7 +681,7 @@ func toolCallIcon(tc core.ToolCall, params ToolCallsParams) string {
 	if _, done := params.ResultMap[tc.ID]; done {
 		return "●"
 	}
-	if params.awaitsApproval(tc.ID) || params.modalNamesNoCall() {
+	if params.parkedOnUser(tc.ID) {
 		return "●"
 	}
 
@@ -707,10 +715,9 @@ func toolCallIcon(tc core.ToolCall, params ToolCallsParams) string {
 //
 // The call a permission prompt is asking about says so instead of counting: its
 // start stamp predates the prompt, so an elapsed timer there would be measuring
-// the user's own deliberation. Under a modal that names no call the same is
-// true of every in-flight row, but nothing here knows which one is parked, so
-// they drop the detail rather than claim to be waiting for an approval nobody
-// asked for.
+// the user's own deliberation. A row frozen by modalNamesNoCall drops the
+// detail instead — it is just as parked, but claiming to wait for an approval
+// would name one nobody asked for.
 func runningRowDetail(tc core.ToolCall, params ToolCallsParams) string {
 	if _, done := params.ResultMap[tc.ID]; done {
 		return ""

--- a/internal/app/conv/message.go
+++ b/internal/app/conv/message.go
@@ -532,6 +532,17 @@ func (p ToolCallsParams) awaitsApproval(toolCallID string) bool {
 	return p.AwaitingApprovalID != "" && p.AwaitingApprovalID == toolCallID
 }
 
+// modalNamesNoCall reports whether a docked modal owns the screen without
+// naming the call it is parked on: a Question or a secret prompt, which stop a
+// call just as a permission request does but have no ID to hand over, or a
+// permission request that somehow arrived without one. Nothing here can tell
+// which in-flight row the user is deciding about, so every row falls back to
+// the blunt freeze — a row that stalls for the length of the answer beats a row
+// claiming a call is running when it is parked on the user (#440).
+func (p ToolCallsParams) modalNamesNoCall() bool {
+	return p.DockedModalActive && p.AwaitingApprovalID == ""
+}
+
 // ToolResultData holds the data needed to render a tool result inline.
 type ToolResultData struct {
 	ToolName    string
@@ -578,7 +589,7 @@ func RenderToolCalls(params ToolCallsParams) string {
 				// permission prompt is asking about that would advertise a
 				// subagent as working before it was allowed to spawn.
 				icon := agentIcon(params.Blink)
-				if params.awaitsApproval(tc.ID) {
+				if params.awaitsApproval(tc.ID) || params.modalNamesNoCall() {
 					icon = "●"
 				}
 				sb.WriteString(renderAgentToolLine(label, params.Width, icon, color))
@@ -656,12 +667,13 @@ func RenderToolCalls(params ToolCallsParams) string {
 // it holds a static bullet until it is allowed to run. Its batch siblings keep
 // spinning: the gate lives inside each tool's Execute and a parallel batch runs
 // one goroutine per call, so an allow-listed sibling really is executing while
-// the user decides.
+// the user decides. A modal that names no call still freezes every row —
+// see modalNamesNoCall.
 func toolCallIcon(tc core.ToolCall, params ToolCallsParams) string {
 	if _, done := params.ResultMap[tc.ID]; done {
 		return "●"
 	}
-	if params.awaitsApproval(tc.ID) {
+	if params.awaitsApproval(tc.ID) || params.modalNamesNoCall() {
 		return "●"
 	}
 
@@ -695,13 +707,19 @@ func toolCallIcon(tc core.ToolCall, params ToolCallsParams) string {
 //
 // The call a permission prompt is asking about says so instead of counting: its
 // start stamp predates the prompt, so an elapsed timer there would be measuring
-// the user's own deliberation.
+// the user's own deliberation. Under a modal that names no call the same is
+// true of every in-flight row, but nothing here knows which one is parked, so
+// they drop the detail rather than claim to be waiting for an approval nobody
+// asked for.
 func runningRowDetail(tc core.ToolCall, params ToolCallsParams) string {
 	if _, done := params.ResultMap[tc.ID]; done {
 		return ""
 	}
 	if params.awaitsApproval(tc.ID) {
 		return toolResultStyle.Render(" · waiting for approval")
+	}
+	if params.modalNamesNoCall() {
+		return ""
 	}
 	started, ok := params.ToolStartedAt[tc.ID]
 	if !ok {

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -1372,10 +1372,10 @@ func TestRenderDecision(t *testing.T) {
 	}
 }
 
-// A docked modal parks the turn on the user's answer, so an Agent row must
-// hold its glyph instead of blinking ●/○ off the frame counter — a blink reads
-// as a subagent working while the user decides whether to let it start.
-func TestRenderToolCallsFreezesAgentRowUnderDockedModal(t *testing.T) {
+// An Agent call waiting on its permission prompt must hold its glyph instead
+// of blinking ●/○ off the frame counter — a blink reads as a subagent working
+// while the user is still deciding whether to let it spawn.
+func TestRenderToolCallsFreezesAgentRowAwaitingApproval(t *testing.T) {
 	call := core.ToolCall{ID: "tc-1", Name: tool.ToolAgent, Input: `{"agent":"reviewer","prompt":"review it"}`}
 	params := ToolCallsParams{
 		ToolCalls:    []core.ToolCall{call},
@@ -1388,26 +1388,78 @@ func TestRenderToolCallsFreezesAgentRowUnderDockedModal(t *testing.T) {
 	}
 
 	// agentIcon flips every agentBlinkTicks frames; both phases must render
-	// the same static bullet once the modal is up.
+	// the same static bullet once the prompt is up.
 	for _, blink := range []int{0, agentBlinkTicks} {
 		params.Blink = blink
 		live := stripANSI(RenderToolCalls(params))
 		if !strings.Contains(live, agentIcon(blink)) {
-			t.Fatalf("blink %d: RenderToolCalls() = %q, want the blinking icon while no modal is up", blink, live)
+			t.Fatalf("blink %d: RenderToolCalls() = %q, want the blinking icon while the call runs unprompted", blink, live)
 		}
 
-		params.DockedModalActive = true
+		params.AwaitingApprovalID = call.ID
 		frozen := stripANSI(RenderToolCalls(params))
-		params.DockedModalActive = false
+		params.AwaitingApprovalID = ""
 
 		if !strings.Contains(frozen, "●") {
-			t.Fatalf("blink %d: RenderToolCalls() = %q, want a static bullet under the modal", blink, frozen)
+			t.Fatalf("blink %d: RenderToolCalls() = %q, want a static bullet while the call waits on approval", blink, frozen)
 		}
 		if strings.Contains(frozen, "○") {
-			t.Fatalf("blink %d: RenderToolCalls() = %q, agent row still blinks under the modal", blink, frozen)
+			t.Fatalf("blink %d: RenderToolCalls() = %q, agent row still blinks while it waits on approval", blink, frozen)
 		}
-		if strings.Contains(frozen, "ctrl+o") {
-			t.Fatalf("blink %d: RenderToolCalls() = %q, ctrl+o hint is dead while the modal owns the keyboard", blink, frozen)
-		}
+	}
+}
+
+// The ctrl+o affordance is dead while a docked modal owns the keyboard: every
+// key goes to the overlay, so the hint points at a shortcut that cannot reach
+// the row offering it. That freeze is about keyboard ownership, not about which
+// call is waiting, so it stays on the modal flag.
+func TestRenderToolCallsDropsExpandHintUnderDockedModal(t *testing.T) {
+	call := core.ToolCall{ID: "tc-1", Name: tool.ToolAgent, Input: `{"agent":"reviewer","prompt":"review it"}`}
+	params := ToolCallsParams{
+		ToolCalls:         []core.ToolCall{call},
+		ResultMap:         map[string]ToolResultData{},
+		PendingCalls:      []core.ToolCall{call},
+		SpinnerView:       "⋯",
+		Width:             100,
+		Interactive:       true,
+		DockedModalActive: true,
+	}
+
+	if got := stripANSI(RenderToolCalls(params)); strings.Contains(got, "ctrl+o") {
+		t.Fatalf("RenderToolCalls() = %q, ctrl+o hint is dead while the modal owns the keyboard", got)
+	}
+}
+
+// A permission prompt stops the call it is asking about, not the batch. The
+// gated row says what it is waiting for; the sibling that was allowed to run
+// keeps its spinner and its timer, because it really is executing.
+func TestRenderToolCallsSeparatesAwaitingCallFromRunningSibling(t *testing.T) {
+	gated := core.ToolCall{ID: "tc-1", Name: "Bash", Input: `{"command":"rm -rf build"}`}
+	running := core.ToolCall{ID: "tc-2", Name: "Bash", Input: `{"command":"npm test"}`}
+	batch := []core.ToolCall{gated, running}
+	params := ToolCallsParams{
+		ToolCalls:    batch,
+		ResultMap:    map[string]ToolResultData{},
+		ParallelMode: true,
+		PendingCalls: batch,
+		SpinnerView:  "⋯",
+		Width:        100,
+		// Both were stamped by their PreToolEvent before the prompt went out.
+		ToolStartedAt: map[string]time.Time{
+			"tc-1": time.Now().Add(-9 * time.Second),
+			"tc-2": time.Now().Add(-9 * time.Second),
+		},
+		AwaitingApprovalID: gated.ID,
+	}
+
+	rendered := stripANSI(RenderToolCalls(params))
+	if !strings.Contains(rendered, "● Bash(rm -rf build) · waiting for approval") {
+		t.Fatalf("RenderToolCalls() = %q, want the gated row to report waiting instead of running", rendered)
+	}
+	if strings.Contains(rendered, "Bash(rm -rf build) · 9s") {
+		t.Fatalf("RenderToolCalls() = %q, gated row is timing the user's deliberation", rendered)
+	}
+	if !strings.Contains(rendered, "⋯ Bash(npm test) · 9s") {
+		t.Fatalf("RenderToolCalls() = %q, want the sibling that was allowed to run to keep spinning and ticking", rendered)
 	}
 }

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -1463,3 +1463,46 @@ func TestRenderToolCallsSeparatesAwaitingCallFromRunningSibling(t *testing.T) {
 		t.Fatalf("RenderToolCalls() = %q, want the sibling that was allowed to run to keep spinning and ticking", rendered)
 	}
 }
+
+// Not every docked modal names a call: an AskUserQuestion prompt parks the call
+// that asked it just as hard as a permission request does, but carries no tool
+// call ID. With nothing to name, the rows keep the blunt freeze — otherwise the
+// asked call spins and ticks the user's answer time, which is #440 by another
+// route.
+func TestRenderToolCallsFreezesEveryRowUnderModalNamingNoCall(t *testing.T) {
+	asking := core.ToolCall{ID: "tc-1", Name: "AskUserQuestion", Input: `{"questions":[]}`}
+	agentCall := core.ToolCall{ID: "tc-2", Name: tool.ToolAgent, Input: `{"agent":"reviewer","prompt":"review it"}`}
+	batch := []core.ToolCall{asking, agentCall}
+	params := ToolCallsParams{
+		ToolCalls:    batch,
+		ResultMap:    map[string]ToolResultData{},
+		ParallelMode: true,
+		PendingCalls: batch,
+		SpinnerView:  "⋯",
+		Width:        100,
+		ToolStartedAt: map[string]time.Time{
+			"tc-1": time.Now().Add(-9 * time.Second),
+			"tc-2": time.Now().Add(-9 * time.Second),
+		},
+		// The question modal owns the screen, and no permission request named
+		// a call.
+		DockedModalActive: true,
+	}
+
+	for _, blink := range []int{0, agentBlinkTicks} {
+		params.Blink = blink
+		rendered := stripANSI(RenderToolCalls(params))
+		if strings.Contains(rendered, "⋯") {
+			t.Fatalf("blink %d: RenderToolCalls() = %q, a row spins while the modal owns the screen", blink, rendered)
+		}
+		if strings.Contains(rendered, "· 9s") {
+			t.Fatalf("blink %d: RenderToolCalls() = %q, a row is timing the user's answer", blink, rendered)
+		}
+		if strings.Contains(rendered, "waiting for approval") {
+			t.Fatalf("blink %d: RenderToolCalls() = %q, no approval was asked for", blink, rendered)
+		}
+		if strings.Contains(rendered, "○") {
+			t.Fatalf("blink %d: RenderToolCalls() = %q, agent row still blinks under the modal", blink, rendered)
+		}
+	}
+}

--- a/internal/app/conv/tool.go
+++ b/internal/app/conv/tool.go
@@ -28,8 +28,13 @@ type ToolExecState struct {
 	// lines"), keyed by tool-call ID — the replaceable companion to the
 	// elapsed timer, showing output is actually flowing. Cleared with StartedAt.
 	Progress map[string]string
-	Ctx      context.Context
-	Cancel   context.CancelFunc
+	// AwaitingApprovalID is the tool call parked on the permission modal. Its
+	// PreToolEvent already stamped it as started, so without this the row would
+	// spin and tick as if the call had been allowed to run. Empty while no
+	// permission request is open.
+	AwaitingApprovalID string
+	Ctx                context.Context
+	Cancel             context.CancelFunc
 }
 
 func (t *ToolExecState) Begin() context.Context {
@@ -54,6 +59,7 @@ func (t *ToolExecState) Reset() {
 	t.ClearPending()
 	t.StartedAt = nil
 	t.Progress = nil
+	t.AwaitingApprovalID = ""
 	t.Ctx = nil
 	t.Cancel = nil
 }
@@ -61,6 +67,7 @@ func (t *ToolExecState) Reset() {
 func (t *ToolExecState) Track(calls []core.ToolCall) {
 	t.StartedAt = nil
 	t.Progress = nil
+	t.AwaitingApprovalID = ""
 	if len(calls) == 0 {
 		t.ClearPending()
 		return
@@ -79,12 +86,29 @@ func (t *ToolExecState) MarkCurrent(toolCallID string) {
 }
 
 // MarkStarted stamps the moment a tool call began executing, so the view can
-// show how long it has been running. Called once per call, on its PreToolEvent.
+// show how long it has been running. Called on its PreToolEvent, and again
+// when a permission prompt is approved — the first stamp then covers only how
+// long the user took to answer, which is not what the row is reporting.
 func (t *ToolExecState) MarkStarted(toolCallID string) {
+	if toolCallID == "" {
+		return
+	}
 	if t.StartedAt == nil {
 		t.StartedAt = make(map[string]time.Time)
 	}
 	t.StartedAt[toolCallID] = time.Now()
+}
+
+// MarkAwaitingApproval records the call whose permission request is open, so
+// its row reports waiting rather than running. Only one request is on screen
+// at a time; a later one replaces it.
+func (t *ToolExecState) MarkAwaitingApproval(toolCallID string) {
+	t.AwaitingApprovalID = toolCallID
+}
+
+// ClearAwaitingApproval drops the waiting state once the request is answered.
+func (t *ToolExecState) ClearAwaitingApproval() {
+	t.AwaitingApprovalID = ""
 }
 
 // SetProgress records the latest output counter for a running tool call. A blank

--- a/internal/app/conv/update_test.go
+++ b/internal/app/conv/update_test.go
@@ -93,3 +93,46 @@ func TestMarkToolCallCompleteAdvancesAndClearsPendingState(t *testing.T) {
 		t.Fatalf("CurrentIdx = %d, want 0", state.CurrentIdx)
 	}
 }
+
+// A gated call carries its PreToolEvent stamp through the whole permission
+// prompt, so approving it has to restamp — otherwise the row's elapsed timer
+// reports the user's deliberation as execution time (issue #440).
+func TestApprovalRestampsGatedCallAndClearsWaiting(t *testing.T) {
+	state := ToolExecState{}
+	state.Track([]core.ToolCall{{ID: "tc-1", Name: "Bash"}})
+
+	state.MarkCurrent("tc-1")
+	state.MarkStarted("tc-1")
+	state.MarkAwaitingApproval("tc-1")
+	prompted := state.StartedAt["tc-1"]
+
+	// The user takes a while to answer, then approves.
+	state.ClearAwaitingApproval()
+	state.MarkStarted("tc-1")
+
+	if state.AwaitingApprovalID != "" {
+		t.Fatalf("AwaitingApprovalID = %q, want it cleared once the request is answered", state.AwaitingApprovalID)
+	}
+	if !state.StartedAt["tc-1"].After(prompted) {
+		t.Fatal("approving a gated call must restamp it, or its timer counts the wait for the user")
+	}
+}
+
+// The waiting state belongs to one batch: a new one (or a cancelled turn) must
+// not leave a row of the next batch marked as parked on an answered prompt.
+func TestTrackAndResetClearWaitingState(t *testing.T) {
+	state := ToolExecState{}
+	state.Track([]core.ToolCall{{ID: "tc-1", Name: "Bash"}})
+	state.MarkAwaitingApproval("tc-1")
+
+	state.Track([]core.ToolCall{{ID: "tc-2", Name: "Bash"}})
+	if state.AwaitingApprovalID != "" {
+		t.Fatalf("AwaitingApprovalID = %q, want a new batch to start with nothing waiting", state.AwaitingApprovalID)
+	}
+
+	state.MarkAwaitingApproval("tc-2")
+	state.Reset()
+	if state.AwaitingApprovalID != "" {
+		t.Fatalf("AwaitingApprovalID = %q, want a reset turn to leave nothing waiting", state.AwaitingApprovalID)
+	}
+}

--- a/internal/app/conv/view.go
+++ b/internal/app/conv/view.go
@@ -32,6 +32,10 @@ type RenderContext struct {
 	// ToolProgress maps a running command's ID to its latest output counter
 	// ("1.2k lines"), shown next to the timer. Empty for calls with no output.
 	ToolProgress map[string]string
+	// AwaitingApprovalID is the in-flight call parked on a permission prompt.
+	// It was stamped as started before the prompt went out, so its row has to
+	// be told apart from the siblings that really are executing.
+	AwaitingApprovalID string
 
 	// ── Renderer / terminal env ─────────────────────────────────
 	Width      int
@@ -257,26 +261,27 @@ func renderAssistantWithTools(p RenderContext, msg core.ChatMessage, idx int, is
 	}
 
 	sb.WriteString(RenderToolCalls(ToolCallsParams{
-		ToolCalls:         msg.ToolCalls,
-		ToolCallsExpanded: msg.ToolCallsExpanded,
-		ResultMap:         resultMap,
-		ParallelMode:      len(p.PendingCalls) > 1,
-		DockedModalActive: p.DockedModalActive,
-		TaskActivity:      p.TaskActivity,
-		PendingCalls:      p.PendingCalls,
-		CurrentIdx:        p.CurrentIdx,
-		ToolStartedAt:     p.ToolStartedAt,
-		ToolProgress:      p.ToolProgress,
-		ModelName:         p.ModelName,
-		InputTokens:       p.InputTokens,
-		OutputTokens:      p.OutputTokens,
-		Blink:             p.Blink,
-		AgentColors:       p.AgentColors,
-		SpinnerView:       p.SpinnerView,
-		TaskOwnerMap:      p.TaskOwnerMap,
-		MDRenderer:        p.MDRenderer,
-		Width:             p.Width,
-		Interactive:       p.Interactive,
+		ToolCalls:          msg.ToolCalls,
+		ToolCallsExpanded:  msg.ToolCallsExpanded,
+		ResultMap:          resultMap,
+		ParallelMode:       len(p.PendingCalls) > 1,
+		DockedModalActive:  p.DockedModalActive,
+		TaskActivity:       p.TaskActivity,
+		PendingCalls:       p.PendingCalls,
+		CurrentIdx:         p.CurrentIdx,
+		ToolStartedAt:      p.ToolStartedAt,
+		ToolProgress:       p.ToolProgress,
+		AwaitingApprovalID: p.AwaitingApprovalID,
+		ModelName:          p.ModelName,
+		InputTokens:        p.InputTokens,
+		OutputTokens:       p.OutputTokens,
+		Blink:              p.Blink,
+		AgentColors:        p.AgentColors,
+		SpinnerView:        p.SpinnerView,
+		TaskOwnerMap:       p.TaskOwnerMap,
+		MDRenderer:         p.MDRenderer,
+		Width:              p.Width,
+		Interactive:        p.Interactive,
 	}))
 
 	return sb.String()

--- a/internal/app/update_approval.go
+++ b/internal/app/update_approval.go
@@ -62,9 +62,14 @@ func (m *model) handlePermGateDecision(decision permissionDecision) tea.Cmd {
 	if req == nil {
 		return nil
 	}
+	m.conv.Tool.ClearAwaitingApproval()
 	reason := "user denied"
 	if decision.Approved {
 		reason = "user approved"
+		// Restamp: the call has been sitting on its PreToolEvent stamp since
+		// before the prompt went up, so the row's elapsed timer would otherwise
+		// report how long the user deliberated as execution time.
+		m.conv.Tool.MarkStarted(req.ToolCallID)
 		if decision.AllowAll && m.env.SessionPermissions != nil && decision.Request != nil {
 			m.env.SessionPermissions.AllowTool(decision.Request.ToolName)
 		}

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -385,12 +385,13 @@ func (m model) messageRenderParams() conv.RenderContext {
 		InlinedResults: conv.PrecomputeInlinedResults(m.conv.Messages, m.conv.CommittedCount),
 
 		// Streaming + tool execution
-		StreamActive:  m.conv.Stream.Active,
-		BuildingTool:  m.conv.Stream.BuildingTool,
-		PendingCalls:  m.conv.Tool.PendingCalls,
-		CurrentIdx:    m.conv.Tool.CurrentIdx,
-		ToolStartedAt: m.conv.Tool.StartedAt,
-		ToolProgress:  m.conv.Tool.Progress,
+		StreamActive:       m.conv.Stream.Active,
+		BuildingTool:       m.conv.Stream.BuildingTool,
+		PendingCalls:       m.conv.Tool.PendingCalls,
+		CurrentIdx:         m.conv.Tool.CurrentIdx,
+		ToolStartedAt:      m.conv.Tool.StartedAt,
+		ToolProgress:       m.conv.Tool.Progress,
+		AwaitingApprovalID: m.conv.Tool.AwaitingApprovalID,
 
 		// Renderer env
 		Width:      m.env.Width,

--- a/internal/app/view_test.go
+++ b/internal/app/view_test.go
@@ -217,6 +217,39 @@ func TestHandlePermGateMarksTheCallItAsksAbout(t *testing.T) {
 	}
 }
 
+// A request with no call ID names nothing, so the per-call state has to stay
+// empty rather than hold a stale ID — that is what puts the rows back on the
+// docked-modal freeze instead of leaving the gated call spinning over the
+// user's deliberation. Unreachable on the main agent path today, but it is the
+// seam that would degrade first.
+func TestHandlePermGateWithoutCallIDFallsBackToTheModalFreeze(t *testing.T) {
+	m := dockedModalModel(t, "about to check the disk")
+	m.services.Agent = &agent.Session{}
+	m.services.Session = &session.Setup{}
+	spinnerGlyph := ansi.Strip(m.conv.Spinner.View())
+
+	m.HandlePermGate(&conv.PermGateRequest{
+		RequestID:   "req-1",
+		ToolName:    "Bash",
+		Description: "check disk",
+		Input:       map[string]any{"command": "df -h"},
+	})
+
+	if got := m.conv.Tool.AwaitingApprovalID; got != "" {
+		t.Fatalf("awaiting call = %q, want no call named when the request carries no ID", got)
+	}
+
+	frame, _ := m.viewString()
+	for line := range strings.SplitSeq(ansi.Strip(frame), "\n") {
+		if !strings.Contains(line, "Bash(") {
+			continue
+		}
+		if strings.Contains(line, spinnerGlyph) {
+			t.Fatalf("tool row %q spins while the modal owns the screen", line)
+		}
+	}
+}
+
 // The stream stays open across a permission gate, so the assistant message
 // carrying the rationale still counts as the live tail. Its bullet must not
 // spin either — the turn is parked on the modal, not producing text.

--- a/internal/app/view_test.go
+++ b/internal/app/view_test.go
@@ -7,9 +7,11 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
 
+	"github.com/genai-io/san/internal/agent"
 	"github.com/genai-io/san/internal/app/conv"
 	"github.com/genai-io/san/internal/app/input"
 	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/session"
 	"github.com/genai-io/san/internal/subagent"
 	"github.com/genai-io/san/internal/todo"
 	"github.com/genai-io/san/internal/tool"
@@ -116,6 +118,9 @@ func dockedModalModelWithCalls(t *testing.T, rationale string, batch []core.Tool
 		m.conv.Tool.MarkCurrent(call.ID)
 		m.conv.Tool.MarkStarted(call.ID)
 	}
+	// What HandlePermGate records when the request lands: the modal is asking
+	// about the first call, not the batch.
+	m.conv.Tool.MarkAwaitingApproval(batch[0].ID)
 
 	m.userInput.Approval.Show(&perm.PermissionRequest{
 		ID:          "req-1",
@@ -165,31 +170,50 @@ func TestDockedModalStaysWithinTerminalHeight(t *testing.T) {
 }
 
 // PreTool stamps a call before the permission request, so the in-flight state
-// is live while the user decides. No row may spin: the call being approved has
-// not been allowed to start, and its batch siblings are stuck behind the same
-// answer.
-func TestDockedModalDoesNotShowPendingCallsAsRunning(t *testing.T) {
+// is live while the user decides. The call the modal is asking about has not
+// been allowed to start: its row must say so rather than spin and tick an
+// elapsed timer over the user's deliberation (issue #440).
+func TestDockedModalDoesNotShowTheGatedCallAsRunning(t *testing.T) {
 	m := dockedModalModel(t, "about to check the disk")
 	spinnerGlyph := ansi.Strip(m.conv.Spinner.View())
 
 	frame, _ := m.viewString()
 
-	rows := map[string]string{}
+	var row string
 	for line := range strings.SplitSeq(ansi.Strip(frame), "\n") {
-		for _, cmd := range []string{"df -h", "date"} {
-			if strings.Contains(line, "Bash("+cmd+")") {
-				rows[cmd] = line
-			}
+		if strings.Contains(line, "Bash(df -h)") {
+			row = line
 		}
 	}
-	for _, cmd := range []string{"df -h", "date"} {
-		row, ok := rows[cmd]
-		if !ok {
-			t.Fatalf("modal frame has no row for %q:\n%s", cmd, frame)
-		}
-		if strings.Contains(row, spinnerGlyph) {
-			t.Fatalf("tool row %q spins while the batch waits on the approval modal", row)
-		}
+	if row == "" {
+		t.Fatalf("modal frame has no row for the gated call:\n%s", frame)
+	}
+	if strings.Contains(row, spinnerGlyph) {
+		t.Fatalf("tool row %q spins while it waits on the approval modal", row)
+	}
+	if !strings.Contains(row, "waiting for approval") {
+		t.Fatalf("tool row %q does not say what it is waiting for", row)
+	}
+}
+
+// The awaiting state is keyed by tool call, so the request has to carry the ID
+// of the call it gates — the whole point of routing it through the modal.
+func TestHandlePermGateMarksTheCallItAsksAbout(t *testing.T) {
+	m := dockedModalModel(t, "about to check the disk")
+	m.services.Agent = &agent.Session{}
+	m.services.Session = &session.Setup{}
+	m.conv.Tool.ClearAwaitingApproval()
+
+	m.HandlePermGate(&conv.PermGateRequest{
+		RequestID:   "req-1",
+		ToolCallID:  "bash-1",
+		ToolName:    "Bash",
+		Description: "check disk",
+		Input:       map[string]any{"command": "df -h"},
+	})
+
+	if got := m.conv.Tool.AwaitingApprovalID; got != "bash-1" {
+		t.Fatalf("awaiting call = %q, want the call the request gates", got)
 	}
 }
 


### PR DESCRIPTION
Fixes #440.

## Problem

`applyPreTool` stamps a tool call as started (`MarkCurrent` + `MarkStarted`) on its `PreToolEvent`, which the agent emits in the *resolve* phase — before the tool's `Execute` runs, and therefore before the permission request goes out. A gated call was already "running" as far as the view was concerned:

- its row spun with a live elapsed timer while the user was still deciding, so the timer measured deliberation, not execution;
- nothing in the render path could tell that call apart from a batch sibling that really was executing — the permission gate lives inside each tool's `Execute`, and a parallel batch runs one goroutine per call.

#437 worked around it by freezing *every* in-flight row while a docked modal is up (`RenderContext.DockedModalActive`). In a mixed batch `[A allow-listed, B prompts]`, A genuinely runs while B's modal is open, but A's row showed a static bullet with no timer until B was answered.

## Fix

Give the pending call an identity on the permission request, so the view can name exactly which row is waiting:

- `PermGateRequest` carries `ToolCallID`, stamped in `prompt()` from the context the agent puts on every call (`core.WithToolCallID`) — the permission func signature carries the tool name, not the call. Both entry points get it: the normal decider path and a hook-forced prompt.
- `HandlePermGate` records it as `ToolExecState.AwaitingApprovalID`; `handlePermGateDecision` clears it, and on approval calls `MarkStarted` again so the row's timer measures execution instead of the wait for an answer.
- `toolCallIcon` / `runningRowDetail` and the Agent row's blink consult that state. The gated row holds a static bullet and says `· waiting for approval`; siblings that were allowed to run keep spinning and ticking.
- The state is per batch: `Track` and `Reset` clear it, so a new batch or a cancelled turn never inherits a stale waiting row.

Naming a call is precise but not universal, so the blanket freeze stays as the fallback rather than being dropped (`modalNamesNoCall`): when a docked modal is up and **no** call is named, every in-flight row holds still exactly as it did before this PR — static bullet, no row detail, no blinking Agent row, and no "waiting for approval" claim nobody made. That covers the modals that park a call without having an ID to hand over — an `AskUserQuestion` prompt is the live case, a secret prompt the other — and doubles as the safety net for a permission request that somehow arrives with an empty `ToolCallID` (`HandlePermGate` logs that case, so the degradation is visible rather than silent).

`DockedModalActive` keeps the two freezes that really are about the modal: the assistant bullet (the turn is parked on the answer) and the `(ctrl+o to expand)` hint (the overlay owns the keyboard).

The scrollback concern in the issue comes along for free: every render path — live view, `renderAndCommit`, background flush — builds its params through `messageRenderParams`, so a resize reflow or compact reprint while a prompt is open now commits the waiting state rather than a spinner frame for a call that was never allowed to start.

## Not covered

The fallback is a stopgap, not the design: only the permission modal names its call, so a genuinely running sibling still freezes while an `AskUserQuestion` is open. The deeper fix — thread the call ID through every docked modal, at which point the fallback stops firing on its own — is #453; the ID is already in the context at each of those seams, it just isn't forwarded.

A call *queued* behind an open prompt is still drawn as running. Two shapes reach it: a second gated call in a parallel batch, whose request is sitting in the gate channel the TUI has not polled yet; and later calls of a sequential batch, which the view already renders as in flight whenever a batch has more than one call (`ParallelMode: len(PendingCalls) > 1`). Both predate this change and need the agent to tell the UI which calls actually began executing — worth a separate issue.

## Tests

- `internal/agent`: the gate stamps `ToolCallID` from the execution context, on the decider path and on a hook-forced prompt.
- `internal/app/conv`: a gated row reports waiting while its running sibling keeps its spinner and timer; an Agent row awaiting approval stops blinking; a docked modal that names no call freezes every row without claiming an approval was asked for; approving restamps the call and clears the waiting state; `Track`/`Reset` clear it.
- `internal/app`: the modal frame no longer shows the gated call as running, `HandlePermGate` marks the call its request names, and a request with no ID leaves the per-call state empty so the rows fall back to the modal freeze. The `ctrl+o` freeze keeps its own test on the modal flag.

Manual check: run a `Bash` call that prompts, leave the modal up for ~20s, approve — the row starts its timer at approval instead of showing 20s+.
