### PR TITLE
feat(llm): add GitHub Copilot as a subscription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Subcommands: `inspector` · `agent` · `plugin` · `mcp` — run `san <command> 
 |:--------|:---------|
 | **Anthropic** (Claude) | `ANTHROPIC_API_KEY` or [Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude) |
 | **OpenAI** (GPT, o-series, Codex) | `OPENAI_API_KEY`, or a ChatGPT subscription (sign in via `/models`) |
+| **GitHub Copilot** (all Copilot models) | a Copilot subscription (sign in via `/models`) |
 | **Google** (Gemini) | `GOOGLE_API_KEY` |
 | **DeepSeek** (DeepSeek V4) | `DEEPSEEK_API_KEY` |
 | **Moonshot** (Kimi) | `MOONSHOT_API_KEY` |

--- a/README.zh.md
+++ b/README.zh.md
@@ -135,6 +135,7 @@ san --resume                 # 选择历史会话恢复
 |:--------|:---------|
 | **Anthropic** (Claude) | `ANTHROPIC_API_KEY` 或 [Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude) |
 | **OpenAI** (GPT, o 系列, Codex) | `OPENAI_API_KEY`，或使用 ChatGPT 订阅（通过 `/models` 登录） |
+| **GitHub Copilot**（Copilot 全部模型） | 使用 Copilot 订阅（通过 `/models` 登录） |
 | **Google** (Gemini) | `GOOGLE_API_KEY` |
 | **DeepSeek** (DeepSeek V4) | `DEEPSEEK_API_KEY` |
 | **Moonshot** (Kimi) | `MOONSHOT_API_KEY` |

--- a/cmd/san/main.go
+++ b/cmd/san/main.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/genai-io/san/internal/llm/alibaba"
 	_ "github.com/genai-io/san/internal/llm/anthropic"
 	_ "github.com/genai-io/san/internal/llm/bigmodel"
+	_ "github.com/genai-io/san/internal/llm/copilot"
 	_ "github.com/genai-io/san/internal/llm/custom"
 	_ "github.com/genai-io/san/internal/llm/deepseek"
 	_ "github.com/genai-io/san/internal/llm/google"

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -50,6 +50,11 @@ for Anthropic). Supported providers and the env var each one reads:
 
 You can also set them in `.env` or `~/.san/providers.json`.
 
+Two providers take a subscription instead of a key: **ChatGPT Subscription**
+(OpenAI) and **Copilot Subscription** (GitHub Copilot). Pick either in
+`/models` and San opens the browser to sign in — Copilot shows an
+eight-character code to type on the GitHub page it opens.
+
 ## First Turn
 
 Type a prompt and press `Enter`:

--- a/docs/reference/package-map.md
+++ b/docs/reference/package-map.md
@@ -76,7 +76,7 @@ Configuration and supporting capabilities:
 | `internal/secret` | `infrastructure` | Secret storage helpers. |
 | `internal/filecache` | `infrastructure` | File restore/cache helpers. |
 | `internal/markdown` | `infrastructure` | Markdown frontmatter parsing. |
-| `internal/proc` | `infrastructure` | Cross-platform process-group / signal helpers (Unix/Windows variants). |
+| `internal/proc` | `infrastructure` | Cross-platform process-group / signal helpers (Unix/Windows variants) and the OS URL launcher. |
 | `internal/confdir` | `infrastructure` | Shared `.san` configuration directory naming helper. |
 | `internal/atomicfile` | `infrastructure` | Temp-file-then-rename file replacement, so a reader never sees a half-written file. |
 

--- a/internal/app/input/on_provider.go
+++ b/internal/app/input/on_provider.go
@@ -159,6 +159,17 @@ type ProviderSelector struct {
 	lastConnectAuthIdx int // item index that triggered the connection
 	lastConnectSuccess bool
 
+	// loginPrompt holds the instruction for an interactive sign-in still in
+	// flight — the page to open and, for device flows, the code to type there.
+	// It replaces the hint line until the sign-in resolves; a zero value means
+	// nothing is pending.
+	loginPrompt llm.LoginPrompt
+
+	// cancelLogin stops an interactive sign-in when the user closes the
+	// selector. A device flow otherwise keeps polling GitHub every few seconds
+	// for its full 15-minute lifetime with nobody left to read the result.
+	cancelLogin context.CancelFunc
+
 	// spinnerTick advances on each providerConnectingTickMsg; used to pick a braille
 	// frame while a connect/refresh is in flight.
 	spinnerTick int
@@ -195,6 +206,13 @@ type providerConnectResultMsg struct {
 	Provider   llm.Name
 	AuthMethod llm.AuthMethod
 	Models     []llm.ModelInfo
+}
+
+// providerLoginPromptMsg carries the instruction an in-flight interactive
+// sign-in needs the user to follow.
+type providerLoginPromptMsg struct {
+	AuthIdx int
+	Prompt  llm.LoginPrompt
 }
 
 // providerModelsLoadedMsg is sent when async model loading completes.
@@ -264,6 +282,9 @@ func UpdateProvider(deps OverlayDeps, state *ProviderState, msg tea.Msg) (tea.Cm
 			state.Selector.AdvanceSpinner()
 			return providerConnectingTickCmd(), true
 		}
+		return nil, true
+	case providerLoginPromptMsg:
+		state.Selector.HandleLoginPrompt(msg)
 		return nil, true
 	case providerConnectResultMsg:
 		cmd := state.Selector.HandleConnectResult(msg)

--- a/internal/app/input/on_provider_auth.go
+++ b/internal/app/input/on_provider_auth.go
@@ -454,7 +454,10 @@ func (s *ProviderSelector) connectInteractive(item providerAuthMethodItem, authI
 		return nil
 	}
 	prompts := make(chan llm.LoginPrompt, 1)
-	ctx, cancel := context.WithCancel(context.Background())
+	// The cancellable context covers the sign-in only. Once it returns the
+	// credentials are already stored, so closing the selector during the model
+	// listing that follows must not abandon a connection the user completed.
+	signIn, cancel := context.WithCancel(context.Background())
 	s.cancelLogin = cancel
 
 	work := func() tea.Msg {
@@ -474,14 +477,14 @@ func (s *ProviderSelector) connectInteractive(item providerAuthMethodItem, authI
 		}
 		defer close(prompts)
 
-		if err := llm.Login(ctx, item.Provider, item.AuthMethod, onPrompt); err != nil {
+		if err := llm.Login(signIn, item.Provider, item.AuthMethod, onPrompt); err != nil {
 			return providerConnectResultMsg{
 				AuthIdx: authIdx,
 				Success: false,
 				Message: fmt.Sprintf("sign-in failed: %s", err.Error()),
 			}
 		}
-		return s.connectResultMsg(ctx, item, authIdx)
+		return s.connectResultMsg(context.Background(), item, authIdx)
 	}
 
 	// Resolves when the flow publishes an instruction, or to nil when it

--- a/internal/app/input/on_provider_auth.go
+++ b/internal/app/input/on_provider_auth.go
@@ -348,6 +348,11 @@ const (
 	providerStatusConnecting = "Connecting..."
 )
 
+// connectVerifyTimeout caps the model listing that records a connection after an
+// interactive sign-in. It runs detached from the sign-in's cancellable context —
+// the credentials are already stored by then — so it needs its own ceiling.
+const connectVerifyTimeout = 30 * time.Second
+
 // IsConnecting reports whether a connect/refresh is in flight, so the spinner-tick
 // loop keeps ticking and the row renders an animated frame.
 func (s *ProviderSelector) IsConnecting() bool {
@@ -484,7 +489,12 @@ func (s *ProviderSelector) connectInteractive(item providerAuthMethodItem, authI
 				Message: fmt.Sprintf("sign-in failed: %s", err.Error()),
 			}
 		}
-		return s.connectResultMsg(context.Background(), item, authIdx)
+		// Detached from signIn on purpose — the credentials are stored, so this
+		// must survive the user closing the selector — but still bounded, since
+		// nothing in this generic path guarantees ListModels ever returns.
+		listing, done := context.WithTimeout(context.Background(), connectVerifyTimeout)
+		defer done()
+		return s.connectResultMsg(listing, item, authIdx)
 	}
 
 	// Resolves when the flow publishes an instruction, or to nil when it

--- a/internal/app/input/on_provider_auth.go
+++ b/internal/app/input/on_provider_auth.go
@@ -415,6 +415,9 @@ func (s *ProviderSelector) beginConnect(status string, authIdx int) bool {
 	s.lastConnectResult = status
 	s.lastConnectAuthIdx = authIdx
 	s.lastConnectSuccess = false
+	// Any sign-in instruction belongs to the connect this call starts; every
+	// connect/refresh passes through here, so clearing it once here is enough.
+	s.loginPrompt = llm.LoginPrompt{}
 	return true
 }
 
@@ -437,25 +440,41 @@ func (s *ProviderSelector) connectResultMsg(ctx context.Context, item providerAu
 	}
 }
 
-// connectInteractive runs an OAuth (PKCE) sign-in for an auth method that
+// connectInteractive runs an OAuth sign-in for an auth method that
 // authenticates in the browser, then records the connection. It reuses the
 // connect spinner and result plumbing so the row animates while the browser
 // flow is in progress.
+//
+// The sign-in also reports what the user has to do — a URL, plus a code to type
+// there for device flows. That arrives partway through the blocking Login call,
+// so it rides its own channel and its own command, letting the footer show the
+// instruction while the same flow is still waiting on the browser.
 func (s *ProviderSelector) connectInteractive(item providerAuthMethodItem, authIdx int) tea.Cmd {
 	if !s.beginConnect(providerStatusConnecting, authIdx) {
 		return nil
 	}
+	prompts := make(chan llm.LoginPrompt, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancelLogin = cancel
 
 	work := func() tea.Msg {
-		ctx := context.Background()
+		defer cancel()
 
-		// Log the authorize URL so it's recoverable when the browser can't be
-		// opened automatically (e.g. over SSH).
-		onURL := func(u string) {
+		onPrompt := func(p llm.LoginPrompt) {
+			// Log it too, so it's recoverable from the log when the browser
+			// can't be opened automatically (e.g. over SSH).
 			log.Logger().Info("provider sign-in",
-				zap.String("provider", string(item.Provider)), zap.String("url", u))
+				zap.String("provider", string(item.Provider)),
+				zap.String("url", p.URL),
+				zap.String("user_code", p.UserCode))
+			select {
+			case prompts <- p:
+			default: // a prompt is already queued; the first one is the live instruction.
+			}
 		}
-		if err := llm.Login(ctx, item.Provider, item.AuthMethod, onURL); err != nil {
+		defer close(prompts)
+
+		if err := llm.Login(ctx, item.Provider, item.AuthMethod, onPrompt); err != nil {
 			return providerConnectResultMsg{
 				AuthIdx: authIdx,
 				Success: false,
@@ -464,7 +483,18 @@ func (s *ProviderSelector) connectInteractive(item providerAuthMethodItem, authI
 		}
 		return s.connectResultMsg(ctx, item, authIdx)
 	}
-	return tea.Batch(providerConnectingTickCmd(), work)
+
+	// Resolves when the flow publishes an instruction, or to nil when it
+	// finishes without one (the channel closes on the way out either way).
+	waitPrompt := func() tea.Msg {
+		p, ok := <-prompts
+		if !ok {
+			return nil
+		}
+		return providerLoginPromptMsg{AuthIdx: authIdx, Prompt: p}
+	}
+
+	return tea.Batch(providerConnectingTickCmd(), work, waitPrompt)
 }
 
 // connectAuthMethod initiates an async connection to a provider auth method.
@@ -477,6 +507,27 @@ func (s *ProviderSelector) connectAuthMethod(item providerAuthMethodItem, authId
 		return s.connectResultMsg(context.Background(), item, authIdx)
 	}
 	return tea.Batch(providerConnectingTickCmd(), work)
+}
+
+// cancelInteractiveLogin stops an in-flight sign-in, if any. It is idempotent,
+// so closing the selector twice — or closing it after the sign-in already
+// finished — is a no-op.
+func (s *ProviderSelector) cancelInteractiveLogin() {
+	if s.cancelLogin == nil {
+		return
+	}
+	s.cancelLogin()
+	s.cancelLogin = nil
+}
+
+// HandleLoginPrompt shows what an in-flight interactive sign-in needs from the
+// user. It is ignored once the sign-in it belongs to has resolved, so a late
+// prompt can't reinstate the instruction over a finished row.
+func (s *ProviderSelector) HandleLoginPrompt(msg providerLoginPromptMsg) {
+	if !s.IsConnecting() || msg.AuthIdx != s.lastConnectAuthIdx {
+		return
+	}
+	s.loginPrompt = msg.Prompt
 }
 
 // HandleConnectResult updates the selector state with connection result.

--- a/internal/app/input/on_provider_auth.go
+++ b/internal/app/input/on_provider_auth.go
@@ -263,16 +263,24 @@ func (s *ProviderSelector) executeCredentialRemove() tea.Cmd {
 	return nil
 }
 
-// tryConnectOrPromptKey connects if env vars are available, otherwise shows API key input.
-func (s *ProviderSelector) tryConnectOrPromptKey(am providerAuthMethodItem, providerIdx, authIdx int) tea.Cmd {
+// tryConnectOrPromptKey connects if env vars are available, otherwise shows API
+// key input.
+//
+// formAuthIdx addresses the auth method within its provider, which is what the
+// API-key form needs to route the entered key. The connect helpers want
+// something different — the visible row their spinner and result render on —
+// so they take s.selectedIdx, the row the user pressed Enter on. The two agree
+// only for the first row, which is why mixing them up parks the spinner on
+// whatever provider happens to be listed first.
+func (s *ProviderSelector) tryConnectOrPromptKey(am providerAuthMethodItem, providerIdx, formAuthIdx int) tea.Cmd {
 	// Interactive (OAuth) auth signs in via the browser, not an API key. If a
 	// prior token is present, validate it with the normal connect path instead
 	// of forcing a fresh browser login.
 	if llm.SupportsInteractiveLogin(am.Provider, am.AuthMethod) {
 		if llm.HasInteractiveCredentials(am.Provider, am.AuthMethod) {
-			return s.connectAuthMethod(am, authIdx)
+			return s.connectAuthMethod(am, s.selectedIdx)
 		}
-		return s.connectInteractive(am, authIdx)
+		return s.connectInteractive(am, s.selectedIdx)
 	}
 
 	if am.Status == llm.StatusAvailable || providerIsEnvReady(am.EnvVars) {
@@ -285,7 +293,7 @@ func (s *ProviderSelector) tryConnectOrPromptKey(am providerAuthMethodItem, prov
 		return nil
 	}
 	s.apiKeyProviderIdx = providerIdx
-	s.apiKeyAuthIdx = authIdx
+	s.apiKeyAuthIdx = formAuthIdx
 	s.initAPIKeyInput(envVar)
 	return nil
 }

--- a/internal/app/input/on_provider_data.go
+++ b/internal/app/input/on_provider_data.go
@@ -421,6 +421,7 @@ func (s *ProviderSelector) resetNavigation() {
 // Cancel cancels the selector and clears transient state so the next open starts cleanly.
 func (s *ProviderSelector) Cancel() {
 	s.active = false
+	s.cancelInteractiveLogin()
 	s.connectedProviders = nil
 	s.allProviders = nil
 	s.allModels = nil

--- a/internal/app/input/on_provider_test.go
+++ b/internal/app/input/on_provider_test.go
@@ -917,6 +917,10 @@ func TestLoginPromptShowsDeviceCodeUntilSignInResolves(t *testing.T) {
 	if !strings.Contains(hints, "github.com/login/device") {
 		t.Errorf("hints = %q, want the verification URL", hints)
 	}
+	// Esc is what abandons the sign-in, so the prompt must not displace it.
+	if !strings.Contains(hints, "Esc cancel") {
+		t.Errorf("hints = %q, want Esc to stay visible during a sign-in", hints)
+	}
 
 	// Once the sign-in resolves the instruction is stale, so the footer goes
 	// back to the normal key hints.
@@ -975,20 +979,9 @@ func TestLoginPromptDoesNotHideModalHints(t *testing.T) {
 	})
 
 	// A sign-in can be pending for 15 minutes; a modal opened during it owns the
-	// footer, because its keys are the only ones not documented anywhere else.
+	// footer, because its keys are documented nowhere else.
 	m.confirmRemoveActive = true
 	if got := m.renderHints(); !strings.Contains(got, "y confirm") {
 		t.Errorf("hints = %q, want the confirm-remove keys while its modal is open", got)
-	}
-
-	// With no modal up, the prompt shows — but never at the cost of Esc, which
-	// is what abandons the sign-in.
-	m.confirmRemoveActive = false
-	got := m.renderHints()
-	if !strings.Contains(got, "ABCD-1234") {
-		t.Errorf("hints = %q, want the device code", got)
-	}
-	if !strings.Contains(got, "Esc cancel") {
-		t.Errorf("hints = %q, want Esc to stay visible during a sign-in", got)
 	}
 }

--- a/internal/app/input/on_provider_test.go
+++ b/internal/app/input/on_provider_test.go
@@ -985,3 +985,43 @@ func TestLoginPromptDoesNotHideModalHints(t *testing.T) {
 		t.Errorf("hints = %q, want the confirm-remove keys while its modal is open", got)
 	}
 }
+
+// TestInteractiveConnectMarksTheSelectedRow pins the spinner and result to the
+// row the user pressed Enter on. The auth-method index the API-key form uses is
+// a different number, and handing that to the connect helpers instead parked the
+// spinner on whichever provider was listed first.
+func TestInteractiveConnectMarksTheSelectedRow(t *testing.T) {
+	// Both interactive branches: reusing a stored token, and a fresh sign-in.
+	for _, stored := range []bool{true, false} {
+		t.Run(fmt.Sprintf("stored=%v", stored), func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			providerName := llm.Name(strings.ToLower(strings.ReplaceAll(t.Name(), "/", "-")))
+			authMethod := llm.AuthMethod("subscription-row")
+
+			llm.Register(llm.Meta{
+				Provider:    providerName,
+				AuthMethod:  authMethod,
+				DisplayName: "Row Index Test",
+			}, func(context.Context) (llm.Provider, error) {
+				return &staticListProvider{name: string(providerName)}, nil
+			})
+			llm.RegisterAuthenticator(providerName, authMethod, &storedCredentialAuthenticator{has: stored})
+			t.Cleanup(func() { llm.Unregister(providerName, authMethod) })
+
+			m := NewProviderSelector()
+			m.active = true
+			m.selectedIdx = 4
+
+			// A single-auth-method provider row passes 0 as the form's auth
+			// index; the spinner must still land on row 4, not row 0.
+			m.tryConnectOrPromptKey(providerAuthMethodItem{
+				Provider:   providerName,
+				AuthMethod: authMethod,
+			}, 2, 0)
+
+			if m.lastConnectAuthIdx != 4 {
+				t.Errorf("lastConnectAuthIdx = %d, want the selected row 4", m.lastConnectAuthIdx)
+			}
+		})
+	}
+}

--- a/internal/app/input/on_provider_test.go
+++ b/internal/app/input/on_provider_test.go
@@ -965,3 +965,30 @@ func TestLoginPromptWithoutCodeJustPointsAtTheBrowser(t *testing.T) {
 		t.Errorf("renderLoginPrompt = %q, want the authorize URL", got)
 	}
 }
+
+func TestLoginPromptDoesNotHideModalHints(t *testing.T) {
+	m := NewProviderSelector()
+	m.active = true
+	m.beginConnect(providerStatusConnecting, 0)
+	m.HandleLoginPrompt(providerLoginPromptMsg{
+		Prompt: llm.LoginPrompt{URL: "https://github.com/login/device", UserCode: "ABCD-1234"},
+	})
+
+	// A sign-in can be pending for 15 minutes; a modal opened during it owns the
+	// footer, because its keys are the only ones not documented anywhere else.
+	m.confirmRemoveActive = true
+	if got := m.renderHints(); !strings.Contains(got, "y confirm") {
+		t.Errorf("hints = %q, want the confirm-remove keys while its modal is open", got)
+	}
+
+	// With no modal up, the prompt shows — but never at the cost of Esc, which
+	// is what abandons the sign-in.
+	m.confirmRemoveActive = false
+	got := m.renderHints()
+	if !strings.Contains(got, "ABCD-1234") {
+		t.Errorf("hints = %q, want the device code", got)
+	}
+	if !strings.Contains(got, "Esc cancel") {
+		t.Errorf("hints = %q, want Esc to stay visible during a sign-in", got)
+	}
+}

--- a/internal/app/input/on_provider_test.go
+++ b/internal/app/input/on_provider_test.go
@@ -910,23 +910,33 @@ func TestLoginPromptShowsDeviceCodeUntilSignInResolves(t *testing.T) {
 		Prompt:  llm.LoginPrompt{URL: "https://github.com/login/device", UserCode: "ABCD-1234"},
 	})
 
-	hints := m.renderHints()
-	if !strings.Contains(hints, "ABCD-1234") {
-		t.Errorf("hints = %q, want the device code — it is shown nowhere else", hints)
+	// The code rides on the connecting provider's own row, so it is obvious
+	// which sign-in it belongs to; the row is where the spinner already is.
+	row := xansi.Strip(m.appendConnectResult("2 auth methods", 3))
+	if !strings.Contains(row, "ABCD-1234") {
+		t.Errorf("row = %q, want the device code beside the spinner", row)
 	}
+	if other := xansi.Strip(m.appendConnectResult("", 4)); strings.Contains(other, "ABCD-1234") {
+		t.Errorf("row 4 = %q, want the code only on the connecting row", other)
+	}
+
+	// The URL is long and the same every time, so it stays in the footer where
+	// there is width for it — alongside the Esc that abandons the sign-in.
+	hints := xansi.Strip(m.renderHints())
 	if !strings.Contains(hints, "github.com/login/device") {
 		t.Errorf("hints = %q, want the verification URL", hints)
 	}
-	// Esc is what abandons the sign-in, so the prompt must not displace it.
 	if !strings.Contains(hints, "Esc cancel") {
 		t.Errorf("hints = %q, want Esc to stay visible during a sign-in", hints)
 	}
 
-	// Once the sign-in resolves the instruction is stale, so the footer goes
-	// back to the normal key hints.
+	// Once the sign-in resolves the instruction is stale everywhere.
 	m.HandleConnectResult(providerConnectResultMsg{AuthIdx: 3, Success: false, Message: "sign-in failed"})
-	if got := m.renderHints(); strings.Contains(got, "ABCD-1234") {
-		t.Errorf("hints = %q, want the device code gone after the sign-in resolved", got)
+	if got := xansi.Strip(m.appendConnectResult("", 3)); strings.Contains(got, "ABCD-1234") {
+		t.Errorf("row = %q, want the device code gone after the sign-in resolved", got)
+	}
+	if got := xansi.Strip(m.renderHints()); strings.Contains(got, "login/device") {
+		t.Errorf("hints = %q, want the URL gone after the sign-in resolved", got)
 	}
 }
 

--- a/internal/app/input/on_provider_test.go
+++ b/internal/app/input/on_provider_test.go
@@ -70,7 +70,7 @@ type storedCredentialAuthenticator struct {
 	has        bool
 }
 
-func (a *storedCredentialAuthenticator) Login(context.Context, func(string)) error {
+func (a *storedCredentialAuthenticator) Login(context.Context, func(llm.LoginPrompt)) error {
 	a.loginCalls++
 	return fmt.Errorf("unexpected login")
 }
@@ -897,5 +897,71 @@ func TestRebuildModelsTabSortsByNameDescending(t *testing.T) {
 	want := []string{"unknown", "large", "current-small", "medium-b", "medium-a"}
 	if strings.Join(ids, ",") != strings.Join(want, ",") {
 		t.Fatalf("model order = %v, want %v", ids, want)
+	}
+}
+
+func TestLoginPromptShowsDeviceCodeUntilSignInResolves(t *testing.T) {
+	m := NewProviderSelector()
+	m.active = true
+	m.beginConnect(providerStatusConnecting, 3)
+
+	m.HandleLoginPrompt(providerLoginPromptMsg{
+		AuthIdx: 3,
+		Prompt:  llm.LoginPrompt{URL: "https://github.com/login/device", UserCode: "ABCD-1234"},
+	})
+
+	hints := m.renderHints()
+	if !strings.Contains(hints, "ABCD-1234") {
+		t.Errorf("hints = %q, want the device code — it is shown nowhere else", hints)
+	}
+	if !strings.Contains(hints, "github.com/login/device") {
+		t.Errorf("hints = %q, want the verification URL", hints)
+	}
+
+	// Once the sign-in resolves the instruction is stale, so the footer goes
+	// back to the normal key hints.
+	m.HandleConnectResult(providerConnectResultMsg{AuthIdx: 3, Success: false, Message: "sign-in failed"})
+	if got := m.renderHints(); strings.Contains(got, "ABCD-1234") {
+		t.Errorf("hints = %q, want the device code gone after the sign-in resolved", got)
+	}
+}
+
+func TestLoginPromptIgnoredWhenNoSignInIsPending(t *testing.T) {
+	m := NewProviderSelector()
+	m.active = true
+
+	// No connect in flight: a late prompt must not paint an instruction over a
+	// row the user is done with.
+	m.HandleLoginPrompt(providerLoginPromptMsg{
+		AuthIdx: 3,
+		Prompt:  llm.LoginPrompt{URL: "https://github.com/login/device", UserCode: "ABCD-1234"},
+	})
+	if got := m.renderLoginPrompt(); got != "" {
+		t.Errorf("renderLoginPrompt = %q, want empty with no sign-in pending", got)
+	}
+
+	// A prompt for a different row is stale too.
+	m.beginConnect(providerStatusConnecting, 3)
+	m.HandleLoginPrompt(providerLoginPromptMsg{
+		AuthIdx: 9,
+		Prompt:  llm.LoginPrompt{URL: "https://github.com/login/device", UserCode: "WXYZ-5678"},
+	})
+	if got := m.renderLoginPrompt(); got != "" {
+		t.Errorf("renderLoginPrompt = %q, want empty for a prompt from another row", got)
+	}
+}
+
+func TestLoginPromptWithoutCodeJustPointsAtTheBrowser(t *testing.T) {
+	m := NewProviderSelector()
+	m.active = true
+	m.beginConnect(providerStatusConnecting, 0)
+
+	m.HandleLoginPrompt(providerLoginPromptMsg{
+		Prompt: llm.LoginPrompt{URL: "https://auth.openai.com/oauth/authorize?x=1"},
+	})
+
+	got := m.renderLoginPrompt()
+	if !strings.Contains(got, "auth.openai.com") {
+		t.Errorf("renderLoginPrompt = %q, want the authorize URL", got)
 	}
 }

--- a/internal/app/input/on_provider_view.go
+++ b/internal/app/input/on_provider_view.go
@@ -379,11 +379,6 @@ func (s *ProviderSelector) renderConfirmRemove() string {
 // ── Footer hints ────────────────────────────────────────────────────────────
 
 func (s *ProviderSelector) renderHints() string {
-	// A sign-in waiting on the browser takes the footer: the device code exists
-	// nowhere else, so the user can't finish without seeing it here.
-	if prompt := s.renderLoginPrompt(); prompt != "" {
-		return prompt
-	}
 	if s.customFormActive {
 		return kit.DimStyle().Render("Tab/↑/↓ switch field · Enter save & connect · Esc cancel")
 	}
@@ -395,6 +390,14 @@ func (s *ProviderSelector) renderHints() string {
 	}
 	if s.confirmRemoveActive {
 		return kit.DimStyle().Render("y confirm · any other key cancel")
+	}
+
+	// A sign-in waiting on the browser takes the footer once the modals above
+	// have had their say — their own instructions are the only ones on screen,
+	// while the device code can still be recovered from the log. Esc stays
+	// visible either way, since it is what abandons the sign-in.
+	if prompt := s.renderLoginPrompt(); prompt != "" {
+		return prompt + kit.DimStyle().Render(" · Esc cancel")
 	}
 
 	var parts []string

--- a/internal/app/input/on_provider_view.go
+++ b/internal/app/input/on_provider_view.go
@@ -410,10 +410,10 @@ func (s *ProviderSelector) renderHints() string {
 	return kit.DimStyle().Render(strings.Join(parts, " · "))
 }
 
-// renderLoginPrompt renders the instruction for an interactive sign-in that is
-// still waiting on the browser, or "" when none is pending. Device flows put
-// the code first and highlighted — it is the part the user has to copy, and it
-// is shown nowhere else.
+// renderLoginPrompt renders where to complete an interactive sign-in that is
+// still waiting on the browser, or "" when none is pending. For a device flow
+// the code itself rides on the provider's row next to the spinner, so this only
+// carries the page to open.
 func (s *ProviderSelector) renderLoginPrompt() string {
 	if s.loginPrompt.URL == "" || !s.IsConnecting() {
 		return ""
@@ -421,9 +421,7 @@ func (s *ProviderSelector) renderLoginPrompt() string {
 	if s.loginPrompt.UserCode == "" {
 		return kit.DimStyle().Render("Finish the sign-in in your browser: " + s.loginPrompt.URL)
 	}
-	code := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Accent).Bold(true).Render(s.loginPrompt.UserCode)
-	return kit.DimStyle().Render("Enter code ") + code +
-		kit.DimStyle().Render(" at "+s.loginPrompt.URL)
+	return kit.DimStyle().Render("Enter the code at " + s.loginPrompt.URL)
 }
 
 // ── Connection result ───────────────────────────────────────────────────────
@@ -436,7 +434,9 @@ func (s *ProviderSelector) appendConnectResult(envInfo string, itemIdx int) stri
 		return envInfo
 	}
 	result := s.renderConnectResult()
-	if envInfo == "" {
+	// Measure, don't compare: a styled empty string still carries ANSI codes, so
+	// a provider with nothing in its info column would otherwise get the gap.
+	if lipgloss.Width(envInfo) == 0 {
 		return result
 	}
 	return envInfo + "   " + result
@@ -462,10 +462,24 @@ func (s *ProviderSelector) connectResultStyle() lipgloss.Style {
 var providerSpinnerFrames = kit.BrailleSpinnerFrames
 
 func (s *ProviderSelector) renderConnectResult() string {
-	// While in flight, show just the animated braille spinner (no text).
-	if s.IsConnecting() {
-		frame := providerSpinnerFrames[s.spinnerTick%len(providerSpinnerFrames)]
-		return kit.DimStyle().Render(frame)
+	if !s.IsConnecting() {
+		return s.connectResultStyle().Render(s.lastConnectResult)
 	}
-	return s.connectResultStyle().Render(s.lastConnectResult)
+
+	// While in flight the row shows the animated braille spinner, plus the
+	// device code when one is pending. The code sits here rather than in the
+	// footer because it belongs to this provider, and it is short enough to fit
+	// the info column at any panel width; its URL is long and identical every
+	// time, so that stays in the footer.
+	frame := kit.DimStyle().Render(providerSpinnerFrames[s.spinnerTick%len(providerSpinnerFrames)])
+	if s.loginPrompt.UserCode == "" {
+		return frame
+	}
+	return frame + " " + loginCodeStyle().Render(s.loginPrompt.UserCode)
+}
+
+// loginCodeStyle highlights the device code — it is the one thing on screen the
+// user has to copy.
+func loginCodeStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(kit.CurrentTheme.Accent).Bold(true)
 }

--- a/internal/app/input/on_provider_view.go
+++ b/internal/app/input/on_provider_view.go
@@ -379,6 +379,11 @@ func (s *ProviderSelector) renderConfirmRemove() string {
 // ── Footer hints ────────────────────────────────────────────────────────────
 
 func (s *ProviderSelector) renderHints() string {
+	// A sign-in waiting on the browser takes the footer: the device code exists
+	// nowhere else, so the user can't finish without seeing it here.
+	if prompt := s.renderLoginPrompt(); prompt != "" {
+		return prompt
+	}
 	if s.customFormActive {
 		return kit.DimStyle().Render("Tab/↑/↓ switch field · Enter save & connect · Esc cancel")
 	}
@@ -401,6 +406,22 @@ func (s *ProviderSelector) renderHints() string {
 	}
 	parts = append(parts, "←/→/Tab switch", "Esc cancel")
 	return kit.DimStyle().Render(strings.Join(parts, " · "))
+}
+
+// renderLoginPrompt renders the instruction for an interactive sign-in that is
+// still waiting on the browser, or "" when none is pending. Device flows put
+// the code first and highlighted — it is the part the user has to copy, and it
+// is shown nowhere else.
+func (s *ProviderSelector) renderLoginPrompt() string {
+	if s.loginPrompt.URL == "" || !s.IsConnecting() {
+		return ""
+	}
+	if s.loginPrompt.UserCode == "" {
+		return kit.DimStyle().Render("Finish the sign-in in your browser: " + s.loginPrompt.URL)
+	}
+	code := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Accent).Bold(true).Render(s.loginPrompt.UserCode)
+	return kit.DimStyle().Render("Enter code ") + code +
+		kit.DimStyle().Render(" at "+s.loginPrompt.URL)
 }
 
 // ── Connection result ───────────────────────────────────────────────────────

--- a/internal/app/input/on_provider_view.go
+++ b/internal/app/input/on_provider_view.go
@@ -393,9 +393,8 @@ func (s *ProviderSelector) renderHints() string {
 	}
 
 	// A sign-in waiting on the browser takes the footer once the modals above
-	// have had their say — their own instructions are the only ones on screen,
-	// while the device code can still be recovered from the log. Esc stays
-	// visible either way, since it is what abandons the sign-in.
+	// have had their say — their keys are documented nowhere else, while the
+	// device code can still be recovered from the log.
 	if prompt := s.renderLoginPrompt(); prompt != "" {
 		return prompt + kit.DimStyle().Render(" · Esc cancel")
 	}

--- a/internal/llm/auth.go
+++ b/internal/llm/auth.go
@@ -5,6 +5,15 @@ import (
 	"fmt"
 )
 
+// LoginPrompt is what the user has to do to finish an interactive sign-in: the
+// page to open and, for device-code flows, the code to type there. A
+// browser-callback (PKCE) flow leaves UserCode empty, because opening the URL
+// is the whole instruction.
+type LoginPrompt struct {
+	URL      string
+	UserCode string
+}
+
 // Authenticator performs interactive (non-API-key) sign-in for a provider auth
 // method — e.g. an OAuth subscription login. Provider packages register one per
 // (provider, authMethod) alongside their factory, so product code can trigger
@@ -12,9 +21,10 @@ import (
 // package.
 type Authenticator interface {
 	// Login runs the interactive sign-in, persisting credentials on success.
-	// onURL, if non-nil, receives a URL the user must visit — useful when a
-	// browser cannot be opened automatically (e.g. over SSH).
-	Login(ctx context.Context, onURL func(string)) error
+	// onPrompt, if non-nil, receives the instruction the user must follow —
+	// needed when a browser cannot be opened automatically (e.g. over SSH), and
+	// always needed for device-code flows, where the code exists nowhere else.
+	Login(ctx context.Context, onPrompt func(LoginPrompt)) error
 	// Logout clears any stored credentials for the auth method.
 	Logout() error
 }
@@ -58,12 +68,12 @@ func HasInteractiveCredentials(provider Name, authMethod AuthMethod) bool {
 }
 
 // Login runs the interactive sign-in for a provider auth method.
-func Login(ctx context.Context, provider Name, authMethod AuthMethod, onURL func(string)) error {
+func Login(ctx context.Context, provider Name, authMethod AuthMethod, onPrompt func(LoginPrompt)) error {
 	a := globalRegistry.authenticator(provider, authMethod)
 	if a == nil {
 		return fmt.Errorf("provider %s:%s does not support interactive login", provider, authMethod)
 	}
-	return a.Login(ctx, onURL)
+	return a.Login(ctx, onPrompt)
 }
 
 // Logout clears stored credentials for a provider auth method. It is a no-op for

--- a/internal/llm/auth_test.go
+++ b/internal/llm/auth_test.go
@@ -11,9 +11,9 @@ type fakeAuthenticator struct {
 	hasCredentials bool
 }
 
-func (f *fakeAuthenticator) Login(_ context.Context, onURL func(string)) error {
-	if onURL != nil {
-		onURL("https://example.com/authorize")
+func (f *fakeAuthenticator) Login(_ context.Context, onPrompt func(LoginPrompt)) error {
+	if onPrompt != nil {
+		onPrompt(LoginPrompt{URL: "https://example.com/authorize", UserCode: "ABCD-1234"})
 	}
 	f.loggedIn = true
 	return nil
@@ -60,15 +60,15 @@ func TestAuthenticatorRegistrationAndDispatch(t *testing.T) {
 		t.Fatal("expected stored credentials after the fake reports them")
 	}
 
-	var gotURL string
-	if err := Login(context.Background(), provider, method, func(u string) { gotURL = u }); err != nil {
+	var got LoginPrompt
+	if err := Login(context.Background(), provider, method, func(p LoginPrompt) { got = p }); err != nil {
 		t.Fatalf("Login: %v", err)
 	}
 	if !fa.loggedIn {
 		t.Error("Login was not dispatched to the authenticator")
 	}
-	if gotURL == "" {
-		t.Error("onURL callback was not invoked")
+	if got.URL == "" || got.UserCode == "" {
+		t.Errorf("onPrompt callback did not deliver the sign-in instruction: %+v", got)
 	}
 
 	if err := Logout(provider, method); err != nil || !fa.loggedOut {

--- a/internal/llm/copilot/catalog.go
+++ b/internal/llm/copilot/catalog.go
@@ -1,0 +1,106 @@
+package copilot
+
+import (
+	"cmp"
+	"slices"
+
+	"github.com/genai-io/san/internal/llm"
+)
+
+// modelsResponse is the Copilot /models catalog. It lists every model the
+// account is entitled to, across vendors (OpenAI, Anthropic, Google, …), all
+// served through the same Chat Completions-shaped endpoint.
+type modelsResponse struct {
+	Data []catalogModel `json:"data"`
+}
+
+// catalogModel is one catalog entry. model_picker_enabled marks the models the
+// editor plugins offer users; the rest are internal or deprecated aliases.
+type catalogModel struct {
+	ID                 string             `json:"id"`
+	Name               string             `json:"name"`
+	Vendor             string             `json:"vendor"`
+	ModelPickerEnabled bool               `json:"model_picker_enabled"`
+	Capabilities       modelCapabilities  `json:"capabilities"`
+	Policy             *modelPolicyStatus `json:"policy"`
+}
+
+// modelCapabilities describes what an entry can do. Type separates chat models
+// from the embedding models the same catalog carries.
+type modelCapabilities struct {
+	Type     string        `json:"type"`
+	Limits   modelLimits   `json:"limits"`
+	Supports modelSupports `json:"supports"`
+}
+
+type modelLimits struct {
+	MaxContextWindowTokens int `json:"max_context_window_tokens"`
+	MaxOutputTokens        int `json:"max_output_tokens"`
+	MaxPromptTokens        int `json:"max_prompt_tokens"`
+}
+
+// modelSupports lists per-model features. Only tool calling is read: San drives
+// every model through tool calls, so it decides whether an entry is usable at
+// all. The catalog also reports `vision` per model, which San can't yet act on
+// — llm.ModelInfo has no image-support field to carry it through the model
+// store, so image requests opt in unconditionally and let the backend reject.
+type modelSupports struct {
+	ToolCalls bool `json:"tool_calls"`
+}
+
+// modelPolicyStatus reports per-model terms the user must accept once in
+// GitHub's settings. Until then the model is listed but rejects requests.
+type modelPolicyStatus struct {
+	State string `json:"state"`
+}
+
+// toModelInfos converts the catalog to llm.ModelInfo, keeping only the chat
+// models a user can actually run a turn with: san drives every model through
+// tool calls, so an entry without tool support would fail on the first turn.
+// Duplicate ids (the catalog repeats a model under several versions) collapse
+// to the first entry.
+func (r modelsResponse) toModelInfos() []llm.ModelInfo {
+	seen := make(map[string]bool, len(r.Data))
+	models := make([]llm.ModelInfo, 0, len(r.Data))
+
+	for _, m := range r.Data {
+		if m.ID == "" || seen[m.ID] {
+			continue
+		}
+		if !m.ModelPickerEnabled {
+			continue
+		}
+		if m.Capabilities.Type != "" && m.Capabilities.Type != "chat" {
+			continue
+		}
+		if !m.Capabilities.Supports.ToolCalls {
+			continue
+		}
+		// A model whose policy hasn't been accepted answers every request with
+		// an error until the user enables it on github.com, so listing it would
+		// only offer a broken choice.
+		if m.Policy != nil && m.Policy.State != "" && m.Policy.State != "enabled" {
+			continue
+		}
+		seen[m.ID] = true
+
+		name := cmp.Or(m.Name, m.ID)
+		models = append(models, llm.ModelInfo{
+			ID:               m.ID,
+			Name:             name,
+			DisplayName:      name,
+			InputTokenLimit:  m.Capabilities.Limits.contextWindow(),
+			OutputTokenLimit: m.Capabilities.Limits.MaxOutputTokens,
+		})
+	}
+
+	slices.SortFunc(models, func(a, b llm.ModelInfo) int { return cmp.Compare(a.ID, b.ID) })
+	return models
+}
+
+// contextWindow returns the usable input window. Most entries report the whole
+// window; a few only report the prompt budget, which is the same number for our
+// purposes (how much context san may send).
+func (l modelLimits) contextWindow() int {
+	return cmp.Or(l.MaxContextWindowTokens, l.MaxPromptTokens)
+}

--- a/internal/llm/copilot/catalog_test.go
+++ b/internal/llm/copilot/catalog_test.go
@@ -1,0 +1,93 @@
+package copilot
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// copilotCatalogJSON is a trimmed sample of the /models reply, covering each
+// kind of entry the conversion has to make a decision about.
+const copilotCatalogJSON = `{"data":[
+  {"id":"gpt-5","name":"GPT-5","vendor":"OpenAI","model_picker_enabled":true,
+   "capabilities":{"type":"chat","limits":{"max_context_window_tokens":272000,"max_output_tokens":128000},
+   "supports":{"tool_calls":true,"vision":true}}},
+  {"id":"gpt-5","name":"GPT-5 (duplicate version)","model_picker_enabled":true,
+   "capabilities":{"type":"chat","limits":{"max_context_window_tokens":1},"supports":{"tool_calls":true}}},
+  {"id":"claude-sonnet-4.5","name":"Claude Sonnet 4.5","vendor":"Anthropic","model_picker_enabled":true,
+   "capabilities":{"type":"chat","limits":{"max_prompt_tokens":144000,"max_output_tokens":16000},
+   "supports":{"tool_calls":true,"vision":true}}},
+  {"id":"text-embedding-3-small","model_picker_enabled":true,
+   "capabilities":{"type":"embeddings","supports":{"tool_calls":false}}},
+  {"id":"gpt-4o-internal","model_picker_enabled":false,
+   "capabilities":{"type":"chat","supports":{"tool_calls":true}}},
+  {"id":"no-tools-model","model_picker_enabled":true,
+   "capabilities":{"type":"chat","supports":{"tool_calls":false}}},
+  {"id":"unaccepted-terms","model_picker_enabled":true,"policy":{"state":"unconfigured"},
+   "capabilities":{"type":"chat","supports":{"tool_calls":true}}}
+]}`
+
+func parseCatalog(t *testing.T) modelsResponse {
+	t.Helper()
+	var resp modelsResponse
+	if err := json.Unmarshal([]byte(copilotCatalogJSON), &resp); err != nil {
+		t.Fatalf("unmarshal catalog: %v", err)
+	}
+	return resp
+}
+
+func TestCatalogKeepsOnlyRunnableChatModels(t *testing.T) {
+	models := parseCatalog(t).toModelInfos()
+
+	got := make([]string, len(models))
+	for i, m := range models {
+		got[i] = m.ID
+	}
+	// Sorted by id; embeddings, picker-hidden, tool-less, policy-blocked and
+	// duplicate entries are all dropped.
+	want := []string{"claude-sonnet-4.5", "gpt-5"}
+	if len(got) != len(want) {
+		t.Fatalf("models = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("models = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestCatalogCarriesTokenLimits(t *testing.T) {
+	byID := make(map[string]int)
+	outputByID := make(map[string]int)
+	for _, m := range parseCatalog(t).toModelInfos() {
+		byID[m.ID] = m.InputTokenLimit
+		outputByID[m.ID] = m.OutputTokenLimit
+	}
+
+	if byID["gpt-5"] != 272000 {
+		t.Errorf("gpt-5 input limit = %d, want 272000", byID["gpt-5"])
+	}
+	if outputByID["gpt-5"] != 128000 {
+		t.Errorf("gpt-5 output limit = %d, want 128000", outputByID["gpt-5"])
+	}
+	// Entries that only report a prompt budget still get a usable input limit —
+	// a zero one would break the context bar and auto-compact.
+	if byID["claude-sonnet-4.5"] != 144000 {
+		t.Errorf("claude-sonnet-4.5 input limit = %d, want the reported prompt budget 144000", byID["claude-sonnet-4.5"])
+	}
+}
+
+func TestCatalogFallsBackToIDWhenUnnamed(t *testing.T) {
+	resp := modelsResponse{Data: []catalogModel{{
+		ID:                 "bare-model",
+		ModelPickerEnabled: true,
+		Capabilities:       modelCapabilities{Type: "chat", Supports: modelSupports{ToolCalls: true}},
+	}}}
+
+	models := resp.toModelInfos()
+	if len(models) != 1 {
+		t.Fatalf("got %d models, want 1", len(models))
+	}
+	if models[0].DisplayName != "bare-model" {
+		t.Errorf("DisplayName = %q, want the id as fallback", models[0].DisplayName)
+	}
+}

--- a/internal/llm/copilot/client.go
+++ b/internal/llm/copilot/client.go
@@ -1,0 +1,126 @@
+// Package copilot implements the Provider interface for GitHub Copilot.
+//
+// Copilot's chat endpoint speaks OpenAI Chat Completions, so the openai-go SDK
+// drives it with a Copilot base URL plus the editor headers the backend gates
+// on. What differs from a normal OpenAI-compatible provider is authentication:
+// a GitHub subscription login rather than an API key, with a short-lived bearer
+// re-minted from the stored GitHub token as it expires.
+package copilot
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/packages/param"
+
+	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/llm/copilot/oauth"
+	"github.com/genai-io/san/internal/llm/openaicompat"
+)
+
+// modelsFetchTimeout bounds the catalog request so a slow or blocked fetch
+// doesn't wedge the connect flow.
+const modelsFetchTimeout = 8 * time.Second
+
+// Client implements the Provider interface for GitHub Copilot using the OpenAI SDK.
+type Client struct {
+	client openai.Client
+	name   string
+}
+
+// NewClient creates a new Copilot client with the given OpenAI SDK client.
+func NewClient(client openai.Client, name string) *Client {
+	return &Client{client: client, name: name}
+}
+
+// Name returns the provider name.
+func (c *Client) Name() string { return c.name }
+
+// Stream sends a completion request and returns a channel of streaming chunks.
+func (c *Client) Stream(ctx context.Context, opts llm.CompletionOptions) <-chan llm.StreamChunk {
+	return openaicompat.StreamChatCompletions(ctx, openaicompat.ChatStreamConfig{
+		Client:           c.client,
+		ProviderName:     c.name,
+		Options:          opts,
+		ConvertAssistant: openaicompat.DefaultAssistantMessage,
+		ConfigureParams:  useLegacyMaxTokens,
+		RequestOptions:   perRequestOptions(opts.Messages),
+	})
+}
+
+// useLegacyMaxTokens moves the output cap onto `max_tokens`, the field the
+// editor plugins send. GitHub publishes no schema for this endpoint, and
+// whether it also honours OpenAI's newer `max_completion_tokens` is unverified
+// — an unread cap means unbounded replies, so send the name known to work. The
+// two are mutually exclusive, so the new one has to go.
+func useLegacyMaxTokens(params *openai.ChatCompletionNewParams) {
+	if !params.MaxCompletionTokens.Valid() {
+		return
+	}
+	params.MaxTokens = openai.Int(params.MaxCompletionTokens.Value)
+	params.MaxCompletionTokens = param.Opt[int64]{}
+}
+
+// perRequestOptions builds the Copilot headers that depend on what this turn
+// actually sends. The rest of the editor identity is fixed on the client.
+func perRequestOptions(messages []core.Message) []option.RequestOption {
+	// Copilot meters an agent's follow-up turns differently from a turn the
+	// user typed, and reads that from X-Initiator. San infers it from the
+	// history — anything past the opening user message means the loop is
+	// driving — which is an approximation: a resumed session's first user turn
+	// still reads as "agent".
+	initiator := "user"
+	vision := false
+	for _, msg := range messages {
+		if msg.Role == core.RoleAssistant || msg.ToolResult != nil {
+			initiator = "agent"
+		}
+		if len(msg.Images) > 0 {
+			vision = true
+		}
+	}
+
+	opts := []option.RequestOption{option.WithHeader("X-Initiator", initiator)}
+	if vision {
+		// Image parts are rejected unless the request opts into vision.
+		opts = append(opts, option.WithHeader("Copilot-Vision-Request", "true"))
+	}
+	return opts
+}
+
+// ListModels returns the models this Copilot account is entitled to.
+//
+// Errors are propagated rather than masked with a fallback list: connect
+// verifies the subscription by listing models, and Copilot's lineup changes
+// often enough that a hardcoded catalog would mostly be wrong. A signed-out or
+// unentitled account must fail here instead of being recorded as connected and
+// failing on the first real request.
+func (c *Client) ListModels(ctx context.Context) ([]llm.ModelInfo, error) {
+	var resp modelsResponse
+	err := c.client.Get(ctx, "models", nil, &resp, option.WithRequestTimeout(modelsFetchTimeout))
+	if err != nil {
+		// Credential-source failures (raised by the auth middleware before the
+		// request is sent) and a 401/403 from the endpoint both mean the same
+		// thing here: sign in again. Subscription auth has no API key to check,
+		// so don't route either through the API-key-oriented normalizer.
+		var credErr *oauth.CredentialError
+		if errors.As(err, &credErr) || openaicompat.IsAuthError(err) {
+			return nil, fmt.Errorf("GitHub Copilot sign-in required: %w", err)
+		}
+		return nil, openaicompat.NormalizeAPIError(c.name, err)
+	}
+
+	models := resp.toModelInfos()
+	if len(models) == 0 {
+		return nil, errors.New("this GitHub account has no Copilot chat models available")
+	}
+	return models, nil
+}
+
+// Ensure Client implements Provider
+var _ llm.Provider = (*Client)(nil)

--- a/internal/llm/copilot/client_test.go
+++ b/internal/llm/copilot/client_test.go
@@ -1,0 +1,255 @@
+package copilot
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+
+	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/llm/copilot/oauth"
+)
+
+// recordingTransport captures the request and replies with a canned body, so
+// tests can assert on the URL and headers the provider actually sends.
+type recordingTransport struct {
+	status int
+	body   string
+	last   *http.Request
+}
+
+func (r *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.last = req
+	status := r.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(r.body)),
+		Request:    req,
+	}, nil
+}
+
+func newTestClient(tr http.RoundTripper) *Client {
+	sdk := openai.NewClient(
+		option.WithBaseURL("https://api.githubcopilot.com/"),
+		option.WithAPIKey("test-bearer"),
+		option.WithMaxRetries(0),
+		option.WithHTTPClient(&http.Client{Transport: tr}),
+	)
+	return NewClient(sdk, "copilot:subscription")
+}
+
+func TestListModelsRequestsTheCatalogEndpoint(t *testing.T) {
+	tr := &recordingTransport{body: copilotCatalogJSON}
+
+	models, err := newTestClient(tr).ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if len(models) == 0 {
+		t.Fatal("expected the catalog to yield models")
+	}
+	if got := tr.last.URL.String(); got != "https://api.githubcopilot.com/models" {
+		t.Errorf("catalog URL = %q, want the Copilot /models endpoint", got)
+	}
+}
+
+func TestListModelsFailsWhenNoChatModelsAreEntitled(t *testing.T) {
+	// An account with only embedding entitlements can't run a turn, so connect
+	// must fail rather than record a provider with nothing to select.
+	tr := &recordingTransport{body: `{"data":[{"id":"text-embedding-3-small","model_picker_enabled":true,
+	  "capabilities":{"type":"embeddings","supports":{"tool_calls":false}}}]}`}
+
+	if _, err := newTestClient(tr).ListModels(context.Background()); err == nil {
+		t.Fatal("expected ListModels to fail when no chat model is available")
+	}
+}
+
+// TestListModelsAsksForSignInOnEndpointAuthFailure covers the 401/403 the
+// endpoint itself returns. Subscription auth has no API key to check, so the
+// advice must be "sign in", not the normalizer's "check your key".
+func TestListModelsAsksForSignInOnEndpointAuthFailure(t *testing.T) {
+	tr := &recordingTransport{status: http.StatusUnauthorized, body: `{"error":{"message":"bad token"}}`}
+
+	_, err := newTestClient(tr).ListModels(context.Background())
+	if err == nil {
+		t.Fatal("expected ListModels to surface a 401 rather than fall back")
+	}
+	if !strings.Contains(err.Error(), "sign-in required") {
+		t.Errorf("ListModels error = %q, want it to say sign-in is required", err)
+	}
+}
+
+// TestListModelsReportsSignInWhenCredentialIsMissing covers the other half: a
+// credential failure raised by the token source before any request goes out.
+func TestListModelsReportsSignInWhenCredentialIsMissing(t *testing.T) {
+	sdk := openai.NewClient(
+		option.WithBaseURL("https://api.githubcopilot.com/"),
+		option.WithAPIKey("test-bearer"),
+		option.WithMaxRetries(0),
+		option.WithMiddleware(func(*http.Request, option.MiddlewareNext) (*http.Response, error) {
+			return nil, &oauth.CredentialError{Err: errors.New("not signed in")}
+		}),
+	)
+
+	_, err := NewClient(sdk, "copilot:subscription").ListModels(context.Background())
+	var credErr *oauth.CredentialError
+	if !errors.As(err, &credErr) {
+		t.Fatalf("ListModels error = %T (%v), want the credential error preserved", err, err)
+	}
+	if !strings.Contains(err.Error(), "sign-in required") {
+		t.Errorf("ListModels error = %q, want it to say sign-in is required", err)
+	}
+}
+
+// streamHeaders runs one turn through the client and returns the headers that
+// reached the wire — the per-turn headers are only observable there, since the
+// SDK's request options are opaque until applied.
+func streamHeaders(t *testing.T, messages []core.Message) http.Header {
+	t.Helper()
+	tr := &recordingTransport{body: "data: [DONE]\n\n"}
+
+	stream := newTestClient(tr).Stream(context.Background(), llm.CompletionOptions{
+		Model:    "gpt-5",
+		Messages: messages,
+	})
+	for range stream { //nolint:revive // draining the stream is what completes the request
+	}
+
+	if tr.last == nil {
+		t.Fatal("no request was sent")
+	}
+	return tr.last.Header
+}
+
+func TestStreamMarksAgentTurns(t *testing.T) {
+	tests := []struct {
+		name     string
+		messages []core.Message
+		want     string
+	}{
+		{
+			name:     "first user turn",
+			messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+			want:     "user",
+		},
+		{
+			name: "turn after an assistant reply",
+			messages: []core.Message{
+				{Role: core.RoleUser, Content: "hi"},
+				{Role: core.RoleAssistant, Content: "hello"},
+				{Role: core.RoleUser, Content: "again"},
+			},
+			want: "agent",
+		},
+		{
+			name: "turn replaying a tool result",
+			messages: []core.Message{
+				{Role: core.RoleUser, Content: "hi"},
+				{Role: core.RoleUser, ToolResult: &core.ToolResult{ToolCallID: "1", Content: "done"}},
+			},
+			want: "agent",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := streamHeaders(t, tc.messages).Get("X-Initiator"); got != tc.want {
+				t.Errorf("X-Initiator = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStreamOptsIntoVisionOnlyWithImages(t *testing.T) {
+	textOnly := []core.Message{{Role: core.RoleUser, Content: "hi"}}
+	if got := streamHeaders(t, textOnly).Get("Copilot-Vision-Request"); got != "" {
+		t.Errorf("vision header on a text-only turn = %q, want it unset", got)
+	}
+
+	withImage := []core.Message{{
+		Role:    core.RoleUser,
+		Content: "what is this",
+		Images:  []core.Image{{MediaType: "image/png", Data: "aGk="}},
+	}}
+	if got := streamHeaders(t, withImage).Get("Copilot-Vision-Request"); got != "true" {
+		t.Errorf("vision header on an image turn = %q, want true", got)
+	}
+}
+
+func TestSubscriptionMetaUsesInteractiveAuth(t *testing.T) {
+	if SubscriptionMeta.Provider != llm.Copilot {
+		t.Errorf("provider = %q, want copilot", SubscriptionMeta.Provider)
+	}
+	if SubscriptionMeta.AuthMethod != llm.AuthSubscription {
+		t.Errorf("auth method = %q, want subscription", SubscriptionMeta.AuthMethod)
+	}
+	// EnvVars must stay empty: a non-empty list would make the registry treat
+	// the provider as API-key auth and skip the sign-in path entirely.
+	if len(SubscriptionMeta.EnvVars) != 0 {
+		t.Errorf("EnvVars = %v, want none for an OAuth provider", SubscriptionMeta.EnvVars)
+	}
+	if !llm.SupportsInteractiveLogin(llm.Copilot, llm.AuthSubscription) {
+		t.Error("copilot:subscription should register an interactive authenticator")
+	}
+}
+
+func TestRetargetSwitchesToEnterpriseHost(t *testing.T) {
+	req, err := http.NewRequest(http.MethodPost, "https://api.githubcopilot.com/chat/completions", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	retarget(req, "https://api.business.githubcopilot.com")
+	if req.URL.Host != "api.business.githubcopilot.com" {
+		t.Errorf("host = %q, want the reported enterprise host", req.URL.Host)
+	}
+	if req.URL.Path != "/chat/completions" {
+		t.Errorf("path = %q, want it preserved", req.URL.Path)
+	}
+
+	// A malformed endpoint must leave the request alone rather than send it nowhere.
+	retarget(req, "::not a url::")
+	if req.URL.Host != "api.business.githubcopilot.com" {
+		t.Errorf("host = %q, want it unchanged by an unparseable endpoint", req.URL.Host)
+	}
+}
+
+func TestStreamSendsTheOutputCapAsMaxTokens(t *testing.T) {
+	tr := &recordingTransport{body: "data: [DONE]\n\n"}
+
+	stream := newTestClient(tr).Stream(context.Background(), llm.CompletionOptions{
+		Model:     "gpt-5",
+		MaxTokens: 4096,
+		Messages:  []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	for range stream { //nolint:revive // draining the stream is what completes the request
+	}
+
+	body, err := io.ReadAll(tr.last.Body)
+	if err != nil {
+		t.Fatalf("read request body: %v", err)
+	}
+	var sent map[string]any
+	if err := json.Unmarshal(body, &sent); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	if got, ok := sent["max_tokens"]; !ok || got != float64(4096) {
+		t.Errorf("max_tokens = %v (present=%v), want 4096", got, ok)
+	}
+	// The two caps are mutually exclusive; sending both is a 400.
+	if _, ok := sent["max_completion_tokens"]; ok {
+		t.Error("max_completion_tokens was sent alongside max_tokens")
+	}
+}

--- a/internal/llm/copilot/oauth/device.go
+++ b/internal/llm/copilot/oauth/device.go
@@ -1,0 +1,179 @@
+package oauth
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/genai-io/san/internal/proc"
+)
+
+// loginTimeout bounds how long we wait for the user to authorize the device
+// before giving up. GitHub's own device codes expire in 15 minutes.
+const loginTimeout = 15 * time.Minute
+
+// UserCode is the device-flow instruction for the user: the page to open and
+// the code to type there. GitHub does not offer a pre-filled verification URL,
+// so the code has to reach the user through the UI — it exists nowhere else.
+type UserCode struct {
+	VerificationURI string
+	Code            string
+}
+
+// Login runs the GitHub device-flow sign-in for Copilot. It requests a device
+// code, hands the user code to onCode, opens the verification page, polls until
+// the user authorizes, then verifies the account actually has Copilot access
+// before persisting anything. It blocks until the flow completes, the context
+// is cancelled, or it times out.
+func Login(ctx context.Context, onCode func(UserCode)) error {
+	ctx, cancel := context.WithTimeout(ctx, loginTimeout)
+	defer cancel()
+
+	device, err := requestDeviceCode(ctx)
+	if err != nil {
+		return err
+	}
+	if onCode != nil {
+		onCode(UserCode{VerificationURI: device.VerificationURI, Code: device.UserCode})
+	}
+	_ = proc.OpenURL(device.VerificationURI) // best-effort; onCode lets the caller show it if this fails.
+
+	githubToken, err := pollAccessToken(ctx, device, pollInterval(device))
+	if err != nil {
+		return err
+	}
+
+	// Verify entitlement before storing: a GitHub account without an active
+	// Copilot subscription authorizes the device fine and only fails later, at
+	// the first request. Minting the bearer here turns that into a clear
+	// sign-in error and warms the token cache in the same round-trip.
+	tokens, err := MintBearer(ctx, Tokens{GitHubToken: githubToken})
+	if err != nil {
+		return err
+	}
+	if err := save(tokens); err != nil {
+		return fmt.Errorf("save credentials: %w", err)
+	}
+	return nil
+}
+
+// deviceCodeResponse is GitHub's reply to the device-code request. The reply
+// also carries expires_in, which loginTimeout already covers.
+type deviceCodeResponse struct {
+	DeviceCode      string `json:"device_code"`
+	UserCode        string `json:"user_code"`
+	VerificationURI string `json:"verification_uri"`
+	Interval        int    `json:"interval"`
+}
+
+// requestDeviceCode starts the device flow.
+func requestDeviceCode(ctx context.Context) (deviceCodeResponse, error) {
+	var out deviceCodeResponse
+	err := postJSON(ctx, deviceCodeURL, map[string]string{
+		"client_id": ClientID,
+		"scope":     scope,
+	}, &out)
+	if err != nil {
+		return deviceCodeResponse{}, fmt.Errorf("request device code: %w", err)
+	}
+	if out.DeviceCode == "" || out.UserCode == "" {
+		return deviceCodeResponse{}, errors.New("GitHub returned no device code")
+	}
+	if out.VerificationURI == "" {
+		out.VerificationURI = githubBaseURL + "/login/device"
+	}
+	return out, nil
+}
+
+// accessTokenResponse is GitHub's reply while polling. A pending or throttled
+// poll comes back 200 with an `error` code rather than an HTTP error status.
+type accessTokenResponse struct {
+	AccessToken      string `json:"access_token"`
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+// pollInterval is how long to wait between polls: what GitHub asks for, with a
+// floor so a missing or over-eager interval can't get us rate-limited.
+func pollInterval(device deviceCodeResponse) time.Duration {
+	return time.Duration(max(device.Interval, 5)) * time.Second
+}
+
+// slowDownBackoff widens the poll interval after GitHub rate-limits us. The
+// device-flow spec asks for five extra seconds each time.
+func slowDownBackoff(interval time.Duration) time.Duration { return interval + 5*time.Second }
+
+// pollAccessToken polls until the user authorizes the device, honouring the
+// interval GitHub asks for and backing off further when told to slow down.
+func pollAccessToken(ctx context.Context, device deviceCodeResponse, interval time.Duration) (string, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return "", fmt.Errorf("sign-in did not complete: %w", ctx.Err())
+		case <-time.After(interval):
+		}
+
+		var out accessTokenResponse
+		if err := postJSON(ctx, accessTokenURL, map[string]string{
+			"client_id":   ClientID,
+			"device_code": device.DeviceCode,
+			"grant_type":  "urn:ietf:params:oauth:grant-type:device_code",
+		}, &out); err != nil {
+			// A transient network blip mid-poll shouldn't abort a flow the user
+			// may already be completing in the browser; keep polling until the
+			// device code itself expires.
+			continue
+		}
+
+		switch out.Error {
+		case "":
+			if out.AccessToken == "" {
+				continue
+			}
+			return out.AccessToken, nil
+		case "authorization_pending":
+			// The user hasn't finished in the browser yet.
+		case "slow_down":
+			interval = slowDownBackoff(interval)
+		case "expired_token":
+			return "", errors.New("the sign-in code expired before it was entered — try again")
+		case "access_denied":
+			return "", errors.New("sign-in was denied in the browser")
+		default:
+			return "", fmt.Errorf("sign-in failed: %s", cmp.Or(out.ErrorDescription, out.Error))
+		}
+	}
+}
+
+// postJSON posts a JSON body to a GitHub OAuth endpoint and decodes the reply.
+func postJSON(ctx context.Context, endpoint string, payload map[string]string, out any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", UserAgent)
+
+	resp, err := httpClient().Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("%s returned %s", endpoint, resp.Status)
+	}
+	return json.Unmarshal(raw, out)
+}

--- a/internal/llm/copilot/oauth/device.go
+++ b/internal/llm/copilot/oauth/device.go
@@ -49,18 +49,32 @@ func Login(ctx context.Context, onCode func(UserCode)) error {
 		return err
 	}
 
-	// Verify entitlement before storing: a GitHub account without an active
-	// Copilot subscription authorizes the device fine and only fails later, at
-	// the first request. Minting the bearer here turns that into a clear
-	// sign-in error and warms the token cache in the same round-trip.
-	tokens, err := MintBearer(ctx, Tokens{GitHubToken: githubToken})
-	if err != nil {
-		return err
+	return persistSignIn(ctx, githubToken)
+}
+
+// persistSignIn stores what the device flow just earned. It mints a bearer
+// first, because a GitHub account without an active Copilot subscription
+// authorizes the device fine and would otherwise only fail at the first
+// request — minting here turns that into a clear sign-in error and warms the
+// token cache in the same round-trip.
+//
+// Only the account's own verdict (revoked token, no subscription) is worth
+// discarding the credential over. A transient exchange failure still keeps the
+// GitHub token, so a retry can re-mint instead of sending the user back through
+// a fresh 15-minute device flow.
+func persistSignIn(ctx context.Context, githubToken string) error {
+	tokens, mintErr := MintBearer(ctx, Tokens{GitHubToken: githubToken})
+	if mintErr != nil {
+		var notEntitled *NotEntitledError
+		if errors.As(mintErr, &notEntitled) {
+			return mintErr
+		}
+		tokens = Tokens{GitHubToken: githubToken}
 	}
 	if err := save(tokens); err != nil {
 		return fmt.Errorf("save credentials: %w", err)
 	}
-	return nil
+	return mintErr
 }
 
 // deviceCodeResponse is GitHub's reply to the device-code request. The reply
@@ -112,9 +126,18 @@ func slowDownBackoff(interval time.Duration) time.Duration { return interval + 5
 // pollAccessToken polls until the user authorizes the device, honouring the
 // interval GitHub asks for and backing off further when told to slow down.
 func pollAccessToken(ctx context.Context, device deviceCodeResponse, interval time.Duration) (string, error) {
+	// A poll failure is never fatal on its own — the user may still be finishing
+	// in the browser — but a permanently failing endpoint (an org policy that
+	// bars device flow, a proxy rejecting the call) would otherwise time out
+	// with nothing to show for it, so the last one is kept to report at the end.
+	var lastErr error
+
 	for {
 		select {
 		case <-ctx.Done():
+			if lastErr != nil {
+				return "", fmt.Errorf("sign-in did not complete: %w", lastErr)
+			}
 			return "", fmt.Errorf("sign-in did not complete: %w", ctx.Err())
 		case <-time.After(interval):
 		}
@@ -125,11 +148,10 @@ func pollAccessToken(ctx context.Context, device deviceCodeResponse, interval ti
 			"device_code": device.DeviceCode,
 			"grant_type":  "urn:ietf:params:oauth:grant-type:device_code",
 		}, &out); err != nil {
-			// A transient network blip mid-poll shouldn't abort a flow the user
-			// may already be completing in the browser; keep polling until the
-			// device code itself expires.
+			lastErr = err
 			continue
 		}
+		lastErr = nil
 
 		switch out.Error {
 		case "":

--- a/internal/llm/copilot/oauth/device.go
+++ b/internal/llm/copilot/oauth/device.go
@@ -28,9 +28,9 @@ type UserCode struct {
 
 // Login runs the GitHub device-flow sign-in for Copilot. It requests a device
 // code, hands the user code to onCode, opens the verification page, polls until
-// the user authorizes, then verifies the account actually has Copilot access
-// before persisting anything. It blocks until the flow completes, the context
-// is cancelled, or it times out.
+// the user authorizes, then mints a bearer to confirm Copilot access before
+// reporting success. It blocks until the flow completes, the context is
+// cancelled, or it times out.
 func Login(ctx context.Context, onCode func(UserCode)) error {
 	ctx, cancel := context.WithTimeout(ctx, loginTimeout)
 	defer cancel()
@@ -58,18 +58,18 @@ func Login(ctx context.Context, onCode func(UserCode)) error {
 // request — minting here turns that into a clear sign-in error and warms the
 // token cache in the same round-trip.
 //
-// Only the account's own verdict (revoked token, no subscription) is worth
-// discarding the credential over. A transient exchange failure still keeps the
-// GitHub token, so a retry can re-mint instead of sending the user back through
-// a fresh 15-minute device flow.
+// Only the account's own verdict is worth discarding the credential over; a
+// transient exchange failure keeps the GitHub token so a retry can re-mint.
 func persistSignIn(ctx context.Context, githubToken string) error {
-	tokens, mintErr := MintBearer(ctx, Tokens{GitHubToken: githubToken})
+	authorized := Tokens{GitHubToken: githubToken}
+
+	tokens, mintErr := MintBearer(ctx, authorized)
 	if mintErr != nil {
-		var notEntitled *NotEntitledError
+		var notEntitled *notEntitledError
 		if errors.As(mintErr, &notEntitled) {
 			return mintErr
 		}
-		tokens = Tokens{GitHubToken: githubToken}
+		tokens = authorized
 	}
 	if err := save(tokens); err != nil {
 		return fmt.Errorf("save credentials: %w", err)
@@ -127,18 +127,14 @@ func slowDownBackoff(interval time.Duration) time.Duration { return interval + 5
 // interval GitHub asks for and backing off further when told to slow down.
 func pollAccessToken(ctx context.Context, device deviceCodeResponse, interval time.Duration) (string, error) {
 	// A poll failure is never fatal on its own — the user may still be finishing
-	// in the browser — but a permanently failing endpoint (an org policy that
-	// bars device flow, a proxy rejecting the call) would otherwise time out
-	// with nothing to show for it, so the last one is kept to report at the end.
+	// in the browser — but an endpoint that rejects every poll would otherwise
+	// time out with nothing to show for it, so keep the last one to report.
 	var lastErr error
 
 	for {
 		select {
 		case <-ctx.Done():
-			if lastErr != nil {
-				return "", fmt.Errorf("sign-in did not complete: %w", lastErr)
-			}
-			return "", fmt.Errorf("sign-in did not complete: %w", ctx.Err())
+			return "", fmt.Errorf("sign-in did not complete: %w", cmp.Or(lastErr, ctx.Err()))
 		case <-time.After(interval):
 		}
 

--- a/internal/llm/copilot/oauth/device_test.go
+++ b/internal/llm/copilot/oauth/device_test.go
@@ -1,0 +1,94 @@
+package oauth
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPollAccessTokenWaitsOutAuthorizationPending(t *testing.T) {
+	tr := &stubTransport{bodies: []string{
+		`{"error":"authorization_pending"}`,
+		`{"error":"authorization_pending"}`,
+		`{"access_token":"gho_granted"}`,
+	}}
+	serveStub(t, tr)
+
+	token, err := pollAccessToken(context.Background(), deviceCodeResponse{DeviceCode: "dev"}, time.Millisecond)
+	if err != nil {
+		t.Fatalf("pollAccessToken: %v", err)
+	}
+	if token != "gho_granted" {
+		t.Errorf("token = %q, want gho_granted", token)
+	}
+	if tr.calls != 3 {
+		t.Errorf("polled %d times, want 3 (two pending, then granted)", tr.calls)
+	}
+}
+
+func TestPollAccessTokenStopsOnTerminalErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		wantInErr string
+	}{
+		{"expired code", `{"error":"expired_token"}`, "expired"},
+		{"user declined", `{"error":"access_denied"}`, "denied"},
+		{"unknown failure", `{"error":"unsupported_grant_type","error_description":"bad grant"}`, "bad grant"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			serveStub(t, &stubTransport{bodies: []string{tc.body}})
+
+			_, err := pollAccessToken(context.Background(), deviceCodeResponse{DeviceCode: "dev"}, time.Millisecond)
+			if err == nil || !strings.Contains(err.Error(), tc.wantInErr) {
+				t.Fatalf("pollAccessToken = %v, want an error mentioning %q", err, tc.wantInErr)
+			}
+		})
+	}
+}
+
+func TestSlowDownWidensPollInterval(t *testing.T) {
+	if got := slowDownBackoff(5 * time.Second); got != 10*time.Second {
+		t.Errorf("slowDownBackoff(5s) = %v, want 10s", got)
+	}
+}
+
+func TestPollAccessTokenGivesUpWhenCancelled(t *testing.T) {
+	serveStub(t, &stubTransport{bodies: []string{`{"error":"authorization_pending"}`}})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	if _, err := pollAccessToken(ctx, deviceCodeResponse{DeviceCode: "dev"}, 5*time.Millisecond); err == nil {
+		t.Fatal("expected pollAccessToken to stop when the context is cancelled")
+	}
+}
+
+func TestRequestDeviceCodeDefaultsVerificationURI(t *testing.T) {
+	serveStub(t, &stubTransport{bodies: []string{
+		`{"device_code":"dev","user_code":"ABCD-1234","interval":5}`,
+	}})
+
+	device, err := requestDeviceCode(context.Background())
+	if err != nil {
+		t.Fatalf("requestDeviceCode: %v", err)
+	}
+	if device.UserCode != "ABCD-1234" {
+		t.Errorf("user code = %q, want ABCD-1234", device.UserCode)
+	}
+	if device.VerificationURI != githubBaseURL+"/login/device" {
+		t.Errorf("verification URI = %q, want the default device page", device.VerificationURI)
+	}
+}
+
+func TestPollIntervalHasFloor(t *testing.T) {
+	if got := pollInterval(deviceCodeResponse{Interval: 0}); got != 5*time.Second {
+		t.Errorf("pollInterval with no interval = %v, want the 5s floor", got)
+	}
+	if got := pollInterval(deviceCodeResponse{Interval: 12}); got != 12*time.Second {
+		t.Errorf("pollInterval = %v, want GitHub's 12s", got)
+	}
+}

--- a/internal/llm/copilot/oauth/device_test.go
+++ b/internal/llm/copilot/oauth/device_test.go
@@ -57,14 +57,43 @@ func TestSlowDownWidensPollInterval(t *testing.T) {
 	}
 }
 
-func TestPollAccessTokenGivesUpWhenCancelled(t *testing.T) {
-	serveStub(t, &stubTransport{bodies: []string{`{"error":"authorization_pending"}`}})
+func TestPollAccessTokenReportsWhyItGaveUp(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		body      string
+		wantInErr string
+	}{
+		{
+			name:      "still waiting on the browser",
+			body:      `{"error":"authorization_pending"}`,
+			wantInErr: "context deadline exceeded",
+		},
+		{
+			// An org policy that bars the device flow rejects every poll; the
+			// timeout alone would tell the user nothing about why.
+			name:      "endpoint rejects every poll",
+			status:    http.StatusForbidden,
+			body:      `{}`,
+			wantInErr: "403",
+		},
+	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
-	defer cancel()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			serveStub(t, &stubTransport{status: tc.status, bodies: []string{tc.body}})
 
-	if _, err := pollAccessToken(ctx, deviceCodeResponse{DeviceCode: "dev"}, 5*time.Millisecond); err == nil {
-		t.Fatal("expected pollAccessToken to stop when the context is cancelled")
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+			defer cancel()
+
+			_, err := pollAccessToken(ctx, deviceCodeResponse{DeviceCode: "dev"}, 5*time.Millisecond)
+			if err == nil {
+				t.Fatal("expected pollAccessToken to give up")
+			}
+			if !strings.Contains(err.Error(), tc.wantInErr) {
+				t.Errorf("error = %q, want it to mention %q", err, tc.wantInErr)
+			}
+		})
 	}
 }
 
@@ -122,22 +151,5 @@ func TestPersistSignInDiscardsCredentialWithoutEntitlement(t *testing.T) {
 	}
 	if HasCredentials() {
 		t.Error("expected no stored credentials when the account has no Copilot access")
-	}
-}
-
-func TestPollAccessTokenReportsThePersistentHTTPFailure(t *testing.T) {
-	// An org policy that bars the device flow fails every poll; the timeout
-	// message alone would tell the user nothing about why.
-	serveStub(t, &stubTransport{status: http.StatusForbidden, bodies: []string{`{}`}})
-
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
-	defer cancel()
-
-	_, err := pollAccessToken(ctx, deviceCodeResponse{DeviceCode: "dev"}, 5*time.Millisecond)
-	if err == nil {
-		t.Fatal("expected pollAccessToken to fail")
-	}
-	if !strings.Contains(err.Error(), "403") {
-		t.Errorf("error = %q, want the underlying HTTP failure surfaced", err)
 	}
 }

--- a/internal/llm/copilot/oauth/device_test.go
+++ b/internal/llm/copilot/oauth/device_test.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -90,5 +91,53 @@ func TestPollIntervalHasFloor(t *testing.T) {
 	}
 	if got := pollInterval(deviceCodeResponse{Interval: 12}); got != 12*time.Second {
 		t.Errorf("pollInterval = %v, want GitHub's 12s", got)
+	}
+}
+
+func TestPersistSignInKeepsTokenWhenTheExchangeBlips(t *testing.T) {
+	isolateSecrets(t)
+	serveStub(t, &stubTransport{status: http.StatusBadGateway, bodies: []string{`{}`}})
+
+	// The browser authorization already succeeded, so the GitHub token is good;
+	// only the bearer exchange failed. Throwing it away would cost the user
+	// another full device flow.
+	err := persistSignIn(context.Background(), "gho_authorized")
+	if err == nil {
+		t.Fatal("expected persistSignIn to report the failed exchange")
+	}
+	stored, ok := load()
+	if !ok || stored.GitHubToken != "gho_authorized" {
+		t.Errorf("stored credentials = %+v, want the authorized GitHub token kept", stored)
+	}
+}
+
+func TestPersistSignInDiscardsCredentialWithoutEntitlement(t *testing.T) {
+	isolateSecrets(t)
+	serveStub(t, &stubTransport{status: http.StatusForbidden, bodies: []string{`{}`}})
+
+	// No Copilot subscription is the account's own verdict — retrying with the
+	// same token can never work, so nothing should be left behind.
+	if err := persistSignIn(context.Background(), "gho_authorized"); err == nil {
+		t.Fatal("expected persistSignIn to fail without a subscription")
+	}
+	if HasCredentials() {
+		t.Error("expected no stored credentials when the account has no Copilot access")
+	}
+}
+
+func TestPollAccessTokenReportsThePersistentHTTPFailure(t *testing.T) {
+	// An org policy that bars the device flow fails every poll; the timeout
+	// message alone would tell the user nothing about why.
+	serveStub(t, &stubTransport{status: http.StatusForbidden, bodies: []string{`{}`}})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	_, err := pollAccessToken(ctx, deviceCodeResponse{DeviceCode: "dev"}, 5*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected pollAccessToken to fail")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("error = %q, want the underlying HTTP failure surfaced", err)
 	}
 }

--- a/internal/llm/copilot/oauth/token.go
+++ b/internal/llm/copilot/oauth/token.go
@@ -92,10 +92,7 @@ func (t Tokens) bearerStale() bool {
 // endpoint returns the Copilot API root to call, defaulting to the individual
 // one when the exchange didn't report a specific host.
 func (t Tokens) endpoint() string {
-	if t.APIEndpoint == "" {
-		return DefaultAPIEndpoint
-	}
-	return t.APIEndpoint
+	return cmp.Or(t.APIEndpoint, DefaultAPIEndpoint)
 }
 
 // load reads the stored credential blob. The bool is false when no usable blob exists.
@@ -152,14 +149,14 @@ type CredentialError struct{ Err error }
 func (e *CredentialError) Error() string { return e.Err.Error() }
 func (e *CredentialError) Unwrap() error { return e.Err }
 
-// NotEntitledError marks a mint that the account itself can never satisfy: the
-// GitHub token was revoked, or the plan carries no Copilot. It separates those
-// from a transient exchange failure, so a caller can tell whether the stored
-// GitHub token is still worth keeping.
-type NotEntitledError struct{ Err error }
+// notEntitledError marks a mint the account itself can never satisfy — a
+// revoked GitHub token, or a plan without Copilot — as opposed to a transient
+// exchange failure. Sign-in uses it to decide whether the credential is worth
+// keeping for a retry.
+type notEntitledError struct{ Err error }
 
-func (e *NotEntitledError) Error() string { return e.Err.Error() }
-func (e *NotEntitledError) Unwrap() error { return e.Err }
+func (e *notEntitledError) Error() string { return e.Err.Error() }
+func (e *notEntitledError) Unwrap() error { return e.Err }
 
 // TokenSource returns a valid Copilot bearer and the API endpoint to send it
 // to, re-minting the bearer when it nears expiry. It is safe for concurrent
@@ -239,9 +236,9 @@ func MintBearer(ctx context.Context, t Tokens) (Tokens, error) {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	switch {
 	case resp.StatusCode == http.StatusUnauthorized:
-		return Tokens{}, &NotEntitledError{errors.New("GitHub rejected the stored token — sign in again")}
+		return Tokens{}, &notEntitledError{errors.New("GitHub rejected the stored token — sign in again")}
 	case resp.StatusCode == http.StatusForbidden:
-		return Tokens{}, &NotEntitledError{errors.New("this GitHub account has no active Copilot subscription")}
+		return Tokens{}, &notEntitledError{errors.New("this GitHub account has no active Copilot subscription")}
 	case resp.StatusCode < 200 || resp.StatusCode >= 300:
 		return Tokens{}, fmt.Errorf("copilot token endpoint returned %s", resp.Status)
 	}

--- a/internal/llm/copilot/oauth/token.go
+++ b/internal/llm/copilot/oauth/token.go
@@ -11,6 +11,7 @@
 package oauth
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -151,6 +152,15 @@ type CredentialError struct{ Err error }
 func (e *CredentialError) Error() string { return e.Err.Error() }
 func (e *CredentialError) Unwrap() error { return e.Err }
 
+// NotEntitledError marks a mint that the account itself can never satisfy: the
+// GitHub token was revoked, or the plan carries no Copilot. It separates those
+// from a transient exchange failure, so a caller can tell whether the stored
+// GitHub token is still worth keeping.
+type NotEntitledError struct{ Err error }
+
+func (e *NotEntitledError) Error() string { return e.Err.Error() }
+func (e *NotEntitledError) Unwrap() error { return e.Err }
+
 // TokenSource returns a valid Copilot bearer and the API endpoint to send it
 // to, re-minting the bearer when it nears expiry. It is safe for concurrent
 // use; mints are serialized so a burst of requests triggers at most one.
@@ -184,9 +194,9 @@ func (ts *TokenSource) Token(ctx context.Context) (bearer, apiEndpoint string, e
 		}
 		return "", "", &CredentialError{fmt.Errorf("Copilot token refresh failed: %w", err)}
 	}
-	if err := save(minted); err != nil {
-		return "", "", &CredentialError{fmt.Errorf("save credentials: %w", err)}
-	}
+	// Persisting is only a warm start for the next process — the bearer in hand
+	// is valid either way, so an unwritable store must not fail a live turn.
+	_ = save(minted)
 	return minted.CopilotToken, minted.endpoint(), nil
 }
 
@@ -229,9 +239,9 @@ func MintBearer(ctx context.Context, t Tokens) (Tokens, error) {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	switch {
 	case resp.StatusCode == http.StatusUnauthorized:
-		return Tokens{}, errors.New("GitHub rejected the stored token — sign in again")
+		return Tokens{}, &NotEntitledError{errors.New("GitHub rejected the stored token — sign in again")}
 	case resp.StatusCode == http.StatusForbidden:
-		return Tokens{}, errors.New("this GitHub account has no active Copilot subscription")
+		return Tokens{}, &NotEntitledError{errors.New("this GitHub account has no active Copilot subscription")}
 	case resp.StatusCode < 200 || resp.StatusCode >= 300:
 		return Tokens{}, fmt.Errorf("copilot token endpoint returned %s", resp.Status)
 	}
@@ -246,7 +256,10 @@ func MintBearer(ctx context.Context, t Tokens) (Tokens, error) {
 
 	updated := t
 	updated.CopilotToken = ctr.Token
-	updated.APIEndpoint = ctr.Endpoints.API
+	// Keep the endpoint we already know when a reply omits it: dropping back to
+	// the individual host would send an enterprise bearer to the wrong API for
+	// the rest of the session, and across restarts.
+	updated.APIEndpoint = cmp.Or(ctr.Endpoints.API, t.APIEndpoint)
 	updated.ExpiresAt = bearerExpiry(ctr.ExpiresAt)
 	return updated, nil
 }

--- a/internal/llm/copilot/oauth/token.go
+++ b/internal/llm/copilot/oauth/token.go
@@ -1,0 +1,265 @@
+// Package oauth implements GitHub Copilot sign-in: the GitHub OAuth 2.0 device
+// flow that yields a long-lived GitHub token, plus the exchange of that token
+// for the short-lived bearer the Copilot API requires, and the storage and
+// refresh around both.
+//
+// It lets a user with a GitHub Copilot subscription drive san without a metered
+// API key, mirroring how the official editor plugins authenticate. The package
+// depends only on the stdlib and leaf infrastructure (internal/secret,
+// internal/proc) — never on internal/llm — so a headless `san login` command
+// could reuse it later.
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/genai-io/san/internal/secret"
+)
+
+const (
+	// ClientID is the GitHub Copilot editor plugin's public OAuth client id. We
+	// reuse it on purpose: copilot_internal/v2/token only mints API bearers for
+	// GitHub tokens issued to a Copilot-enabled OAuth client, so a client id of
+	// our own would be rejected there.
+	ClientID = "Iv1.b507a08c87ecfe98"
+
+	// scope is all the device flow needs — the Copilot entitlement rides on the
+	// account, not on an extra scope.
+	scope = "read:user"
+
+	githubBaseURL   = "https://github.com"
+	deviceCodeURL   = githubBaseURL + "/login/device/code"
+	accessTokenURL  = githubBaseURL + "/login/oauth/access_token"
+	copilotTokenURL = "https://api.github.com/copilot_internal/v2/token"
+
+	// DefaultAPIEndpoint is the Copilot API root for individual accounts.
+	// Business/enterprise accounts are served from their own host, which the
+	// token exchange reports back.
+	DefaultAPIEndpoint = "https://api.githubcopilot.com"
+
+	// StoreKey is the secret-store key under which the credential blob is persisted.
+	StoreKey = "GITHUB_COPILOT_AUTH"
+
+	// refreshWindow is how long before expiry we proactively mint a new Copilot
+	// bearer. The bearer lives around 30 minutes, so this still uses most of it.
+	refreshWindow = 5 * time.Minute
+
+	// httpTimeout bounds each auth round-trip so a hung endpoint can't wedge a
+	// sign-in or an in-flight turn's token refresh.
+	httpTimeout = 30 * time.Second
+)
+
+// Editor identity sent on every GitHub and Copilot API call. The backend only
+// serves clients it recognises as a Copilot chat plugin, so these mirror what
+// GitHub's own VS Code extension sends. Exported because the provider client
+// puts the same values on its chat requests.
+const (
+	copilotChatVersion = "0.26.7"
+
+	EditorVersion       = "vscode/1.99.3"
+	EditorPluginVersion = "copilot-chat/" + copilotChatVersion
+	UserAgent           = "GitHubCopilotChat/" + copilotChatVersion
+	APIVersion          = "2025-04-01"
+	IntegrationID       = "vscode-chat"
+)
+
+// Tokens is the persisted credential blob for Copilot subscription auth. The
+// GitHub token is the durable credential; the Copilot bearer and its endpoint
+// are a cache of the last exchange, re-minted whenever they go stale.
+type Tokens struct {
+	GitHubToken  string    `json:"github_token"`
+	CopilotToken string    `json:"copilot_token"`
+	APIEndpoint  string    `json:"api_endpoint"`
+	ExpiresAt    time.Time `json:"expires_at"`
+}
+
+func (t Tokens) usable() bool { return t.GitHubToken != "" }
+
+// bearerStale reports whether the cached Copilot bearer is missing or within
+// refreshWindow of expiry.
+func (t Tokens) bearerStale() bool {
+	return t.CopilotToken == "" || time.Now().After(t.ExpiresAt.Add(-refreshWindow))
+}
+
+// endpoint returns the Copilot API root to call, defaulting to the individual
+// one when the exchange didn't report a specific host.
+func (t Tokens) endpoint() string {
+	if t.APIEndpoint == "" {
+		return DefaultAPIEndpoint
+	}
+	return t.APIEndpoint
+}
+
+// load reads the stored credential blob. The bool is false when no usable blob exists.
+func load() (Tokens, bool) {
+	s := secret.Default()
+	if s == nil {
+		return Tokens{}, false
+	}
+	raw := s.Get(StoreKey)
+	if raw == "" {
+		return Tokens{}, false
+	}
+	var t Tokens
+	if err := json.Unmarshal([]byte(raw), &t); err != nil {
+		return Tokens{}, false
+	}
+	return t, t.usable()
+}
+
+// save persists the credential blob to the secret store (0600, via secret.Store).
+func save(t Tokens) error {
+	s := secret.Default()
+	if s == nil {
+		return errors.New("secret store unavailable")
+	}
+	raw, err := json.Marshal(t)
+	if err != nil {
+		return err
+	}
+	return s.Set(StoreKey, string(raw))
+}
+
+// Logout clears the stored Copilot subscription credentials.
+func Logout() error {
+	s := secret.Default()
+	if s == nil {
+		return nil
+	}
+	return s.Delete(StoreKey)
+}
+
+// HasCredentials reports whether a usable credential blob is stored.
+func HasCredentials() bool {
+	_, ok := load()
+	return ok
+}
+
+// CredentialError marks a failure to produce a valid Copilot bearer — not
+// signed in, or a GitHub token that no longer buys Copilot access (revoked, or
+// a lapsed subscription). It signals the connection isn't usable, so callers
+// should surface it rather than fall back to a degraded path.
+type CredentialError struct{ Err error }
+
+func (e *CredentialError) Error() string { return e.Err.Error() }
+func (e *CredentialError) Unwrap() error { return e.Err }
+
+// TokenSource returns a valid Copilot bearer and the API endpoint to send it
+// to, re-minting the bearer when it nears expiry. It is safe for concurrent
+// use; mints are serialized so a burst of requests triggers at most one.
+type TokenSource struct {
+	mu sync.Mutex
+}
+
+// NewTokenSource creates a TokenSource backed by the persisted credentials.
+func NewTokenSource() *TokenSource { return &TokenSource{} }
+
+// Token returns a currently-valid Copilot bearer and the API root it is scoped
+// to. Failures to obtain a credential are returned as *CredentialError.
+func (ts *TokenSource) Token(ctx context.Context) (bearer, apiEndpoint string, err error) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	t, ok := load()
+	if !ok {
+		return "", "", &CredentialError{errors.New("not signed in to GitHub Copilot — connect the Copilot Subscription provider first")}
+	}
+	if !t.bearerStale() {
+		return t.CopilotToken, t.endpoint(), nil
+	}
+
+	minted, err := MintBearer(ctx, t)
+	if err != nil {
+		// A transient mint failure shouldn't break an in-flight turn while the
+		// cached bearer is still technically valid; only surface it once expired.
+		if t.CopilotToken != "" && time.Now().Before(t.ExpiresAt) {
+			return t.CopilotToken, t.endpoint(), nil
+		}
+		return "", "", &CredentialError{fmt.Errorf("Copilot token refresh failed: %w", err)}
+	}
+	if err := save(minted); err != nil {
+		return "", "", &CredentialError{fmt.Errorf("save credentials: %w", err)}
+	}
+	return minted.CopilotToken, minted.endpoint(), nil
+}
+
+// copilotTokenResponse is the reply from copilot_internal/v2/token. The bearer
+// is short-lived; endpoints.api names the host it is valid against.
+type copilotTokenResponse struct {
+	Token     string `json:"token"`
+	ExpiresAt int64  `json:"expires_at"`
+	Endpoints struct {
+		API string `json:"api"`
+	} `json:"endpoints"`
+}
+
+// MintBearer exchanges the GitHub token for a fresh Copilot bearer, returning
+// the credential blob updated with it. It does not persist — the caller decides
+// whether the result is worth storing (sign-in verifies entitlement with it
+// before saving anything).
+func MintBearer(ctx context.Context, t Tokens) (Tokens, error) {
+	if t.GitHubToken == "" {
+		return Tokens{}, errors.New("no GitHub token available; sign in again")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, copilotTokenURL, nil)
+	if err != nil {
+		return Tokens{}, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "token "+t.GitHubToken)
+	req.Header.Set("Editor-Version", EditorVersion)
+	req.Header.Set("Editor-Plugin-Version", EditorPluginVersion)
+	req.Header.Set("User-Agent", UserAgent)
+	req.Header.Set("X-GitHub-Api-Version", APIVersion)
+
+	resp, err := httpClient().Do(req)
+	if err != nil {
+		return Tokens{}, err
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized:
+		return Tokens{}, errors.New("GitHub rejected the stored token — sign in again")
+	case resp.StatusCode == http.StatusForbidden:
+		return Tokens{}, errors.New("this GitHub account has no active Copilot subscription")
+	case resp.StatusCode < 200 || resp.StatusCode >= 300:
+		return Tokens{}, fmt.Errorf("copilot token endpoint returned %s", resp.Status)
+	}
+
+	var ctr copilotTokenResponse
+	if err := json.Unmarshal(body, &ctr); err != nil {
+		return Tokens{}, fmt.Errorf("decode copilot token response: %w", err)
+	}
+	if ctr.Token == "" {
+		return Tokens{}, errors.New("copilot token endpoint returned no token")
+	}
+
+	updated := t
+	updated.CopilotToken = ctr.Token
+	updated.APIEndpoint = ctr.Endpoints.API
+	updated.ExpiresAt = bearerExpiry(ctr.ExpiresAt)
+	return updated, nil
+}
+
+// bearerExpiry converts the reported unix expiry, falling back to a
+// conservative window when the endpoint omits it.
+func bearerExpiry(expiresAt int64) time.Time {
+	if expiresAt > 0 {
+		return time.Unix(expiresAt, 0)
+	}
+	return time.Now().Add(20 * time.Minute)
+}
+
+// httpClient returns the client used for auth round-trips. It is a variable so
+// tests can answer the GitHub endpoints from a stub transport.
+var httpClient = func() *http.Client { return &http.Client{Timeout: httpTimeout} }

--- a/internal/llm/copilot/oauth/token_test.go
+++ b/internal/llm/copilot/oauth/token_test.go
@@ -165,6 +165,12 @@ func TestMintBearerReportsMissingSubscription(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "no active Copilot subscription") {
 		t.Fatalf("MintBearer on 403 = %v, want a missing-subscription error", err)
 	}
+	// The account's own verdict: sign-in must discard the credential, not keep
+	// it for a retry that can never succeed.
+	var notEntitled *notEntitledError
+	if !errors.As(err, &notEntitled) {
+		t.Errorf("MintBearer on 403 = %T, want *notEntitledError", err)
+	}
 }
 
 func TestMintBearerReportsRevokedToken(t *testing.T) {
@@ -173,6 +179,10 @@ func TestMintBearerReportsRevokedToken(t *testing.T) {
 	_, err := MintBearer(context.Background(), Tokens{GitHubToken: "gho_test"})
 	if err == nil || !strings.Contains(err.Error(), "sign in again") {
 		t.Fatalf("MintBearer on 401 = %v, want a sign-in-again error", err)
+	}
+	var notEntitled *notEntitledError
+	if !errors.As(err, &notEntitled) {
+		t.Errorf("MintBearer on 401 = %T, want *notEntitledError", err)
 	}
 }
 
@@ -213,21 +223,13 @@ func TestMintBearerKeepsKnownEndpointWhenReplyOmitsIt(t *testing.T) {
 	}
 }
 
-func TestMintBearerMarksAccountFailuresAsNotEntitled(t *testing.T) {
-	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
-		serveStub(t, &stubTransport{status: status, bodies: []string{`{}`}})
-
-		_, err := MintBearer(context.Background(), Tokens{GitHubToken: "gho_test"})
-		var notEntitled *NotEntitledError
-		if !errors.As(err, &notEntitled) {
-			t.Errorf("MintBearer on %d = %T (%v), want *NotEntitledError", status, err, err)
-		}
-	}
-
-	// A server-side blip is transient, not an account verdict.
+func TestMintBearerTreatsServerFailuresAsTransient(t *testing.T) {
+	// A 502 is the endpoint's problem, not a verdict on the account, so sign-in
+	// keeps the credential and retries rather than discarding it.
 	serveStub(t, &stubTransport{status: http.StatusBadGateway, bodies: []string{`{}`}})
+
 	_, err := MintBearer(context.Background(), Tokens{GitHubToken: "gho_test"})
-	var notEntitled *NotEntitledError
+	var notEntitled *notEntitledError
 	if errors.As(err, &notEntitled) {
 		t.Errorf("MintBearer on 502 = %v, want a plain transient error", err)
 	}

--- a/internal/llm/copilot/oauth/token_test.go
+++ b/internal/llm/copilot/oauth/token_test.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -32,10 +33,11 @@ func (s *stubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	status := cmp.Or(s.status, http.StatusOK)
 	return &http.Response{
 		StatusCode: status,
-		Status:     http.StatusText(status),
-		Header:     http.Header{"Content-Type": []string{"application/json"}},
-		Body:       io.NopCloser(strings.NewReader(body)),
-		Request:    req,
+		// Match net/http's "403 Forbidden" form — error messages quote it.
+		Status:  fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		Header:  http.Header{"Content-Type": []string{"application/json"}},
+		Body:    io.NopCloser(strings.NewReader(body)),
+		Request: req,
 	}, nil
 }
 
@@ -191,5 +193,42 @@ func TestHasCredentialsTracksStoredGitHubToken(t *testing.T) {
 	}
 	if HasCredentials() {
 		t.Error("expected no credentials after logout")
+	}
+}
+
+func TestMintBearerKeepsKnownEndpointWhenReplyOmitsIt(t *testing.T) {
+	serveStub(t, &stubTransport{bodies: []string{`{"token":"fresh-bearer","expires_at":0}`}})
+
+	// A reply without endpoints.api must not demote an enterprise account to the
+	// individual host — that would send its bearer to the wrong API from here on.
+	got, err := MintBearer(context.Background(), Tokens{
+		GitHubToken: "gho_test",
+		APIEndpoint: "https://api.business.githubcopilot.com",
+	})
+	if err != nil {
+		t.Fatalf("MintBearer: %v", err)
+	}
+	if got.APIEndpoint != "https://api.business.githubcopilot.com" {
+		t.Errorf("APIEndpoint = %q, want the previously known enterprise host", got.APIEndpoint)
+	}
+}
+
+func TestMintBearerMarksAccountFailuresAsNotEntitled(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		serveStub(t, &stubTransport{status: status, bodies: []string{`{}`}})
+
+		_, err := MintBearer(context.Background(), Tokens{GitHubToken: "gho_test"})
+		var notEntitled *NotEntitledError
+		if !errors.As(err, &notEntitled) {
+			t.Errorf("MintBearer on %d = %T (%v), want *NotEntitledError", status, err, err)
+		}
+	}
+
+	// A server-side blip is transient, not an account verdict.
+	serveStub(t, &stubTransport{status: http.StatusBadGateway, bodies: []string{`{}`}})
+	_, err := MintBearer(context.Background(), Tokens{GitHubToken: "gho_test"})
+	var notEntitled *NotEntitledError
+	if errors.As(err, &notEntitled) {
+		t.Errorf("MintBearer on 502 = %v, want a plain transient error", err)
 	}
 }

--- a/internal/llm/copilot/oauth/token_test.go
+++ b/internal/llm/copilot/oauth/token_test.go
@@ -1,0 +1,195 @@
+package oauth
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/genai-io/san/internal/secret"
+)
+
+// stubTransport answers requests with canned JSON, walking `bodies` in order
+// and repeating the last one once the script runs out — enough to model both a
+// single reply and a poll whose answer changes. It records the last request so
+// tests can assert on the headers we send.
+type stubTransport struct {
+	status int // 0 means 200
+	bodies []string
+	calls  int
+	last   *http.Request
+}
+
+func (s *stubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.last = req
+	body := s.bodies[min(s.calls, len(s.bodies)-1)]
+	s.calls++
+	status := cmp.Or(s.status, http.StatusOK)
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}, nil
+}
+
+// serveStub points auth round-trips at the given transport for one test.
+func serveStub(t *testing.T, tr http.RoundTripper) {
+	t.Helper()
+	previous := httpClient
+	httpClient = func() *http.Client { return &http.Client{Transport: tr} }
+	t.Cleanup(func() { httpClient = previous })
+}
+
+// isolateSecrets gives a test its own secret store.
+func isolateSecrets(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	secret.ResetDefault()
+	t.Cleanup(secret.ResetDefault)
+}
+
+func TestTokenSourceNotSignedInIsCredentialError(t *testing.T) {
+	isolateSecrets(t)
+
+	_, _, err := NewTokenSource().Token(context.Background())
+	var credErr *CredentialError
+	if !errors.As(err, &credErr) {
+		t.Fatalf("Token() with no stored credentials = %T (%v), want *CredentialError", err, err)
+	}
+}
+
+func TestTokenSourceReusesFreshBearer(t *testing.T) {
+	isolateSecrets(t)
+	// Any exchange attempt would fail against this transport, so reaching the
+	// cached bearer is the only way this test can pass.
+	serveStub(t, &stubTransport{status: http.StatusInternalServerError, bodies: []string{`{}`}})
+
+	if err := save(Tokens{
+		GitHubToken:  "gho_test",
+		CopilotToken: "cached-bearer",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	bearer, endpoint, err := NewTokenSource().Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if bearer != "cached-bearer" {
+		t.Errorf("bearer = %q, want the cached one", bearer)
+	}
+	if endpoint != DefaultAPIEndpoint {
+		t.Errorf("endpoint = %q, want %q", endpoint, DefaultAPIEndpoint)
+	}
+}
+
+func TestTokenSourceMintsAndPersistsStaleBearer(t *testing.T) {
+	isolateSecrets(t)
+	expiry := time.Now().Add(time.Hour).Unix()
+	tr := &stubTransport{bodies: []string{
+		`{"token":"fresh-bearer","expires_at":` + strconv.FormatInt(expiry, 10) +
+			`,"endpoints":{"api":"https://api.enterprise.githubcopilot.com"}}`,
+	}}
+	serveStub(t, tr)
+
+	// Expired bearer: the source must exchange the GitHub token for a new one.
+	if err := save(Tokens{
+		GitHubToken:  "gho_test",
+		CopilotToken: "expired-bearer",
+		ExpiresAt:    time.Now().Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	bearer, endpoint, err := NewTokenSource().Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if bearer != "fresh-bearer" {
+		t.Errorf("bearer = %q, want fresh-bearer", bearer)
+	}
+	if endpoint != "https://api.enterprise.githubcopilot.com" {
+		t.Errorf("endpoint = %q, want the one the exchange reported", endpoint)
+	}
+	if got := tr.last.Header.Get("Authorization"); got != "token gho_test" {
+		t.Errorf("exchange Authorization = %q, want the GitHub token", got)
+	}
+	if got := tr.last.Header.Get("Editor-Version"); got != EditorVersion {
+		t.Errorf("exchange Editor-Version = %q, want %q", got, EditorVersion)
+	}
+
+	// The mint is persisted, so the next process doesn't have to repeat it.
+	stored, ok := load()
+	if !ok || stored.CopilotToken != "fresh-bearer" {
+		t.Errorf("stored bearer = %+v, want the freshly minted one", stored)
+	}
+}
+
+func TestTokenSourceKeepsValidBearerWhenMintFails(t *testing.T) {
+	isolateSecrets(t)
+	serveStub(t, &stubTransport{status: http.StatusInternalServerError, bodies: []string{`{}`}})
+
+	// Inside the refresh window but not yet expired: a failed mint must not
+	// break a turn that the current bearer can still serve.
+	if err := save(Tokens{
+		GitHubToken:  "gho_test",
+		CopilotToken: "still-valid",
+		ExpiresAt:    time.Now().Add(time.Minute),
+	}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	bearer, _, err := NewTokenSource().Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if bearer != "still-valid" {
+		t.Errorf("bearer = %q, want the still-valid cached one", bearer)
+	}
+}
+
+func TestMintBearerReportsMissingSubscription(t *testing.T) {
+	serveStub(t, &stubTransport{status: http.StatusForbidden, bodies: []string{`{}`}})
+
+	_, err := MintBearer(context.Background(), Tokens{GitHubToken: "gho_test"})
+	if err == nil || !strings.Contains(err.Error(), "no active Copilot subscription") {
+		t.Fatalf("MintBearer on 403 = %v, want a missing-subscription error", err)
+	}
+}
+
+func TestMintBearerReportsRevokedToken(t *testing.T) {
+	serveStub(t, &stubTransport{status: http.StatusUnauthorized, bodies: []string{`{}`}})
+
+	_, err := MintBearer(context.Background(), Tokens{GitHubToken: "gho_test"})
+	if err == nil || !strings.Contains(err.Error(), "sign in again") {
+		t.Fatalf("MintBearer on 401 = %v, want a sign-in-again error", err)
+	}
+}
+
+func TestHasCredentialsTracksStoredGitHubToken(t *testing.T) {
+	isolateSecrets(t)
+
+	if HasCredentials() {
+		t.Fatal("expected no credentials before sign-in")
+	}
+	if err := save(Tokens{GitHubToken: "gho_test"}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if !HasCredentials() {
+		t.Error("expected credentials once a GitHub token is stored")
+	}
+	if err := Logout(); err != nil {
+		t.Fatalf("Logout: %v", err)
+	}
+	if HasCredentials() {
+		t.Error("expected no credentials after logout")
+	}
+}

--- a/internal/llm/copilot/subscription.go
+++ b/internal/llm/copilot/subscription.go
@@ -1,0 +1,96 @@
+package copilot
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+
+	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/llm/copilot/oauth"
+)
+
+// SubscriptionMeta is the metadata for GitHub Copilot via a paid Copilot plan.
+// It has no EnvVars because it authenticates with a GitHub device-flow login,
+// not a key.
+var SubscriptionMeta = llm.Meta{
+	Provider:    llm.Copilot,
+	AuthMethod:  llm.AuthSubscription,
+	EnvVars:     nil,
+	DisplayName: "Copilot Subscription",
+}
+
+// NewSubscriptionClient creates a client that talks to the Copilot chat backend
+// with a subscription bearer instead of an API key. The bearer is injected per
+// request from a re-minting TokenSource, so a long session survives the ~30
+// minute token lifetime transparently.
+func NewSubscriptionClient(ctx context.Context) (llm.Provider, error) {
+	tokens := oauth.NewTokenSource()
+
+	sdk := openai.NewClient(
+		// The trailing slash matters: the SDK resolves "chat/completions"
+		// against this root, and without it the last path segment is dropped.
+		option.WithBaseURL(oauth.DefaultAPIEndpoint+"/"),
+		option.WithMaxRetries(0),
+		option.WithHeader("Copilot-Integration-Id", oauth.IntegrationID),
+		option.WithHeader("Editor-Version", oauth.EditorVersion),
+		option.WithHeader("Editor-Plugin-Version", oauth.EditorPluginVersion),
+		option.WithHeader("User-Agent", oauth.UserAgent),
+		option.WithHeader("Openai-Intent", "conversation-panel"),
+		option.WithHeader("X-GitHub-Api-Version", oauth.APIVersion),
+		option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
+			bearer, endpoint, err := tokens.Token(req.Context())
+			if err != nil {
+				return nil, err
+			}
+			req.Header.Set("Authorization", "Bearer "+bearer)
+			req.Header.Set("X-Request-Id", llm.NewRequestID())
+			retarget(req, endpoint)
+			return next(req)
+		}),
+	)
+
+	return NewClient(sdk, "copilot:subscription"), nil
+}
+
+// retarget points the request at the API root the token exchange reported.
+// Individual accounts use the default host, but business and enterprise plans
+// are served from their own — and which one applies is only known after the
+// first token exchange, too late for the base URL the client was built with.
+func retarget(req *http.Request, endpoint string) {
+	if endpoint == "" || endpoint == oauth.DefaultAPIEndpoint {
+		return
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Host == "" {
+		return
+	}
+	req.URL.Scheme = u.Scheme
+	req.URL.Host = u.Host
+	req.Host = u.Host
+}
+
+// subscriptionAuthenticator adapts the GitHub device flow to llm.Authenticator
+// so the app layer can trigger sign-in/out through the llm facade rather than
+// importing this provider package directly.
+type subscriptionAuthenticator struct{}
+
+func (subscriptionAuthenticator) Login(ctx context.Context, onPrompt func(llm.LoginPrompt)) error {
+	return oauth.Login(ctx, func(c oauth.UserCode) {
+		if onPrompt != nil {
+			onPrompt(llm.LoginPrompt{URL: c.VerificationURI, UserCode: c.Code})
+		}
+	})
+}
+
+func (subscriptionAuthenticator) Logout() error { return oauth.Logout() }
+
+func (subscriptionAuthenticator) HasCredentials() bool { return oauth.HasCredentials() }
+
+func init() {
+	llm.RegisterProviderDisplay(llm.Copilot, llm.ProviderDisplay{Name: "GitHub Copilot", Order: 25})
+	llm.Register(SubscriptionMeta, NewSubscriptionClient)
+	llm.RegisterAuthenticator(llm.Copilot, llm.AuthSubscription, subscriptionAuthenticator{})
+}

--- a/internal/llm/ids.go
+++ b/internal/llm/ids.go
@@ -1,0 +1,17 @@
+package llm
+
+import (
+	"crypto/rand"
+	"fmt"
+)
+
+// NewRequestID returns a random UUIDv4 for the per-request and per-session
+// identifiers provider backends expect in headers (OpenAI's `session_id`,
+// Copilot's `X-Request-Id`).
+func NewRequestID() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}

--- a/internal/llm/openai/oauth/oauth.go
+++ b/internal/llm/openai/oauth/oauth.go
@@ -11,9 +11,9 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os/exec"
-	"runtime"
 	"time"
+
+	"github.com/genai-io/san/internal/proc"
 )
 
 const (
@@ -102,7 +102,7 @@ func Login(ctx context.Context, onURL func(string)) (Account, error) {
 	if onURL != nil {
 		onURL(authURL)
 	}
-	_ = openBrowser(authURL) // best-effort; onURL lets the caller show it if this fails.
+	_ = proc.OpenURL(authURL) // best-effort; onURL lets the caller show it if this fails.
 
 	select {
 	case <-ctx.Done():
@@ -192,20 +192,6 @@ func randomString(n int) (string, error) {
 		return "", err
 	}
 	return base64.RawURLEncoding.EncodeToString(b), nil
-}
-
-// openBrowser launches the OS default handler for a URL without blocking.
-func openBrowser(target string) error {
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = exec.Command("open", target)
-	case "windows":
-		cmd = exec.Command("cmd", "/c", "start", "", target)
-	default:
-		cmd = exec.Command("xdg-open", target)
-	}
-	return cmd.Start()
 }
 
 // writePage renders a minimal HTML result page for the browser callback.

--- a/internal/llm/openai/oauth/token.go
+++ b/internal/llm/openai/oauth/token.go
@@ -4,8 +4,9 @@
 //
 // It lets a user with a ChatGPT Plus/Pro/Business plan drive san's OpenAI
 // provider without a metered API key, mirroring how OpenAI's own Codex CLI
-// authenticates. The package is self-contained (stdlib + internal/secret only)
-// so a headless `san login` command could reuse it later.
+// authenticates. The package depends only on the stdlib and leaf infrastructure
+// (internal/secret, internal/proc) — never on internal/llm — so a headless
+// `san login` command could reuse it later.
 package oauth
 
 import (

--- a/internal/llm/openai/subscription.go
+++ b/internal/llm/openai/subscription.go
@@ -3,7 +3,6 @@ package openai
 import (
 	"cmp"
 	"context"
-	"crypto/rand"
 	"errors"
 	"fmt"
 	"net/http"
@@ -58,14 +57,13 @@ var SubscriptionMeta = llm.Meta{
 // so a long session survives token expiry transparently.
 func NewSubscriptionClient(ctx context.Context) (llm.Provider, error) {
 	tokens := oauth.NewTokenSource()
-	sessionID := newSessionID()
 
 	sdk := openai.NewClient(
 		option.WithBaseURL(codexBaseURL),
 		option.WithMaxRetries(0),
 		option.WithHeader("OpenAI-Beta", "responses=experimental"),
 		option.WithHeader("originator", oauth.Originator),
-		option.WithHeader("session_id", sessionID),
+		option.WithHeader("session_id", llm.NewRequestID()),
 		option.WithHeader("User-Agent", oauth.Originator),
 		option.WithMiddleware(func(req *http.Request, next option.MiddlewareNext) (*http.Response, error) {
 			access, accountID, err := tokens.Token(req.Context())
@@ -194,22 +192,19 @@ func (r codexModelsResponse) toModelInfos() []llm.ModelInfo {
 	return models
 }
 
-// newSessionID returns a random UUIDv4 for the per-session `session_id` header.
-func newSessionID() string {
-	var b [16]byte
-	_, _ = rand.Read(b[:])
-	b[6] = (b[6] & 0x0f) | 0x40 // version 4
-	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
-	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
-}
-
 // subscriptionAuthenticator adapts the ChatGPT OAuth flow to llm.Authenticator
 // so the app layer can trigger sign-in/out through the llm facade rather than
 // importing this provider package directly.
 type subscriptionAuthenticator struct{}
 
-func (subscriptionAuthenticator) Login(ctx context.Context, onURL func(string)) error {
-	_, err := oauth.Login(ctx, onURL)
+func (subscriptionAuthenticator) Login(ctx context.Context, onPrompt func(llm.LoginPrompt)) error {
+	// The PKCE flow needs no user code — opening the authorize URL is the whole
+	// instruction, so the prompt carries just the URL.
+	_, err := oauth.Login(ctx, func(u string) {
+		if onPrompt != nil {
+			onPrompt(llm.LoginPrompt{URL: u})
+		}
+	})
 	return err
 }
 

--- a/internal/llm/openaicompat/stream.go
+++ b/internal/llm/openaicompat/stream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
 
 	"github.com/genai-io/san/internal/core"
 	"github.com/genai-io/san/internal/llm"
@@ -20,6 +21,10 @@ type ChatStreamConfig struct {
 	ConvertAssistant func(core.Message) openai.ChatCompletionMessageParamUnion
 	ConfigureParams  func(*openai.ChatCompletionNewParams)
 	ExtractReasoning bool
+
+	// RequestOptions apply to this request only — for headers a provider has to
+	// vary per turn rather than fix on the client (e.g. Copilot's X-Initiator).
+	RequestOptions []option.RequestOption
 }
 
 // StreamChatCompletions streams an OpenAI-compatible Chat Completions request.
@@ -54,7 +59,7 @@ func StreamChatCompletions(ctx context.Context, cfg ChatStreamConfig) <-chan llm
 
 		log.LogRequestCtx(ctx, cfg.ProviderName, opts.Model, opts)
 
-		stream := cfg.Client.Chat.Completions.NewStreaming(ctx, params)
+		stream := cfg.Client.Chat.Completions.NewStreaming(ctx, params, cfg.RequestOptions...)
 		state := streamutil.NewState(cfg.ProviderName)
 		toolCalls := make(map[int]*core.ToolCall)
 

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -15,6 +15,7 @@ const (
 	AgnesAI    Name = "agnesai"
 	Anthropic  Name = "anthropic"
 	OpenAI     Name = "openai"
+	Copilot    Name = "copilot"
 	Google     Name = "google"
 	Moonshot   Name = "moonshot"
 	Alibaba    Name = "alibaba"

--- a/internal/proc/browser.go
+++ b/internal/proc/browser.go
@@ -1,0 +1,23 @@
+package proc
+
+import (
+	"os/exec"
+	"runtime"
+)
+
+// OpenURL launches the OS default handler for a URL without blocking the
+// caller. It is best-effort: sign-in flows call it as a convenience and still
+// show the URL, because there is no handler to launch on a headless box or
+// over SSH.
+func OpenURL(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", "", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	return cmd.Start()
+}

--- a/internal/proc/doc.go
+++ b/internal/proc/doc.go
@@ -5,4 +5,8 @@
 // group and are not reached. On Windows the helpers terminate only the
 // direct child via Process.Kill — grandchildren are not reaped, because the
 // package does not yet use Job Objects.
+//
+// It also holds the small cross-platform launchers that are not about lifecycle
+// at all — OpenURL hands a URL to the OS default handler — so the per-GOOS
+// command tables live in one place.
 package proc


### PR DESCRIPTION
Adds GitHub Copilot as a provider, authenticated with a Copilot plan instead of an API key. GitHub's device flow yields a long-lived token, exchanged for the ~30-minute bearer the chat endpoint takes; the endpoint speaks OpenAI Chat Completions, so `openaicompat` drives it. Connect from `/models` → GitHub Copilot → Copilot Subscription.

- `Authenticator.Login` now reports an `llm.LoginPrompt` (URL + user code) instead of a bare URL — a device code exists nowhere else, so the selector shows it in the footer until sign-in resolves.
- Sign-in verifies entitlement before storing credentials, so an account without a subscription fails at connect rather than on the first request.
- Output cap is sent as `max_tokens`: GitHub publishes no schema for this endpoint and only that field is known to be read. Thinking-effort is not advertised — the catalog exposes no reliable signal for it.

`github/copilot-sdk` was rejected: it is an agent runtime driving Copilot CLI over JSON-RPC, which would mean delegating San's own agent loop.