### PR TITLE
fix(tui): keep the input separators one column short of the terminal

### DIFF
--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -51,7 +51,14 @@ func (m *model) viewString() (string, *tea.Cursor) {
 		return ov.Render(), nil // fullscreen slash-command picker
 	}
 
-	separator := conv.SeparatorStyle.Render(strings.Repeat("─", m.env.Width))
+	// One column short of the terminal, deliberately. A row written to the last
+	// column leaves the terminal in the deferred-wrap state — the cursor parks
+	// on column W with the line break owed rather than taken — and whether the
+	// renderer's later cursor-up counts that row depends on when the terminal
+	// settles the debt. The separators are the only full-width rows in the live
+	// view, so they were the only ones that could land on that ambiguity, which
+	// showed up as leftover rule rows above the composer after a resize.
+	separator := conv.SeparatorStyle.Render(strings.Repeat("─", max(1, m.env.Width-1)))
 	trackerView := m.renderTrackerList()
 
 	if hasOverlay { // docked modal (Question / Approval)


### PR DESCRIPTION
Resizing the terminal left orphaned rule rows above the composer — the two separators around the input strip appeared to multiply.

A row written to the last column leaves the terminal in the deferred-wrap state: the cursor parks on column W with the line break owed rather than taken, and whether the renderer's later cursor-up counts that row depends on when the terminal settles the debt. Those separators were the only full-width rows in the live view, so they were the only ones that could land on that ambiguity.

Measured over 24 tmux resize runs per variant (`120 -> 140 -> 60 -> 100 -> 75 -> 120`, sampled after the size settles), a leftover rule row survived 14 times at full width and 7 times one column short. The run-to-run spread is wide enough that the difference is suggestive rather than established — the change stands on removing a real ambiguity at no cost.

The remainder is upstream: bubbletea's inline renderer loses row accounting when the terminal reflows the live region (charmbracelet/bubbletea#717, still open). The maintainers' answer on the v2 report (#1567) is to use the alt screen, which San can't do — it commits finished output to native scrollback by design.