### PR TITLE
fix: keep the inlined image path resolvable, and honor ProcessImageRefs' error contract

### DIFF
--- a/internal/app/input/on_textarea.go
+++ b/internal/app/input/on_textarea.go
@@ -316,11 +316,10 @@ func LeadingImagePath(cwd, input string) string {
 // from the text, mirroring @-prefixed behavior — otherwise the leading path
 // would reach the agent as text that reads like an unknown command.
 //
-// An error still comes with usable content: the text that survived the failure,
-// and the images that did load. A caller with somewhere to hand the turn back
-// to (buildUserMessage returns it to the textarea) can ignore both and abort; a
-// caller that has to send something anyway (releaseQueuedMessage runs
-// mid-stream) sends what resolved instead of the raw text.
+// An error still comes with usable content: the text and images returned are
+// what survived the failure. A caller with somewhere to hand the turn back to
+// can ignore both and abort; one that has to send something anyway sends what
+// resolved instead of the raw text.
 func ProcessImageRefs(cwd, input string) (string, []core.Image, error) {
 	content := input
 	var images []core.Image
@@ -340,17 +339,12 @@ func ProcessImageRefs(cwd, input string) (string, []core.Image, error) {
 		}
 		img, err := image.Load(absPath)
 		if err != nil {
-			// The @ was deliberate, so the failure aborts the send. The text is
-			// handed back untouched: nothing has been consumed from it yet, and
-			// a caller that must send anyway should send what the user wrote.
-			return strings.TrimSpace(content), images, fmt.Errorf("loading image %s: %w", absPath, err)
+			return strings.TrimSpace(stripRefs(content, loadedRefs)), images, fmt.Errorf("loading image %s: %w", absPath, err)
 		}
 		images = append(images, img)
 		loadedRefs = append(loadedRefs, match[0])
 	}
-	for _, ref := range loadedRefs {
-		content = strings.ReplaceAll(content, ref, "")
-	}
+	content = stripRefs(content, loadedRefs)
 
 	// Step 2: Process bare image file paths (drag-drop, absolute paths, etc.)
 	// Keep the text in the message, skip silently on load failure, unless
@@ -395,11 +389,18 @@ func ProcessImageRefs(cwd, input string) (string, []core.Image, error) {
 }
 
 // stripLeadingPath drops the leading image-path token from a prompt, leaving
-// the rest of it. leadPath came from LeadingImagePath on this same content, so
-// it is the first token of the trimmed text; TrimPrefix rather than a slice so
-// that stops being an assumption the function can panic on.
+// the rest of it.
 func stripLeadingPath(content, leadPath string) string {
 	return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(content), leadPath))
+}
+
+// stripRefs drops the @-references that were consumed as images, so the text a
+// caller gets back — on the error path too — is the text that survived.
+func stripRefs(content string, refs []string) string {
+	for _, ref := range refs {
+		content = strings.ReplaceAll(content, ref, "")
+	}
+	return content
 }
 
 // PastePlaceholder returns the placeholder text displayed in the textarea for a pasted chunk.

--- a/internal/app/input/on_textarea.go
+++ b/internal/app/input/on_textarea.go
@@ -315,6 +315,12 @@ func LeadingImagePath(cwd, input string) string {
 // (an "upload first" paste), it is consumed as an image reference and removed
 // from the text, mirroring @-prefixed behavior — otherwise the leading path
 // would reach the agent as text that reads like an unknown command.
+//
+// An error still comes with usable content: the text that survived the failure,
+// and the images that did load. A caller with somewhere to hand the turn back
+// to (buildUserMessage returns it to the textarea) can ignore both and abort; a
+// caller that has to send something anyway (releaseQueuedMessage runs
+// mid-stream) sends what resolved instead of the raw text.
 func ProcessImageRefs(cwd, input string) (string, []core.Image, error) {
 	content := input
 	var images []core.Image
@@ -334,7 +340,10 @@ func ProcessImageRefs(cwd, input string) (string, []core.Image, error) {
 		}
 		img, err := image.Load(absPath)
 		if err != nil {
-			return "", nil, fmt.Errorf("loading image %s: %w", absPath, err)
+			// The @ was deliberate, so the failure aborts the send. The text is
+			// handed back untouched: nothing has been consumed from it yet, and
+			// a caller that must send anyway should send what the user wrote.
+			return strings.TrimSpace(content), images, fmt.Errorf("loading image %s: %w", absPath, err)
 		}
 		images = append(images, img)
 		loadedRefs = append(loadedRefs, match[0])
@@ -363,15 +372,10 @@ func ProcessImageRefs(cwd, input string) (string, []core.Image, error) {
 		if err != nil {
 			if !leadingConsumed && leadPath == path {
 				// The leading image path exists (stat passed) but failed to load
-				// (e.g. oversized or corrupt). Consume it from the text so the
-				// agent doesn't see the bare path as an unknown command.
-				leadingConsumed = true
-				// Strip the leading path from content before returning the error,
-				// so the caller can surface a notice while the remaining text
-				// survives.
-				trimmed := strings.TrimSpace(content)
-				content = strings.TrimSpace(trimmed[len(leadPath):])
-				return strings.TrimSpace(content), images, fmt.Errorf("loading image %s: %w", absPath, err)
+				// (e.g. oversized or corrupt). Consume it from the text anyway so
+				// the agent doesn't see the bare path as an unknown command, and
+				// hand the caller the surviving text alongside the error.
+				return stripLeadingPath(content, leadPath), images, fmt.Errorf("loading image %s: %w", absPath, err)
 			}
 			continue
 		}
@@ -380,15 +384,21 @@ func ProcessImageRefs(cwd, input string) (string, []core.Image, error) {
 			leadingConsumed = true
 		}
 	}
-	if leadingConsumed && leadPath != "" {
+	if leadingConsumed {
 		// The image came first in the prompt: consume the leading path as an
 		// image reference so the agent receives the image plus the rest of the
 		// prompt, not a leading path that reads like an unknown command.
-		trimmed := strings.TrimSpace(content)
-		content = strings.TrimSpace(trimmed[len(leadPath):])
+		content = stripLeadingPath(content, leadPath)
 	}
 
 	return strings.TrimSpace(content), images, nil
+}
+
+// stripLeadingPath drops the leading image-path token from a prompt, leaving
+// the rest of it. leadPath came from LeadingImagePath on this same content, so
+// it is the first token of the trimmed text.
+func stripLeadingPath(content, leadPath string) string {
+	return strings.TrimSpace(strings.TrimSpace(content)[len(leadPath):])
 }
 
 // PastePlaceholder returns the placeholder text displayed in the textarea for a pasted chunk.

--- a/internal/app/input/on_textarea.go
+++ b/internal/app/input/on_textarea.go
@@ -396,9 +396,10 @@ func ProcessImageRefs(cwd, input string) (string, []core.Image, error) {
 
 // stripLeadingPath drops the leading image-path token from a prompt, leaving
 // the rest of it. leadPath came from LeadingImagePath on this same content, so
-// it is the first token of the trimmed text.
+// it is the first token of the trimmed text; TrimPrefix rather than a slice so
+// that stops being an assumption the function can panic on.
 func stripLeadingPath(content, leadPath string) string {
-	return strings.TrimSpace(strings.TrimSpace(content)[len(leadPath):])
+	return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(content), leadPath))
 }
 
 // PastePlaceholder returns the placeholder text displayed in the textarea for a pasted chunk.

--- a/internal/app/input/on_textarea_test.go
+++ b/internal/app/input/on_textarea_test.go
@@ -320,13 +320,22 @@ func TestProcessImageRefs(t *testing.T) {
 			wantImage: 0,
 		},
 		{
-			// The error aborts the send, but the text comes back with it: an
-			// @-failure consumes nothing, so a caller that has to send something
-			// anyway sends what the user wrote rather than an empty turn.
+			// The error aborts the send, but the text comes back with it: nothing
+			// was consumed before the failure, so a caller that has to send
+			// something anyway sends what the user wrote rather than an empty turn.
 			name:      "@ with corrupt image returns error and the untouched text",
 			input:     "@" + badPath,
 			wantText:  "@" + badPath,
 			wantImage: 0,
+			wantErr:   true,
+		},
+		{
+			// What survived: the reference that did load is consumed, so the text
+			// no longer names an image the caller is also attaching.
+			name:      "@ failure after a good one returns the surviving text",
+			input:     "@" + pngPath + " and @" + badPath,
+			wantText:  "and @" + badPath,
+			wantImage: 1,
 			wantErr:   true,
 		},
 		{

--- a/internal/app/input/on_textarea_test.go
+++ b/internal/app/input/on_textarea_test.go
@@ -320,9 +320,12 @@ func TestProcessImageRefs(t *testing.T) {
 			wantImage: 0,
 		},
 		{
-			name:      "@ with corrupt image returns error",
+			// The error aborts the send, but the text comes back with it: an
+			// @-failure consumes nothing, so a caller that has to send something
+			// anyway sends what the user wrote rather than an empty turn.
+			name:      "@ with corrupt image returns error and the untouched text",
 			input:     "@" + badPath,
-			wantText:  "",
+			wantText:  "@" + badPath,
 			wantImage: 0,
 			wantErr:   true,
 		},

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -143,7 +143,10 @@ type model struct {
 	flush flushState
 
 	// tempImageFiles holds paths to temporary files created for clipboard
-	// images materialized by adaptTurnForProvider. Cleaned up at OnTurnEnd.
+	// images materialized by adaptTurnForProvider. Session-scoped: the paths
+	// are inlined into persisted message content, so they are removed on the
+	// way out (see removeTempImageFiles), not at the end of the turn that
+	// wrote them.
 	tempImageFiles []string
 }
 

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -142,10 +142,8 @@ type model struct {
 	// block never stalls repaint. See flushState and model_scrollback.go.
 	flush flushState
 
-	// tempImageFiles holds paths to temporary files created for clipboard
-	// images materialized by adaptTurnForProvider. Their paths are inlined into
-	// persisted message content, so they are removed when the process exits
-	// (see removeTempImageFiles), not at the end of the turn that wrote them.
+	// tempImageFiles holds the files adaptTurnForProvider materialized for
+	// clipboard images, removed at exit — see removeTempImageFiles.
 	tempImageFiles []string
 }
 

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -143,10 +143,9 @@ type model struct {
 	flush flushState
 
 	// tempImageFiles holds paths to temporary files created for clipboard
-	// images materialized by adaptTurnForProvider. Session-scoped: the paths
-	// are inlined into persisted message content, so they are removed on the
-	// way out (see removeTempImageFiles), not at the end of the turn that
-	// wrote them.
+	// images materialized by adaptTurnForProvider. Their paths are inlined into
+	// persisted message content, so they are removed when the process exits
+	// (see removeTempImageFiles), not at the end of the turn that wrote them.
 	tempImageFiles []string
 }
 

--- a/internal/app/model_agent_events.go
+++ b/internal/app/model_agent_events.go
@@ -10,10 +10,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 
 	tea "charm.land/bubbletea/v2"
-	"go.uber.org/zap"
 
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/llm"
@@ -122,13 +120,6 @@ func (m *model) OnTurnEnd(result core.Result) tea.Cmd {
 	// from is behind us — give a later failure its full recovery budget again.
 	m.autopilotRecoveries = 0
 	m.services.Agent.SetPluginRoot("")
-	// Clean up any temp image files created for text-only models this turn.
-	for _, p := range m.tempImageFiles {
-		if err := os.Remove(p); err != nil {
-			log.Logger().Warn("remove temp image file", zap.String("path", p), zap.Error(err))
-		}
-	}
-	m.tempImageFiles = nil
 	// Forward to L1 self-learning with whether this turn used a skill and
 	// whether the model called Evolve (the model-decided trigger). No-op when
 	// disabled; the reviewer gates on StopEndTurn internally so cancelled /

--- a/internal/app/model_lifecycle.go
+++ b/internal/app/model_lifecycle.go
@@ -7,14 +7,18 @@ package app
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 	"sync/atomic"
+
+	"go.uber.org/zap"
 
 	"github.com/genai-io/san/internal/app/conv"
 	"github.com/genai-io/san/internal/app/input"
 	"github.com/genai-io/san/internal/app/trigger"
 	"github.com/genai-io/san/internal/broker"
 	"github.com/genai-io/san/internal/hook"
+	"github.com/genai-io/san/internal/log"
 	"github.com/genai-io/san/internal/setting"
 	"github.com/genai-io/san/internal/task"
 	"github.com/genai-io/san/internal/todo"
@@ -273,4 +277,23 @@ func (m *model) FireSessionEnd(reason string) {
 		m.systemInput.FileWatcher.Stop()
 	}
 	broker.Unregister(broker.Main)
+}
+
+// removeTempImageFiles deletes the files adaptTurnForProvider materialized for
+// clipboard images this run. Deleting them at the end of the turn that wrote
+// them would leave every later turn pointing at a path that no longer resolves:
+// the path lives on in the message content conv persists and replays, so it has
+// to keep resolving for as long as the model can still be asked about it.
+//
+// The scope is the process, not the conversation. A --continue or --resume
+// starts a fresh one, which replays that same persisted path with nothing
+// behind it — see #458 for giving these files a home that survives the way the
+// transcript does.
+func (m *model) removeTempImageFiles() {
+	for _, p := range m.tempImageFiles {
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			log.Logger().Warn("remove temp image file", zap.String("path", p), zap.Error(err))
+		}
+	}
+	m.tempImageFiles = nil
 }

--- a/internal/app/model_turn_queue.go
+++ b/internal/app/model_turn_queue.go
@@ -68,13 +68,10 @@ func (m *model) releaseQueuedMessage() (tea.Cmd, bool) {
 		return nil, false
 	}
 	// Process image references (leading image paths, @-references, bare paths)
-	// just like the normal submit path does in buildUserMessage — the raw queued
-	// content hasn't been through ProcessImageRefs yet. On failure the message
-	// still goes out: buildUserMessage can hand a bad turn back to the textarea,
-	// this one can't, because it runs mid-stream and the textarea holds the next
-	// message being typed. What goes out is what resolved — the text that
-	// survived the failure and the images that did load — so a leading path that
-	// failed to load is still consumed rather than sent as bare text.
+	// just like the normal submit path does — the raw queued content hasn't been
+	// through ProcessImageRefs yet. On failure this message still goes out: it
+	// runs mid-stream, so there is no textarea to hand it back to (the user is
+	// typing the next one there). Send what resolved.
 	content, fileImages, err := input.ProcessImageRefs(m.env.CWD, item.Content)
 	if err != nil {
 		m.conv.AddNotice("Image error: " + err.Error())

--- a/internal/app/model_turn_queue.go
+++ b/internal/app/model_turn_queue.go
@@ -70,13 +70,14 @@ func (m *model) releaseQueuedMessage() (tea.Cmd, bool) {
 	// Process image references (leading image paths, @-references, bare paths)
 	// just like the normal submit path does in buildUserMessage — the raw queued
 	// content hasn't been through ProcessImageRefs yet. On failure the message
-	// still goes out, as the user typed it: buildUserMessage can hand a bad turn
-	// back to the textarea, this one can't, because it runs mid-stream and the
-	// textarea holds the next message being typed.
+	// still goes out: buildUserMessage can hand a bad turn back to the textarea,
+	// this one can't, because it runs mid-stream and the textarea holds the next
+	// message being typed. What goes out is what resolved — the text that
+	// survived the failure and the images that did load — so a leading path that
+	// failed to load is still consumed rather than sent as bare text.
 	content, fileImages, err := input.ProcessImageRefs(m.env.CWD, item.Content)
 	if err != nil {
 		m.conv.AddNotice("Image error: " + err.Error())
-		content, fileImages = item.Content, nil
 	}
 	// Images the user attached travel on the item — they were moved off the
 	// textarea when it was queued. Anything pending in the textarea now belongs

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -64,9 +64,6 @@ func Run(opts setting.RunOptions) error {
 		// so the flush runs exactly once regardless of which handler fired it.
 		// Best-effort — the index rebuilds from the transcripts if this fails.
 		_ = fm.services.Session.FlushIndex()
-		// Same seam for the clipboard images written to temp files for a
-		// text-only model: their paths live in the persisted conversation, so
-		// they have to outlast every turn that can still replay them.
 		fm.removeTempImageFiles()
 		printExitMessage(fm)
 	}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -64,9 +64,9 @@ func Run(opts setting.RunOptions) error {
 		// so the flush runs exactly once regardless of which handler fired it.
 		// Best-effort — the index rebuilds from the transcripts if this fails.
 		_ = fm.services.Session.FlushIndex()
-		// Same reasoning for the clipboard images written to temp files for a
+		// Same seam for the clipboard images written to temp files for a
 		// text-only model: their paths live in the persisted conversation, so
-		// they stay readable for as long as the session can still ask about them.
+		// they have to outlast every turn that can still replay them.
 		fm.removeTempImageFiles()
 		printExitMessage(fm)
 	}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -64,6 +64,10 @@ func Run(opts setting.RunOptions) error {
 		// so the flush runs exactly once regardless of which handler fired it.
 		// Best-effort — the index rebuilds from the transcripts if this fails.
 		_ = fm.services.Session.FlushIndex()
+		// Same reasoning for the clipboard images written to temp files for a
+		// text-only model: their paths live in the persisted conversation, so
+		// they stay readable for as long as the session can still ask about them.
+		fm.removeTempImageFiles()
 		printExitMessage(fm)
 	}
 	return nil

--- a/internal/app/text_only_images_test.go
+++ b/internal/app/text_only_images_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/genai-io/san/internal/app/conv"
 	"github.com/genai-io/san/internal/app/input"
 	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/hook"
 	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/reminder"
 	"github.com/genai-io/san/internal/subagent"
@@ -199,5 +200,67 @@ func TestQueuedImageErrorLeavesTheNextMessageAlone(t *testing.T) {
 	last := m.conv.Messages[len(m.conv.Messages)-1]
 	if !strings.Contains(last.Content, "look at") {
 		t.Fatalf("last message = %q, want the queued message sent anyway", last.Content)
+	}
+}
+
+// A queued message that leads with an image path the loader rejects still has
+// to lose the path: the release path can't hand the turn back to the textarea,
+// so whatever it sends is final, and a bare path left in the text is the
+// unknown-command-looking string this whole change exists to remove.
+func TestQueuedLeadingImageFailureStillConsumesThePath(t *testing.T) {
+	m, _ := textOnlyModel(t)
+	dir := t.TempDir()
+	broken := filepath.Join(dir, "broken.png")
+	if err := os.WriteFile(broken, []byte("not an image"), 0o644); err != nil {
+		t.Fatalf("write broken.png: %v", err)
+	}
+	m.env.CWD = dir
+	m.userInput.Queue.Enqueue(broken+" what is this", nil)
+
+	if _, released := m.releaseQueuedMessage(); !released {
+		t.Fatal("queued message was not released")
+	}
+
+	last := m.conv.Messages[len(m.conv.Messages)-1]
+	if strings.Contains(last.Content, broken) {
+		t.Fatalf("last message = %q, want the failed leading path consumed, not sent as text", last.Content)
+	}
+	if !strings.Contains(last.Content, "what is this") {
+		t.Fatalf("last message = %q, want the rest of the prompt to survive", last.Content)
+	}
+}
+
+// The inlined path is written into content that conv persists and replays, so
+// the file behind it has to outlive the turn: a follow-up question reaches a
+// model reading that same path back out of its own history. The files are
+// session-scoped and go at quit instead.
+func TestTempImageFileOutlivesTheTurnThatWroteIt(t *testing.T) {
+	m, _ := textOnlyModel(t)
+	pasted := core.Image{MediaType: "image/png", Data: "ZmFrZQ==", FileName: "clipboard_120000.png"}
+
+	content, providerImages := m.adaptTurnForProvider("what does this show", []core.Image{pasted})
+	if len(providerImages) != 0 {
+		t.Fatalf("provider images = %+v, want none", providerImages)
+	}
+	if len(m.tempImageFiles) != 1 {
+		t.Fatalf("temp files = %+v, want the pasted image materialized", m.tempImageFiles)
+	}
+	path := m.tempImageFiles[0]
+	if !strings.Contains(content, path) {
+		t.Fatalf("content = %q, want the temp path inlined", content)
+	}
+
+	m.services.Hook = hook.NewEngine(nil, "", "", "")
+	m.OnTurnEnd(core.Result{StopReason: core.StopEndTurn})
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stat %s after the turn ended: %v — the path is still in the persisted content", path, err)
+	}
+
+	m.removeTempImageFiles()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("stat %s after quit = %v, want it removed", path, err)
+	}
+	if m.tempImageFiles != nil {
+		t.Fatalf("temp files = %+v, want the list cleared", m.tempImageFiles)
 	}
 }

--- a/internal/app/text_only_images_test.go
+++ b/internal/app/text_only_images_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/genai-io/san/internal/app/conv"
 	"github.com/genai-io/san/internal/app/input"
 	"github.com/genai-io/san/internal/core"
-	"github.com/genai-io/san/internal/hook"
 	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/reminder"
 	"github.com/genai-io/san/internal/subagent"
@@ -53,6 +52,20 @@ func chartImage() core.Image {
 		FileName:  "chart.png",
 		Path:      "/tmp/chart.png",
 	}
+}
+
+// brokenImagePath writes a broken.png the loader rejects, points the model's
+// cwd at it, and returns its absolute path.
+func brokenImagePath(t *testing.T, m *model) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "broken.png")
+	if err := os.WriteFile(path, []byte("not an image"), 0o644); err != nil {
+		t.Fatalf("write broken.png: %v", err)
+	}
+	m.env.CWD = dir
+	return path
 }
 
 // A text-only model gets the image's path as text and no attachment: the path
@@ -181,11 +194,7 @@ func TestCompactRequestCarriesNoImagesForTextOnlyModel(t *testing.T) {
 // image — not both messages.
 func TestQueuedImageErrorLeavesTheNextMessageAlone(t *testing.T) {
 	m, _ := textOnlyModel(t)
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "broken.png"), []byte("not an image"), 0o644); err != nil {
-		t.Fatalf("write broken.png: %v", err)
-	}
-	m.env.CWD = dir
+	brokenImagePath(t, m)
 	m.userInput.Queue.Enqueue("look at @broken.png", nil)
 	// What the user is typing right now, while the turn streams.
 	m.userInput.Images.Pending = []input.PendingImage{{ID: 1, Data: core.Image{FileName: "next.png"}}}
@@ -209,12 +218,7 @@ func TestQueuedImageErrorLeavesTheNextMessageAlone(t *testing.T) {
 // unknown-command-looking string this whole change exists to remove.
 func TestQueuedLeadingImageFailureStillConsumesThePath(t *testing.T) {
 	m, _ := textOnlyModel(t)
-	dir := t.TempDir()
-	broken := filepath.Join(dir, "broken.png")
-	if err := os.WriteFile(broken, []byte("not an image"), 0o644); err != nil {
-		t.Fatalf("write broken.png: %v", err)
-	}
-	m.env.CWD = dir
+	broken := brokenImagePath(t, m)
 	m.userInput.Queue.Enqueue(broken+" what is this", nil)
 
 	if _, released := m.releaseQueuedMessage(); !released {
@@ -232,8 +236,8 @@ func TestQueuedLeadingImageFailureStillConsumesThePath(t *testing.T) {
 
 // The inlined path is written into content that conv persists and replays, so
 // the file behind it has to outlive the turn: a follow-up question reaches a
-// model reading that same path back out of its own history. The files are
-// session-scoped and go at quit instead.
+// model reading that same path back out of its own history. It goes at quit
+// instead.
 func TestTempImageFileOutlivesTheTurnThatWroteIt(t *testing.T) {
 	m, _ := textOnlyModel(t)
 	pasted := core.Image{MediaType: "image/png", Data: "ZmFrZQ==", FileName: "clipboard_120000.png"}
@@ -249,18 +253,12 @@ func TestTempImageFileOutlivesTheTurnThatWroteIt(t *testing.T) {
 	if !strings.Contains(content, path) {
 		t.Fatalf("content = %q, want the temp path inlined", content)
 	}
-
-	m.services.Hook = hook.NewEngine(nil, "", "", "")
-	m.OnTurnEnd(core.Result{StopReason: core.StopEndTurn})
 	if _, err := os.Stat(path); err != nil {
-		t.Fatalf("stat %s after the turn ended: %v — the path is still in the persisted content", path, err)
+		t.Fatalf("stat %s: %v — the path is in the persisted content already", path, err)
 	}
 
 	m.removeTempImageFiles()
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatalf("stat %s after quit = %v, want it removed", path, err)
-	}
-	if m.tempImageFiles != nil {
-		t.Fatalf("temp files = %+v, want the list cleared", m.tempImageFiles)
 	}
 }

--- a/internal/app/update_submit.go
+++ b/internal/app/update_submit.go
@@ -187,11 +187,8 @@ func (m *model) adaptTurnForProvider(content string, images []core.Image) (strin
 			path = img.FileName
 		}
 		if temp {
-			// The path goes into content that is appended to conv, persisted, and
-			// replayed on every later turn, so the file has to outlive the turn
-			// that wrote it — a follow-up question about the image reaches a model
-			// reading this same path out of its own history. removeTempImageFiles
-			// clears them when the process exits.
+			// The path below is inlined into content conv persists and replays, so
+			// the file has to outlive this turn — see removeTempImageFiles.
 			m.tempImageFiles = append(m.tempImageFiles, path)
 		}
 		fmt.Fprintf(&sb, "[Image #%d: %s]\n", i+1, path)

--- a/internal/app/update_submit.go
+++ b/internal/app/update_submit.go
@@ -6,10 +6,14 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
+	"os"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
+	"go.uber.org/zap"
 
 	"github.com/genai-io/san/internal/app/input"
 	"github.com/genai-io/san/internal/core"
@@ -187,12 +191,29 @@ func (m *model) adaptTurnForProvider(content string, images []core.Image) (strin
 			path = img.FileName
 		}
 		if temp {
-			// Written for this turn only; OnTurnEnd removes it.
+			// The path goes into content that is appended to conv, persisted, and
+			// replayed on every later turn, so the file has to outlive the turn
+			// that wrote it — a follow-up question about the image reaches a model
+			// reading this same path out of its own history. removeTempImageFiles
+			// clears them at quit.
 			m.tempImageFiles = append(m.tempImageFiles, path)
 		}
 		fmt.Fprintf(&sb, "[Image #%d: %s]\n", i+1, path)
 	}
 	return strings.TrimSpace(sb.String()), nil
+}
+
+// removeTempImageFiles deletes the files adaptTurnForProvider materialized for
+// clipboard images this session. Called once on the way out, from the seam every
+// quit path converges on — deleting them at the end of the turn that wrote them
+// would leave every later turn pointing at a path that no longer resolves.
+func (m *model) removeTempImageFiles() {
+	for _, p := range m.tempImageFiles {
+		if err := os.Remove(p); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			log.Logger().Warn("remove temp image file", zap.String("path", p), zap.Error(err))
+		}
+	}
+	m.tempImageFiles = nil
 }
 
 // drainInputQueueWhileIdle pops one queued item (if any) and runs it

--- a/internal/app/update_submit.go
+++ b/internal/app/update_submit.go
@@ -6,14 +6,10 @@ package app
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io/fs"
-	"os"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
-	"go.uber.org/zap"
 
 	"github.com/genai-io/san/internal/app/input"
 	"github.com/genai-io/san/internal/core"
@@ -195,25 +191,12 @@ func (m *model) adaptTurnForProvider(content string, images []core.Image) (strin
 			// replayed on every later turn, so the file has to outlive the turn
 			// that wrote it — a follow-up question about the image reaches a model
 			// reading this same path out of its own history. removeTempImageFiles
-			// clears them at quit.
+			// clears them when the process exits.
 			m.tempImageFiles = append(m.tempImageFiles, path)
 		}
 		fmt.Fprintf(&sb, "[Image #%d: %s]\n", i+1, path)
 	}
 	return strings.TrimSpace(sb.String()), nil
-}
-
-// removeTempImageFiles deletes the files adaptTurnForProvider materialized for
-// clipboard images this session. Called once on the way out, from the seam every
-// quit path converges on — deleting them at the end of the turn that wrote them
-// would leave every later turn pointing at a path that no longer resolves.
-func (m *model) removeTempImageFiles() {
-	for _, p := range m.tempImageFiles {
-		if err := os.Remove(p); err != nil && !errors.Is(err, fs.ErrNotExist) {
-			log.Logger().Warn("remove temp image file", zap.String("path", p), zap.Error(err))
-		}
-	}
-	m.tempImageFiles = nil
 }
 
 // drainInputQueueWhileIdle pops one queued item (if any) and runs it

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -110,11 +110,19 @@ func EnsureFilePath(img core.Image) (path string, temp bool, err error) {
 	return f.Name(), true, nil
 }
 
+// extForMediaType picks the file extension a temp image should carry. It does
+// not reverse supportedTypes: two extensions map to image/jpeg there, and Go
+// randomises map iteration, so the same image would land on .jpg or .jpeg from
+// run to run.
 func extForMediaType(mediaType string) string {
-	for ext, mt := range supportedTypes {
-		if mt == mediaType {
-			return ext
-		}
+	switch mediaType {
+	case "image/jpeg":
+		return ".jpg"
+	case "image/webp":
+		return ".webp"
+	case "image/gif":
+		return ".gif"
+	default:
+		return ".png"
 	}
-	return ".png"
 }


### PR DESCRIPTION
Follow-ups on #439, which landed as `fe74e72b`. Three points from reviewing that PR; the design itself is sound and untouched here.

## Problem

**1. The inlined temp path outlives nothing.**

A clipboard image has no file behind it, so `EnsureFilePath` writes one and `adaptTurnForProvider` inlines that path into the content. That content is appended to `conv`, persisted, and replayed on every later turn — but `OnTurnEnd` deleted the file:

- turn 1: the model reads `/var/folders/…/san-image-abc.png`, hands it to an MCP tool — works
- turn 2: the user asks a follow-up, the model reads the same path back out of its own history — `ENOENT`, while the surrounding text still says *"The files are on disk"*

Only clipboard pastes are affected: a file-backed image keeps its own path and was never temp.

**2. `ProcessImageRefs`'s error contract wasn't honored by either caller.**

The leading-path branch stripped the failed path and returned the surviving text, with a comment saying it was *"so the caller can surface a notice while the remaining text survives"*. Neither caller used it:

- `buildUserMessage` returns `ok=false` and drops the message — the user's text survives because the textarea isn't reset, not because of this return
- `releaseQueuedMessage` did `content, fileImages = item.Content, nil`, sending the **raw** text with the bare leading path still in it — the unknown-command-looking string #439 exists to remove

**3. `extForMediaType` was nondeterministic.** It reverse-walked `supportedTypes`, where `.jpg` and `.jpeg` both map to `image/jpeg`, and Go randomises map iteration — so the same image got `.jpg` or `.jpeg` from run to run.

## Fix

- `removeTempImageFiles` runs from the seam in `run.go` every quit path converges on, next to `FlushIndex`, and lives beside `FireSessionEnd` in `model_lifecycle.go`. The files now last as long as the process, so every turn that can still replay the path finds it.

  The scope is the process, not the conversation: a `--continue` / `--resume` starts a fresh one and replays that same persisted path with nothing behind it. Giving these files a home that survives the way the transcript does needs a per-session directory that doesn't exist yet — filed as #458, and the code comment points there rather than claiming more than it delivers.
- `ProcessImageRefs` makes its contract true rather than special-casing the caller: on error it returns the text that survived and the images that did load, on the `@` path as well as the leading-path one. The `@` path returns the input untouched — nothing has been consumed yet — so both callers behave exactly as before there; `releaseQueuedMessage` drops its fallback and uses what came back, which is what finally consumes a failed leading path.
- `extForMediaType` spells the mapping out.

Also drops a dead assignment and a doubled `TrimSpace` in the leading-path branch, and pulls the two identical strip sites into one helper.

## Tests

- `TestTempImageFileOutlivesTheTurnThatWroteIt` — the temp file survives `OnTurnEnd` and goes on `removeTempImageFiles`
- `TestQueuedLeadingImageFailureStillConsumesThePath` — a queued message leading with an unloadable image path loses the path and keeps the rest of the prompt
- `TestProcessImageRefs/@_with_corrupt_image_returns_error_and_the_untouched_text` — updated for the new contract, which it pinned as `""`

Both new tests were checked against `fe74e72b` and fail there.

`go build ./...`, `go test ./...`, `make lint` (vet + layercheck) and `gofmt -l` are clean.

## Not changed

The DeepSeek thinking-effort work and the leading-path parsing behavior are correct as merged — including `thinking: {"type": "disabled"}`, which matches how `moonshot` and `bigmodel` already send their toggle, and the `OnTurnEnd` cleanup ordering relative to `drainTurnQueues`, which survives the `StopCancelled` early return.
