### PR TITLE
fix(tui): let shift+tab cycle modes mid-turn and stop `-r` demoting the mode

### DIFF
--- a/internal/app/autopilot.go
+++ b/internal/app/autopilot.go
@@ -107,8 +107,11 @@ func (m *model) liveAutopilotConfig() setting.AutoPilotSettings {
 // the precondition every steer shares. Steers are the copilot's actions, so
 // none fire unless the copilot is actually driving. Combine with the per-steer
 // toggle at each gate: `if !m.autopilotEngaged() || !<steer> { return }`.
+//
+// Read from the synchronized posture, not env.OperationMode: the steer gates
+// run on the agent goroutine while Shift+Tab may be cycling modes mid-turn.
 func (m *model) autopilotEngaged() bool {
-	return m.env.OperationMode == setting.ModeAutoPilot
+	return m.env.SessionPermissions.CurrentMode() == setting.ModeAutoPilot
 }
 
 var (

--- a/internal/app/autopilot.go
+++ b/internal/app/autopilot.go
@@ -107,9 +107,7 @@ func (m *model) liveAutopilotConfig() setting.AutoPilotSettings {
 // the precondition every steer shares. Steers are the copilot's actions, so
 // none fire unless the copilot is actually driving. Combine with the per-steer
 // toggle at each gate: `if !m.autopilotEngaged() || !<steer> { return }`.
-//
-// Read from the synchronized posture, not env.OperationMode: the steer gates
-// run on the agent goroutine while Shift+Tab may be cycling modes mid-turn.
+// The gates run on the agent goroutine, so this reads the posture.
 func (m *model) autopilotEngaged() bool {
 	return m.env.SessionPermissions.CurrentMode() == setting.ModeAutoPilot
 }

--- a/internal/app/autopilot_test.go
+++ b/internal/app/autopilot_test.go
@@ -212,7 +212,11 @@ func TestPromptSuggestionGatedOnSuggestSteerInEveryMode(t *testing.T) {
 		m := &model{autopilot: &atomic.Pointer[autopilotRuntime]{}}
 		m.services.LLM = &llm.Conn{}
 		m.env.LLMProvider = &autopilotStubProvider{}
+		// Enter the mode the way the app does — the steer gates read the
+		// permission posture, not the raw field.
+		m.env.SessionPermissions = setting.NewSessionPermissions()
 		m.env.OperationMode = mode
+		m.env.ApplyModePermissions(t.TempDir())
 		m.env.AutoPilot.Steers.Suggest = &suggest
 		m.conv.Messages = []core.ChatMessage{
 			{Role: core.RoleAssistant, Content: "Done."},

--- a/internal/app/autopilot_test.go
+++ b/internal/app/autopilot_test.go
@@ -204,36 +204,54 @@ func TestMissionRetireLeavesConfiguredSafetySteers(t *testing.T) {
 	}
 }
 
+// newSuggestionModel builds a model wired far enough for the input hint to
+// fire: a stub provider, a conversation to predict from, and the mode entered
+// the way the app enters it (the steer gates read the permission posture, not
+// the raw field).
+func newSuggestionModel(t *testing.T, suggest bool, mode setting.OperationMode) *model {
+	m := &model{autopilot: &atomic.Pointer[autopilotRuntime]{}}
+	m.services.LLM = &llm.Conn{}
+	m.env.LLMProvider = &autopilotStubProvider{}
+	m.env.SessionPermissions = setting.NewSessionPermissions()
+	m.env.OperationMode = mode
+	m.env.ApplyModePermissions(t.TempDir())
+	m.env.AutoPilot.Steers.Suggest = &suggest
+	m.conv.Messages = []core.ChatMessage{
+		{Role: core.RoleAssistant, Content: "Done."},
+		{Role: core.RoleUser, Content: "Next."},
+		{Role: core.RoleAssistant, Content: "Also done."},
+	}
+	return m
+}
+
 // The Suggest steer is the input hint's feature switch in every mode: when
 // explicitly off the hint never fires — including outside AutoPilot, where
 // generic prediction used to be unconditional.
 func TestPromptSuggestionGatedOnSuggestSteerInEveryMode(t *testing.T) {
-	newModel := func(suggest bool, mode setting.OperationMode) *model {
-		m := &model{autopilot: &atomic.Pointer[autopilotRuntime]{}}
-		m.services.LLM = &llm.Conn{}
-		m.env.LLMProvider = &autopilotStubProvider{}
-		// Enter the mode the way the app does — the steer gates read the
-		// permission posture, not the raw field.
-		m.env.SessionPermissions = setting.NewSessionPermissions()
-		m.env.OperationMode = mode
-		m.env.ApplyModePermissions(t.TempDir())
-		m.env.AutoPilot.Steers.Suggest = &suggest
-		m.conv.Messages = []core.ChatMessage{
-			{Role: core.RoleAssistant, Content: "Done."},
-			{Role: core.RoleUser, Content: "Next."},
-			{Role: core.RoleAssistant, Content: "Also done."},
-		}
-		return m
-	}
-
-	if cmd := newModel(false, setting.ModeNormal).startPromptSuggestion(); cmd != nil {
+	if cmd := newSuggestionModel(t, false, setting.ModeNormal).startPromptSuggestion(); cmd != nil {
 		t.Error("suggest steer off: the hint still fired outside AutoPilot")
 	}
-	if cmd := newModel(false, setting.ModeAutoPilot).startPromptSuggestion(); cmd != nil {
+	if cmd := newSuggestionModel(t, false, setting.ModeAutoPilot).startPromptSuggestion(); cmd != nil {
 		t.Error("suggest steer off: the hint still fired in AutoPilot mode")
 	}
-	if cmd := newModel(true, setting.ModeNormal).startPromptSuggestion(); cmd == nil {
+	if cmd := newSuggestionModel(t, true, setting.ModeNormal).startPromptSuggestion(); cmd == nil {
 		t.Error("suggest steer on: no hint outside AutoPilot")
+	}
+}
+
+// Shift+Tab can now land on AutoPilot mid-turn. The opening proposal is ghost
+// text for a textarea the user cannot type into yet, so it must not cost an LLM
+// call — OnTurnEnd re-arms the hint once the turn is over.
+func TestAutopilotModeSettledSkipsSuggestionMidTurn(t *testing.T) {
+	m := newSuggestionModel(t, true, setting.ModeAutoPilot)
+
+	if cmd := m.handleAutopilotModeSettled(); cmd == nil {
+		t.Fatal("settling on AutoPilot while idle did not start the proposal")
+	}
+
+	m.conv.Stream.Active = true
+	if cmd := m.handleAutopilotModeSettled(); cmd != nil {
+		t.Fatal("settling on AutoPilot mid-turn started the proposal anyway")
 	}
 }
 

--- a/internal/app/env.go
+++ b/internal/app/env.go
@@ -49,6 +49,11 @@ type env struct {
 	ShowContextBar bool
 
 	// ── Permission (mutable — changes per mode cycle) ───────────
+	// Two views of one posture, kept in step by ApplyModePermissions.
+	// OperationMode belongs to the UI goroutine: the status bar renders it and
+	// Shift+Tab advances it. SessionPermissions carries the same mode behind a
+	// mutex, and that is the copy the agent goroutine must read (CurrentMode or
+	// a Snapshot) — the user can cycle modes while a turn is running.
 	OperationMode      setting.OperationMode
 	SessionPermissions *setting.SessionPermissions
 
@@ -236,9 +241,7 @@ func (m *env) ClearCachedInstructions() {
 }
 
 // SessionMode is the mode label persisted with the session and stamped on each
-// permission record. It reads the synchronized posture rather than
-// OperationMode (the UI goroutine's field), because the agent goroutine calls
-// it while the user may be cycling modes mid-turn.
+// permission record. Called from the agent goroutine, so it reads the posture.
 func (m *env) SessionMode() string {
 	switch m.SessionPermissions.CurrentMode() {
 	case setting.ModeAutoAccept:

--- a/internal/app/env.go
+++ b/internal/app/env.go
@@ -235,8 +235,12 @@ func (m *env) ClearCachedInstructions() {
 	m.CachedProjectInstructions = ""
 }
 
+// SessionMode is the mode label persisted with the session and stamped on each
+// permission record. It reads the synchronized posture rather than
+// OperationMode (the UI goroutine's field), because the agent goroutine calls
+// it while the user may be cycling modes mid-turn.
 func (m *env) SessionMode() string {
-	switch m.OperationMode {
+	switch m.SessionPermissions.CurrentMode() {
 	case setting.ModeAutoAccept:
 		return "auto-accept"
 	case setting.ModeAutoPilot:
@@ -244,6 +248,18 @@ func (m *env) SessionMode() string {
 	default:
 		return "normal"
 	}
+}
+
+// resumeOperationMode is the mode a resumed session restores into: the one it
+// recorded, or — for a session that recorded none, which is every session saved
+// before modes were persisted — the mode the launch already established. Only a
+// recorded mode may move the user; an absent one must not demote a startup
+// accept-edits/autopilot posture to Normal behind their back.
+func resumeOperationMode(recorded string, startup setting.OperationMode) setting.OperationMode {
+	if recorded == "" {
+		return startup
+	}
+	return parseSessionMode(recorded)
 }
 
 // parseSessionMode maps a persisted session mode back to the OperationMode a

--- a/internal/app/env_test.go
+++ b/internal/app/env_test.go
@@ -37,6 +37,60 @@ func TestApplyDefaultPermissionMode_RestoresAllModes(t *testing.T) {
 	}
 }
 
+// A session that recorded a mode restores into it; one that recorded none —
+// every session saved before modes were persisted — keeps the mode the launch
+// established, instead of demoting the user to Normal on `san -r`.
+func TestResumeOperationMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		recorded string
+		startup  setting.OperationMode
+		want     setting.OperationMode
+	}{
+		{"no recorded mode keeps accept edits", "", setting.ModeAutoAccept, setting.ModeAutoAccept},
+		{"no recorded mode keeps autopilot", "", setting.ModeAutoPilot, setting.ModeAutoPilot},
+		{"no recorded mode keeps normal", "", setting.ModeNormal, setting.ModeNormal},
+		{"recorded normal wins over startup", "normal", setting.ModeAutoAccept, setting.ModeNormal},
+		{"recorded autopilot restores", "auto-pilot", setting.ModeNormal, setting.ModeAutoPilot},
+		{"recorded bypass never round-trips", "bypass", setting.ModeAutoAccept, setting.ModeNormal},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resumeOperationMode(tt.recorded, tt.startup); got != tt.want {
+				t.Fatalf("resumeOperationMode(%q, %v) = %v, want %v", tt.recorded, tt.startup, got, tt.want)
+			}
+		})
+	}
+}
+
+// Shift+Tab cycles modes on the UI goroutine while the agent goroutine stamps
+// each permission decision with SessionMode(). Run under -race: the reader must
+// go through the synchronized posture, never the UI's OperationMode field.
+func TestSessionModeReadsPostureWhileModesCycle(t *testing.T) {
+	e := env{SessionPermissions: setting.NewSessionPermissions(), CWD: t.TempDir()}
+	cycle := []setting.OperationMode{
+		setting.ModeNormal, setting.ModeAutoAccept, setting.ModeAutoPilot, setting.ModeBypassPermissions,
+	}
+
+	cycled := make(chan struct{})
+	go func() {
+		defer close(cycled)
+		for i := range 200 {
+			e.OperationMode = cycle[i%len(cycle)]
+			e.ApplyModePermissions(e.CWD)
+		}
+	}()
+
+	for range 200 {
+		switch got := e.SessionMode(); got {
+		case "normal", "auto-accept", "auto-pilot":
+		default:
+			t.Fatalf("SessionMode() = %q, want one of the persisted labels", got)
+		}
+	}
+	<-cycled
+}
+
 func TestResetContextDisplay_PreservesCompressions(t *testing.T) {
 	e := &env{Compressions: 3, InputTokens: 100, OutputTokens: 50}
 	e.ResetContextDisplay()

--- a/internal/app/env_test.go
+++ b/internal/app/env_test.go
@@ -37,9 +37,8 @@ func TestApplyDefaultPermissionMode_RestoresAllModes(t *testing.T) {
 	}
 }
 
-// A session that recorded a mode restores into it; one that recorded none —
-// every session saved before modes were persisted — keeps the mode the launch
-// established, instead of demoting the user to Normal on `san -r`.
+// `san -r` restores a recorded mode, and leaves the launch's alone when the
+// session recorded none.
 func TestResumeOperationMode(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -48,8 +47,6 @@ func TestResumeOperationMode(t *testing.T) {
 		want     setting.OperationMode
 	}{
 		{"no recorded mode keeps accept edits", "", setting.ModeAutoAccept, setting.ModeAutoAccept},
-		{"no recorded mode keeps autopilot", "", setting.ModeAutoPilot, setting.ModeAutoPilot},
-		{"no recorded mode keeps normal", "", setting.ModeNormal, setting.ModeNormal},
 		{"recorded normal wins over startup", "normal", setting.ModeAutoAccept, setting.ModeNormal},
 		{"recorded autopilot restores", "auto-pilot", setting.ModeNormal, setting.ModeAutoPilot},
 		{"recorded bypass never round-trips", "bypass", setting.ModeAutoAccept, setting.ModeNormal},
@@ -82,11 +79,7 @@ func TestSessionModeReadsPostureWhileModesCycle(t *testing.T) {
 	}()
 
 	for range 200 {
-		switch got := e.SessionMode(); got {
-		case "normal", "auto-accept", "auto-pilot":
-		default:
-			t.Fatalf("SessionMode() = %q, want one of the persisted labels", got)
-		}
+		_ = e.SessionMode()
 	}
 	<-cycled
 }

--- a/internal/app/model_session.go
+++ b/internal/app/model_session.go
@@ -177,11 +177,11 @@ func (m *model) restoreSessionData(sess *session.Snapshot) {
 
 	// Resume into the operation mode the session was saved in, so an autopilot
 	// run picks up where it left off without re-cycling shift+tab. (Bypass never
-	// round-trips — parseSessionMode maps it to Normal.)
-	if mode := parseSessionMode(sess.Metadata.Mode); mode != m.env.OperationMode {
+	// round-trips — parseSessionMode maps it to Normal.) A session that saved no
+	// mode keeps the launch's — see resumeOperationMode.
+	if mode := resumeOperationMode(sess.Metadata.Mode, m.env.OperationMode); mode != m.env.OperationMode {
 		m.env.OperationMode = mode
-		m.env.ApplyModePermissions(m.env.CWD)
-		m.services.Hook.SetPermissionMode(m.env.OperationModeName())
+		m.applyOperationMode()
 	}
 }
 

--- a/internal/app/update_key_test.go
+++ b/internal/app/update_key_test.go
@@ -99,8 +99,7 @@ func TestCtrlTUsesCachedModelReasoningMetadata(t *testing.T) {
 }
 
 // A running turn is exactly when the user reaches for a laxer mode — every
-// command is stopping for approval — so Shift+Tab must keep cycling mid-stream,
-// and the switch must land on the posture the agent goroutine reads.
+// command is stopping for approval — so Shift+Tab must keep cycling mid-stream.
 func TestShiftTabCyclesModeDuringStream(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	cwd := t.TempDir()
@@ -121,19 +120,6 @@ func TestShiftTabCyclesModeDuringStream(t *testing.T) {
 	}
 	if got := m.env.SessionPermissions.CurrentMode(); got != setting.ModeAutoAccept {
 		t.Fatalf("posture mode = %v, want %v (this is what the permission gate reads)", got, setting.ModeAutoAccept)
-	}
-
-	// Landing on AutoPilot mid-turn engages the copilot for the rest of the
-	// turn, but must not fire the Suggest steer's ghost text at a textarea the
-	// user cannot type into yet.
-	if _, handled := m.handleTextareaShortcut(shiftTab); !handled {
-		t.Fatal("second shift+tab was dropped while a turn was streaming")
-	}
-	if m.env.OperationMode != setting.ModeAutoPilot {
-		t.Fatalf("OperationMode = %v, want %v", m.env.OperationMode, setting.ModeAutoPilot)
-	}
-	if cmd := m.handleAutopilotModeSettled(); cmd != nil {
-		t.Fatal("landing on AutoPilot mid-turn started a prompt suggestion")
 	}
 }
 

--- a/internal/app/update_key_test.go
+++ b/internal/app/update_key_test.go
@@ -6,7 +6,11 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/genai-io/san/internal/app/conv"
+	"github.com/genai-io/san/internal/hook"
 	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/setting"
+	"github.com/genai-io/san/internal/tool/perm"
 )
 
 type testThinkingProvider struct {
@@ -91,6 +95,62 @@ func TestCtrlTUsesCachedModelReasoningMetadata(t *testing.T) {
 	}
 	if m.env.ThinkingEffort != "ultra" {
 		t.Fatalf("ThinkingEffort = %q, want dynamic next effort ultra", m.env.ThinkingEffort)
+	}
+}
+
+// A running turn is exactly when the user reaches for a laxer mode — every
+// command is stopping for approval — so Shift+Tab must keep cycling mid-stream,
+// and the switch must land on the posture the agent goroutine reads.
+func TestShiftTabCyclesModeDuringStream(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := t.TempDir()
+
+	m := &model{}
+	m.env.CWD = cwd
+	m.env.SessionPermissions = setting.NewSessionPermissions()
+	m.services.Setting = setting.New(setting.NewData())
+	m.services.Hook = hook.NewEngine(setting.NewData(), "", cwd, "")
+	m.conv.Stream.Active = true
+
+	shiftTab := tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift}
+	if _, handled := m.handleTextareaShortcut(shiftTab); !handled {
+		t.Fatal("shift+tab was dropped while a turn was streaming")
+	}
+	if m.env.OperationMode != setting.ModeAutoAccept {
+		t.Fatalf("OperationMode = %v, want %v", m.env.OperationMode, setting.ModeAutoAccept)
+	}
+	if got := m.env.SessionPermissions.CurrentMode(); got != setting.ModeAutoAccept {
+		t.Fatalf("posture mode = %v, want %v (this is what the permission gate reads)", got, setting.ModeAutoAccept)
+	}
+
+	// Landing on AutoPilot mid-turn engages the copilot for the rest of the
+	// turn, but must not fire the Suggest steer's ghost text at a textarea the
+	// user cannot type into yet.
+	if _, handled := m.handleTextareaShortcut(shiftTab); !handled {
+		t.Fatal("second shift+tab was dropped while a turn was streaming")
+	}
+	if m.env.OperationMode != setting.ModeAutoPilot {
+		t.Fatalf("OperationMode = %v, want %v", m.env.OperationMode, setting.ModeAutoPilot)
+	}
+	if cmd := m.handleAutopilotModeSettled(); cmd != nil {
+		t.Fatal("landing on AutoPilot mid-turn started a prompt suggestion")
+	}
+}
+
+// The approval prompt keeps Shift+Tab as its "allow all this session"
+// accelerator: it is an overlay, so routeKeypress hands it the key before the
+// mode cycle ever sees it.
+func TestShiftTabAtApprovalPromptDoesNotCycleMode(t *testing.T) {
+	m := &model{conv: conv.NewModel(80)}
+	m.env.SessionPermissions = setting.NewSessionPermissions()
+	m.conv.Stream.Active = true
+	m.userInput.Approval.Show(&perm.PermissionRequest{ToolName: "Bash"}, 80, 24)
+
+	if _, ok := m.routeKeypress(tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift}); !ok {
+		t.Fatal("shift+tab was not routed to the approval overlay")
+	}
+	if m.env.OperationMode != setting.ModeNormal {
+		t.Fatalf("OperationMode = %v, want %v (the approval prompt owns this key)", m.env.OperationMode, setting.ModeNormal)
 	}
 }
 

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -74,9 +74,14 @@ func (m *model) handleTextareaShortcut(msg tea.KeyMsg) (tea.Cmd, bool) {
 		}
 
 	case "shift+tab":
-		if !m.conv.Stream.Active && !m.userInput.Approval.IsActive() &&
-			!m.conv.Modal.Question.IsActive() &&
-			!m.userInput.Provider.Selector.IsActive() && !m.userInput.Suggestions.IsVisible() {
+		// Cycling stays available while a turn is running: being asked to
+		// approve every command is exactly when the user reaches for
+		// accept-edits or autopilot, and the permission gate reads the posture
+		// per call, so the switch lands on the turn's next tool. Overlays that
+		// bind Shift+Tab themselves (the approval prompt's "allow all this
+		// session", the pickers) consume it in routeKeypress before we get
+		// here; the command popup is the one caller that reaches this far.
+		if !m.userInput.Suggestions.IsVisible() {
 			return m.cycleOperationMode(), true
 		}
 

--- a/internal/app/update_keys.go
+++ b/internal/app/update_keys.go
@@ -74,13 +74,13 @@ func (m *model) handleTextareaShortcut(msg tea.KeyMsg) (tea.Cmd, bool) {
 		}
 
 	case "shift+tab":
-		// Cycling stays available while a turn is running: being asked to
-		// approve every command is exactly when the user reaches for
-		// accept-edits or autopilot, and the permission gate reads the posture
-		// per call, so the switch lands on the turn's next tool. Overlays that
-		// bind Shift+Tab themselves (the approval prompt's "allow all this
-		// session", the pickers) consume it in routeKeypress before we get
-		// here; the command popup is the one caller that reaches this far.
+		// Cycling stays available while a turn is running: being asked to approve
+		// every command is exactly when the user reaches for accept-edits or
+		// autopilot, and the permission gate reads the posture per call, so the
+		// switch lands on the turn's next tool. Overlays that bind Shift+Tab
+		// themselves (the approval prompt's "allow all this session", the
+		// pickers) already took it in routeKeypress; the command popup is the one
+		// caller that reaches this far.
 		if !m.userInput.Suggestions.IsVisible() {
 			return m.cycleOperationMode(), true
 		}

--- a/internal/app/update_modal.go
+++ b/internal/app/update_modal.go
@@ -64,8 +64,12 @@ type autopilotModeSettledMsg struct{}
 // the mode has rested on AutoPilot. It no-ops if the user has since cycled away,
 // so a pass-through cycle costs nothing. The mission kick-off is deliberately NOT
 // here — that's the panel's explicit Start button, not a side effect of landing.
+//
+// A mid-turn landing skips it: the proposal is ghost text for an idle textarea
+// (HandlePromptSuggestion drops it while streaming anyway), and OnTurnEnd
+// re-arms the hint once the turn is over.
 func (m *model) handleAutopilotModeSettled() tea.Cmd {
-	if !m.autopilotEngaged() {
+	if !m.autopilotEngaged() || m.conv.Stream.Active {
 		return nil
 	}
 	return m.startPromptSuggestion()

--- a/internal/setting/permission.go
+++ b/internal/setting/permission.go
@@ -228,6 +228,11 @@ func coerceAsk(decision PermissionDecision, session *SessionPermissions) Permiss
 // ask rule overrides the hook's decision. This implements the safety
 // invariant: deny rules > safety checks > ask rules > hook allow.
 func (s *Data) ResolveHookAllow(toolName string, args map[string]any, session *SessionPermissions) bool {
+	// Same reason HasPermissionToUseTool snapshots: this runs on the agent
+	// goroutine, and the working directories it reads below are rewritten by
+	// the UI goroutine whenever the user cycles the mode mid-turn.
+	session = session.Snapshot()
+
 	rule := BuildRule(toolName, args)
 	for _, pattern := range s.Permissions.Deny {
 		if MatchesToolPattern(toolName, args, rule, pattern) {

--- a/internal/setting/settings.go
+++ b/internal/setting/settings.go
@@ -502,6 +502,20 @@ func (sp *SessionPermissions) SetMode(mode OperationMode) {
 	sp.Mode = mode
 }
 
+// CurrentMode reads the active mode under the lock. This is the mode the agent
+// goroutine must consult: the user can cycle the posture (Shift+Tab) while a
+// turn is running, so reading the plain field would race with SetMode. Nil
+// receiver reports Normal, matching how the decision pipeline treats a session
+// without a posture.
+func (sp *SessionPermissions) CurrentMode() OperationMode {
+	if sp == nil {
+		return ModeNormal
+	}
+	sp.mu.RLock()
+	defer sp.mu.RUnlock()
+	return sp.Mode
+}
+
 // GrantEditPosture auto-approves edits and writes and trusts cwd, as one
 // atomic change — the accept-edits and auto-pilot posture.
 func (sp *SessionPermissions) GrantEditPosture(cwd string) {

--- a/internal/setting/settings.go
+++ b/internal/setting/settings.go
@@ -502,15 +502,9 @@ func (sp *SessionPermissions) SetMode(mode OperationMode) {
 	sp.Mode = mode
 }
 
-// CurrentMode reads the active mode under the lock. This is the mode the agent
-// goroutine must consult: the user can cycle the posture (Shift+Tab) while a
-// turn is running, so reading the plain field would race with SetMode. Nil
-// receiver reports Normal, matching how the decision pipeline treats a session
-// without a posture.
+// CurrentMode reads the active mode under the lock — Snapshot for callers that
+// only need the mode, without cloning the allowances.
 func (sp *SessionPermissions) CurrentMode() OperationMode {
-	if sp == nil {
-		return ModeNormal
-	}
 	sp.mu.RLock()
 	defer sp.mu.RUnlock()
 	return sp.Mode


### PR DESCRIPTION
## What & why

Closes #448

Two defects, stacked:

**`san -r` demotes the permission mode.** `restoreSessionData` treated a session that recorded *no* mode (every session saved before modes were persisted) as one that recorded `"normal"`, overwriting the mode the launch restored from `lastOperationMode`. `san` kept `⏵⏵ accept edits on`; `san -r` + pick dropped to ask-for-everything. Now only a recorded mode moves the user.

**Shift+Tab is dead while a turn runs.** `Stream.Active` stays true for the whole turn (`applyChunk` clears it only on a text-only Done), so the key did nothing during tool calls and approval prompts — the one moment you reach for accept-edits or autopilot — while the status bar still said `(shift+tab to cycle)`. The permission gate reads the posture per call, so a mid-turn switch lands on the next tool. The approval prompt keeps Shift+Tab as its "allow all this session" accelerator (it's an overlay, `routeKeypress` gets it first); the other overlay checks in the guard were dead for the same reason and are gone.

Mid-turn cycling means the UI goroutine rewrites the posture while the agent goroutine reads it, so `autopilotEngaged` / `env.SessionMode` now read the new lock-held `SessionPermissions.CurrentMode()`, and `ResolveHookAllow` snapshots like `HasPermissionToUseTool` already did.

## Type of change

- [x] Bug fix

## Testing

```bash
make lint && go test ./...
CGO_ENABLED=1 go test -race ./internal/app/... ./internal/setting/... ./tests/integration/...
```

Four new tests cover the resume mode, mid-stream cycling, the approval accelerator, and the goroutine race (it reports DATA RACE against the pre-fix reader). Also verified in the real TUI.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] All commits signed off (`git commit -s`)
- [x] Tests pass locally
- [x] Docs updated (if behavior or config changed) — none needed; docs already describe Shift+Tab as switching modes mid-session
- [x] Read and follow the [Code of Conduct](CODE_OF_CONDUCT.md)
