### PR TITLE
release: v1.22.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to San are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [v1.22.3] - 2026-08-05
+
+### Fixed
+- Consolidate the v1.22.2 resize-fix changelog entries under a single PR reference ([@yanmxa](https://github.com/yanmxa))
+
 ## [v1.22.2] - 2026-08-04
 
 ### Added
@@ -20,8 +25,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - Preserve the permission gate when a `PreToolUse` hook allows a call ([@yanmxa](https://github.com/yanmxa) in [#446](https://github.com/genai-io/san/pull/446))
 - Keep inlined image paths resolvable and honor `ProcessImageRefs` errors ([@yanmxa](https://github.com/yanmxa) in [#457](https://github.com/genai-io/san/pull/457))
 - Let Shift+Tab cycle modes mid-turn and keep `-r` from demoting the mode ([@yanmxa](https://github.com/yanmxa) in [#459](https://github.com/genai-io/san/pull/459))
-- Prevent narrowing the terminal from stranding frame rows, and count rewrapped rows from actual wrapping ([@yanmxa](https://github.com/yanmxa) in [befdd3a](https://github.com/genai-io/san/commit/befdd3ab06c892ebbd3b1e59738ebe8ede9b0c9a), [d459676](https://github.com/genai-io/san/commit/d459676978e2ce3e1bb7f13794e873495e324cf9))
-- Keep input separators inside the terminal after resize corrections ([@yanmxa](https://github.com/yanmxa) in [5b383e2](https://github.com/genai-io/san/commit/5b383e281111d404a40273fa33cf9c58c28356ca), [a229b08](https://github.com/genai-io/san/commit/a229b0811cec12af38b1e2135f8b6a6bfe840b0f))
+- Prevent terminal narrowing from stranding frame rows by counting actual wrapping behavior ([@yanmxa](https://github.com/yanmxa) in [#460](https://github.com/genai-io/san/pull/460))
 
 ## [v1.22.1] - 2026-07-30
 

--- a/cmd/san/main.go
+++ b/cmd/san/main.go
@@ -33,7 +33,7 @@ import (
 	_ "github.com/genai-io/san/internal/llm/volcengine"
 )
 
-var version = "1.22.2"
+var version = "1.22.3"
 
 // buildTime and commit are set at build time via -X ldflags.
 // When built directly with go build (without ldflags), they remain empty.


### PR DESCRIPTION
Bump version to 1.22.3.

- Consolidate the v1.22.2 resize-fix changelog entries under a single PR reference