### PR TITLE
feat(tui): add /context to show what fills the context window

### DIFF
--- a/docs/reference/slash-commands.md
+++ b/docs/reference/slash-commands.md
@@ -17,6 +17,7 @@ Slash commands are typed directly in the TUI input box. They trigger local UI ac
 | `/skills` | Manage skill states |
 | `/agents` | Manage agents |
 | `/tokenlimit` | View / set token budget |
+| `/context` | Show what is filling the context window, by category |
 | `/compact` | Compress conversation history |
 | `/init` | Create SAN.md and config files |
 | `/memory` | View / edit memory files |
@@ -33,6 +34,7 @@ Slash commands are typed directly in the TUI input box. They trigger local UI ac
 - Selector commands (`/models`, `/skills`, `/search`, etc.) open a scrollable picker overlay.
 - `/clear` immediately resets the visible conversation.
 - `/think` cycles through levels and updates the status bar indicator.
+- `/context` prints a stacked bar and a per-category breakdown into the transcript. The status bar's `ctx X/Y` says how full the window is; `/context` says what filled it. The total is the provider's measured prompt size for the last turn; the split across categories is estimated, since providers report one number with no breakdown.
 - `/loop` has a dedicated reference page: see [Loop Scheduling Command](./loop.md).
 
 ## Automated Tests

--- a/docs/reference/slash-commands.md
+++ b/docs/reference/slash-commands.md
@@ -34,7 +34,7 @@ Slash commands are typed directly in the TUI input box. They trigger local UI ac
 - Selector commands (`/models`, `/skills`, `/search`, etc.) open a scrollable picker overlay.
 - `/clear` immediately resets the visible conversation.
 - `/think` cycles through levels and updates the status bar indicator.
-- `/context` prints a stacked bar and a per-category breakdown into the transcript. The status bar's `ctx X/Y` says how full the window is; `/context` says what filled it. The total is the provider's measured prompt size for the last turn; the split across categories is estimated, since providers report one number with no breakdown.
+- `/context` prints a stacked bar and a per-category breakdown into the transcript. The status bar's `ctx X/Y` says how full the window is; `/context` says what filled it. The total is the provider's measured prompt size for the last turn. On a provider whose prompt-cache breakpoint sits at the end of the system prompt (Anthropic renders tools → system → messages, so the cached prefix is exactly those two), the reported cache tokens also measure the system prompt and toolset exactly, and only the conversation split stays estimated — the footer names which numbers are which. The reading is discarded when it disagrees with the estimate by more than 2×, so a moved breakpoint degrades to estimation rather than reporting a confident wrong number.
 - `/loop` has a dedicated reference page: see [Loop Scheduling Command](./loop.md).
 
 ## Automated Tests

--- a/internal/agent/build.go
+++ b/internal/agent/build.go
@@ -71,6 +71,28 @@ type BuildParams struct {
 	OnEvent func(core.Event)
 }
 
+// System returns the system prompt these params build. Exported so a caller
+// can inspect the prompt — its size, its sections — before any session exists;
+// buildAgent renders from this same function, so the two cannot drift.
+func (p BuildParams) System() core.System {
+	return system.Build(core.ScopeMain,
+		system.WithPersona(p.Persona),
+		system.WithEnvironment(system.Environment{Cwd: p.CWD}),
+	)
+}
+
+// Schemas returns the built-in tool definitions these params produce: the
+// standard set after the disabled-tools filter, plus any conditional extras.
+// MCP tools are not included — they arrive as ready-made core.Tools rather
+// than schemas, and are wired in separately.
+func (p BuildParams) Schemas() []core.ToolSchema {
+	return (&tool.Set{
+		Disabled:       p.DisabledTools,
+		AgentDirectory: p.AgentDirectory,
+		ExtraTools:     p.ExtraTools,
+	}).Tools()
+}
+
 func buildAgent(p BuildParams) (core.Agent, *PermissionGate, error) {
 	if p.Provider == nil {
 		return nil, nil, fmt.Errorf("no LLM provider configured")
@@ -79,10 +101,7 @@ func buildAgent(p BuildParams) (core.Agent, *PermissionGate, error) {
 	client := llm.NewClient(p.Provider, p.ModelID, p.MaxTokens)
 	client.SetThinkingEffort(p.ThinkingEffort)
 
-	sys := system.Build(core.ScopeMain,
-		system.WithPersona(p.Persona),
-		system.WithEnvironment(system.Environment{Cwd: p.CWD}),
-	)
+	sys := p.System()
 
 	cwdFunc := p.CWDFunc
 	if cwdFunc == nil {
@@ -90,11 +109,7 @@ func buildAgent(p BuildParams) (core.Agent, *PermissionGate, error) {
 		cwdFunc = func() string { return cwd }
 	}
 
-	schemas := (&tool.Set{
-		Disabled:       p.DisabledTools,
-		AgentDirectory: p.AgentDirectory,
-		ExtraTools:     p.ExtraTools,
-	}).Tools()
+	schemas := p.Schemas()
 	var adaptOpts []tool.AdaptOption
 	if p.AskUser != nil {
 		adaptOpts = append(adaptOpts, tool.WithAskUser(p.AskUser))

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -192,6 +192,19 @@ func (s *Session) System() core.System {
 	return s.agent.System()
 }
 
+// Tools returns the running agent's toolset, or nil when no agent is active.
+// Like System(), this is the toolset actually being sent — built-ins after
+// the disabled-tools filter, plus whatever MCP and conditional tools were
+// wired in — not a reconstruction of what the params asked for.
+func (s *Session) Tools() core.Tools {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.agent == nil {
+		return nil
+	}
+	return s.agent.Tools()
+}
+
 // SetPluginRoot scopes the next agent turn to a plugin. The slash command
 // flow calls this when the user invokes a /plugin-skill so subprocesses
 // spawned during the turn see PLUGIN_ROOT pointing at that plugin.

--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -89,9 +89,31 @@ func (m *model) applyPersonaAgents() {
 	m.services.Subagent.ClearPersona()
 }
 
+// promptParams fills in the fields that shape the system prompt and the
+// toolset, and only those. It is free of side effects, unlike buildAgentParams
+// below, which layers the recorder, hook wiring, and permission closures on
+// top — so anything that only wants to know what the agent would send (see
+// contextUsage) can call this without starting anything.
+//
+// Both callers going through one constructor is what keeps them in step: a new
+// prompt-shaping input added here reaches the inspector for free, where a
+// second hand-written literal would silently under-report.
+func (m *model) promptParams() agent.BuildParams {
+	return agent.BuildParams{
+		CWD:            m.env.CWD,
+		Persona:        m.personaPrompt(),
+		AgentDirectory: func() string { return m.services.Subagent.PromptSection() },
+		DisabledTools:  m.services.Setting.DisabledTools(),
+		MCPTools:       mcp.AsCoreTools(m.services.MCP.GetToolSchemas(), mcp.NewCaller(m.services.MCP)),
+
+		// Inject the Evolve trigger tool (tailored to the enabled capabilities)
+		// so the model can queue its own self-learning reviews.
+		ExtraTools: m.selfLearnExtraTools(),
+	}
+}
+
 func (m *model) buildAgentParams() agent.BuildParams {
-	schemas := m.services.MCP.GetToolSchemas()
-	mcpTools := mcp.AsCoreTools(schemas, mcp.NewCaller(m.services.MCP))
+	params := m.promptParams()
 
 	maxTokens := kit.GetMaxTokens(m.services.LLM.Store(), m.env.CurrentModel, setting.DefaultMaxTokens)
 	var onEvent func(core.Event)
@@ -133,148 +155,136 @@ func (m *model) buildAgentParams() agent.BuildParams {
 		m.services.Setting.StreamIdleTimeout(),
 	)
 
-	return agent.BuildParams{
-		Provider:       m.env.LLMProvider,
-		ModelID:        m.env.GetModelID(),
-		MaxTokens:      maxTokens,
-		ThinkingEffort: m.env.EffectiveThinkingEffort(),
-		OnEvent:        onEvent,
+	params.Provider = m.env.LLMProvider
+	params.ModelID = m.env.GetModelID()
+	params.MaxTokens = maxTokens
+	params.ThinkingEffort = m.env.EffectiveThinkingEffort()
+	params.OnEvent = onEvent
+	params.CWDFunc = func() string { return m.env.CWD }
+	params.HookEngine = m.services.Hook
 
-		CWD:     m.env.CWD,
-		CWDFunc: func() string { return m.env.CWD },
-
-		AgentDirectory: func() string { return m.services.Subagent.PromptSection() },
-		Persona:        m.personaPrompt(),
-
-		DisabledTools: m.services.Setting.DisabledTools(),
-		MCPTools:      mcpTools,
-		HookEngine:    m.services.Hook,
-
-		// Inject the Evolve trigger tool (tailored to the enabled capabilities)
-		// so the model can queue its own self-learning reviews.
-		ExtraTools: m.selfLearnExtraTools(),
-
-		AskUser: func(ctx context.Context, req *tool.QuestionRequest) (*tool.QuestionResponse, error) {
-			return m.conv.AgentToUI.Ask(ctx, 0, req)
-		},
-		ToolActivity: func(toolCallID string, msg string) {
-			m.conv.AgentToUI.SendForToolCall(toolCallID, msg)
-		},
-		BashPromptResponder: func(ctx context.Context) tool.BashPromptResponder {
-			// Interactive answering is opt-in via the Bash steer, read live (via
-			// the synchronized snapshot — this runs on the agent goroutine) so a
-			// mid-session toggle takes effect: without it, bash stays on the
-			// normal non-tty path even in auto-review.
-			if !m.autopilotEngaged() || !m.liveAutopilotConfig().Steers.BashPrompt {
-				return nil
-			}
-			return bashPromptResponder{model: m}
-		},
-
-		PermissionRules: func(name string, args map[string]any) agent.PermDecisionResult {
-			decision := m.services.Setting.HasPermissionToUseTool(name, args, m.env.SessionPermissions)
-			mode := m.env.SessionMode()
-			input := marshalPermInput(args)
-			switch decision.Behavior {
-			case perm.Permit:
-				rec.RecordPermissionDecided(transcript.PermissionRecord{
-					Tool: name, Input: input, Decision: permDecisionFor(true), Source: transcript.PermissionSourceConfig,
-					Reason: decision.Reason, Mode: mode,
-				})
-				return agent.PermDecisionResult{Decision: decision.Behavior, Reason: decision.Reason}
-			case perm.Reject:
-				rec.RecordPermissionDecided(transcript.PermissionRecord{
-					Tool: name, Input: input, Decision: permDecisionFor(false), Source: transcript.PermissionSourceConfig,
-					Reason: decision.Reason, Mode: mode,
-				})
-				return agent.PermDecisionResult{Decision: decision.Behavior, Reason: decision.Reason}
-			default:
-				return agent.PermDecisionResult{
-					Decision:    perm.Prompt,
-					Reason:      decision.Reason,
-					ToolName:    name,
-					Description: decision.Reason,
-					RequestID:   core.NewMessageID(),
-					Reviewable:  decision.Reviewable,
-				}
-			}
-		},
-
-		PermissionReview: func(ctx context.Context, name string, args map[string]any, reason string) agent.PermReviewResult {
-			// Steers are read live via the synchronized snapshot (agent goroutine)
-			// so a mid-session toggle takes effect.
-			if !m.autopilotEngaged() {
-				return agent.PermReviewResult{}
-			}
-			cfg := m.liveAutopilotConfig()
-			// Defense in depth: no steer may approve an unrecoverable action —
-			// circuit-breaker tier included — even if one somehow reaches here.
-			// The recoverable git tier is deliberately not checked — weighing it
-			// is exactly what the judge is for.
-			if r := setting.CircuitBreakerReason(name, args); r != "" {
-				m.recordDecision(ctx, false, r)
-				return agent.PermReviewResult{}
-			}
-			if r := setting.UnrecoverableReason(name, args); r != "" {
-				m.recordDecision(ctx, false, r)
-				return agent.PermReviewResult{}
-			}
-			// Skill steer: trust skill loads — approve them outright, no judge, so
-			// the copilot can pull in skills without a prompt. Deliberately separate
-			// from the Permission steer, since the judge tends to escalate a skill
-			// load (it can run scripts) and you may want skills without opening the
-			// whole gray zone.
-			if name == tool.ToolSkill && cfg.Steers.Skill {
-				m.env.SessionPermissions.AllowPattern(setting.BuildRule(name, args))
-				m.recordDecision(ctx, true, "skill steer: trusted skill load")
-				return agent.PermReviewResult{Allow: true, Reason: "autopilot: skill steer"}
-			}
-			// Permission steer: delegate gray-zone prompts to the judge. Off ⇒ every
-			// gray-zone call escalates to the human.
-			if !cfg.Steers.PermissionOn() {
-				return agent.PermReviewResult{}
-			}
-			rev := m.autopilot.Load().judge
-			ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-			defer cancel()
-			verdict, err := rev.Permission(ctx, reviewer.Request{
-				ToolName: name, Args: args, Reason: reason, CWD: m.env.CWD, Mission: cfg.Mission,
-				UnderGit: m.env.IsGit,
-			})
-			log.Logger().Debug("auto-review verdict",
-				zap.String("tool", name),
-				zap.Bool("allow", err == nil && verdict.Allow),
-				zap.String("reason", verdict.Reason),
-				zap.Error(err))
-			if err != nil || !verdict.Allow {
-				m.recordDecision(ctx, false, escalationReason(verdict.Reason, err))
-				return agent.PermReviewResult{} // fail closed → escalate to human
-			}
-			if rec != nil {
-				rec.RecordPermissionDecided(transcript.PermissionRecord{
-					Tool: name, Input: marshalPermInput(args), Decision: permDecisionFor(true),
-					Source: transcript.PermissionSourceReviewer, Reason: verdict.Reason, Mode: m.env.SessionMode(),
-				})
-			}
-			// Cache the approval as a session grant so an identical repeat hits the
-			// static fast path instead of the judge, shrinking the gray zone over
-			// the session. Safe to write here: the agent goroutine is the only
-			// mutator (the human-approval writer runs only while it is parked).
-			m.env.SessionPermissions.AllowPattern(setting.BuildRule(name, args))
-			// Tally it and stash the decision so the renderer can draw it inline
-			// under the tool call the judge just let through (the status-bar count
-			// alone doesn't say what was approved or why).
-			m.recordDecision(ctx, true, verdict.Reason)
-			return agent.PermReviewResult{Allow: true, Reason: "autopilot: " + verdict.Reason}
-		},
-
-		HookAllowResolver: func(name string, args map[string]any) bool {
-			return m.services.Setting.ResolveHookAllow(name, args, m.env.SessionPermissions)
-		},
-
-		StreamFirstChunkTimeout: streamFirstChunk,
-		StreamIdleTimeout:       streamIdle,
+	params.AskUser = func(ctx context.Context, req *tool.QuestionRequest) (*tool.QuestionResponse, error) {
+		return m.conv.AgentToUI.Ask(ctx, 0, req)
 	}
+	params.ToolActivity = func(toolCallID string, msg string) {
+		m.conv.AgentToUI.SendForToolCall(toolCallID, msg)
+	}
+	params.BashPromptResponder = func(ctx context.Context) tool.BashPromptResponder {
+		// Interactive answering is opt-in via the Bash steer, read live (via
+		// the synchronized snapshot — this runs on the agent goroutine) so a
+		// mid-session toggle takes effect: without it, bash stays on the
+		// normal non-tty path even in auto-review.
+		if !m.autopilotEngaged() || !m.liveAutopilotConfig().Steers.BashPrompt {
+			return nil
+		}
+		return bashPromptResponder{model: m}
+	}
+
+	params.PermissionRules = func(name string, args map[string]any) agent.PermDecisionResult {
+		decision := m.services.Setting.HasPermissionToUseTool(name, args, m.env.SessionPermissions)
+		mode := m.env.SessionMode()
+		input := marshalPermInput(args)
+		switch decision.Behavior {
+		case perm.Permit:
+			rec.RecordPermissionDecided(transcript.PermissionRecord{
+				Tool: name, Input: input, Decision: permDecisionFor(true), Source: transcript.PermissionSourceConfig,
+				Reason: decision.Reason, Mode: mode,
+			})
+			return agent.PermDecisionResult{Decision: decision.Behavior, Reason: decision.Reason}
+		case perm.Reject:
+			rec.RecordPermissionDecided(transcript.PermissionRecord{
+				Tool: name, Input: input, Decision: permDecisionFor(false), Source: transcript.PermissionSourceConfig,
+				Reason: decision.Reason, Mode: mode,
+			})
+			return agent.PermDecisionResult{Decision: decision.Behavior, Reason: decision.Reason}
+		default:
+			return agent.PermDecisionResult{
+				Decision:    perm.Prompt,
+				Reason:      decision.Reason,
+				ToolName:    name,
+				Description: decision.Reason,
+				RequestID:   core.NewMessageID(),
+				Reviewable:  decision.Reviewable,
+			}
+		}
+	}
+
+	params.PermissionReview = func(ctx context.Context, name string, args map[string]any, reason string) agent.PermReviewResult {
+		// Steers are read live via the synchronized snapshot (agent goroutine)
+		// so a mid-session toggle takes effect.
+		if !m.autopilotEngaged() {
+			return agent.PermReviewResult{}
+		}
+		cfg := m.liveAutopilotConfig()
+		// Defense in depth: no steer may approve an unrecoverable action —
+		// circuit-breaker tier included — even if one somehow reaches here.
+		// The recoverable git tier is deliberately not checked — weighing it
+		// is exactly what the judge is for.
+		if r := setting.CircuitBreakerReason(name, args); r != "" {
+			m.recordDecision(ctx, false, r)
+			return agent.PermReviewResult{}
+		}
+		if r := setting.UnrecoverableReason(name, args); r != "" {
+			m.recordDecision(ctx, false, r)
+			return agent.PermReviewResult{}
+		}
+		// Skill steer: trust skill loads — approve them outright, no judge, so
+		// the copilot can pull in skills without a prompt. Deliberately separate
+		// from the Permission steer, since the judge tends to escalate a skill
+		// load (it can run scripts) and you may want skills without opening the
+		// whole gray zone.
+		if name == tool.ToolSkill && cfg.Steers.Skill {
+			m.env.SessionPermissions.AllowPattern(setting.BuildRule(name, args))
+			m.recordDecision(ctx, true, "skill steer: trusted skill load")
+			return agent.PermReviewResult{Allow: true, Reason: "autopilot: skill steer"}
+		}
+		// Permission steer: delegate gray-zone prompts to the judge. Off ⇒ every
+		// gray-zone call escalates to the human.
+		if !cfg.Steers.PermissionOn() {
+			return agent.PermReviewResult{}
+		}
+		rev := m.autopilot.Load().judge
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		verdict, err := rev.Permission(ctx, reviewer.Request{
+			ToolName: name, Args: args, Reason: reason, CWD: m.env.CWD, Mission: cfg.Mission,
+			UnderGit: m.env.IsGit,
+		})
+		log.Logger().Debug("auto-review verdict",
+			zap.String("tool", name),
+			zap.Bool("allow", err == nil && verdict.Allow),
+			zap.String("reason", verdict.Reason),
+			zap.Error(err))
+		if err != nil || !verdict.Allow {
+			m.recordDecision(ctx, false, escalationReason(verdict.Reason, err))
+			return agent.PermReviewResult{} // fail closed → escalate to human
+		}
+		if rec != nil {
+			rec.RecordPermissionDecided(transcript.PermissionRecord{
+				Tool: name, Input: marshalPermInput(args), Decision: permDecisionFor(true),
+				Source: transcript.PermissionSourceReviewer, Reason: verdict.Reason, Mode: m.env.SessionMode(),
+			})
+		}
+		// Cache the approval as a session grant so an identical repeat hits the
+		// static fast path instead of the judge, shrinking the gray zone over
+		// the session. Safe to write here: the agent goroutine is the only
+		// mutator (the human-approval writer runs only while it is parked).
+		m.env.SessionPermissions.AllowPattern(setting.BuildRule(name, args))
+		// Tally it and stash the decision so the renderer can draw it inline
+		// under the tool call the judge just let through (the status-bar count
+		// alone doesn't say what was approved or why).
+		m.recordDecision(ctx, true, verdict.Reason)
+		return agent.PermReviewResult{Allow: true, Reason: "autopilot: " + verdict.Reason}
+	}
+
+	params.HookAllowResolver = func(name string, args map[string]any) bool {
+		return m.services.Setting.ResolveHookAllow(name, args, m.env.SessionPermissions)
+	}
+
+	params.StreamFirstChunkTimeout = streamFirstChunk
+	params.StreamIdleTimeout = streamIdle
+
+	return params
 }
 
 // resolveReviewerModel picks the provider and model for the auto-review judge.

--- a/internal/app/context_usage.go
+++ b/internal/app/context_usage.go
@@ -8,7 +8,6 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/genai-io/san/internal/agent"
 	"github.com/genai-io/san/internal/app/conv"
 	"github.com/genai-io/san/internal/app/kit"
 	"github.com/genai-io/san/internal/core"
@@ -116,25 +115,22 @@ func (m *model) measuredPromptPrefix(usage conv.ContextUsage) int {
 // reporting zero would understate a fresh window by everything the very next
 // request is about to carry.
 //
-// It goes through BuildParams so the prompt and the toolset come from the same
-// code the real session builds from, and it fills in only the fields those two
-// depend on: unlike buildAgentParams, this has to stay free of side effects —
-// no recorder, no reviewer rebuild, no hook wiring.
+// It goes through promptParams — the same side-effect-free constructor
+// buildAgentParams starts from — so both read one description of what shapes
+// the prompt. A new prompt-shaping input added there reaches this measurement
+// without anyone remembering to update it, which a second hand-written literal
+// would not.
 func (m *model) addUnstartedAgentUsage(usage *conv.ContextUsage) {
-	params := agent.BuildParams{
-		CWD:            m.env.CWD,
-		Persona:        m.personaPrompt(),
-		DisabledTools:  m.services.Setting.DisabledTools(),
-		AgentDirectory: func() string { return m.services.Subagent.PromptSection() },
-		ExtraTools:     m.selfLearnExtraTools(),
-	}
+	params := m.promptParams()
 
 	usage.SystemPrompt = kit.EstimateTokens(params.System().Prompt())
 	for _, schema := range params.Schemas() {
 		usage.Tools += kit.EstimateTokens(toolSchemaWire(schema))
 	}
-	for _, schema := range m.services.MCP.GetToolSchemas() {
-		usage.MCPTools += kit.EstimateTokens(toolSchemaWire(schema))
+	// MCP tools arrive as ready-made core.Tools rather than schemas, so they sit
+	// outside Schemas() and are counted off the same list params already carries.
+	for _, t := range params.MCPTools {
+		usage.MCPTools += kit.EstimateTokens(toolSchemaWire(t.Schema()))
 	}
 }
 

--- a/internal/app/context_usage.go
+++ b/internal/app/context_usage.go
@@ -1,0 +1,144 @@
+// Context-window accounting for /context: what currently occupies the
+// model's context window, broken down by category.
+package app
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/genai-io/san/internal/agent"
+	"github.com/genai-io/san/internal/app/conv"
+	"github.com/genai-io/san/internal/app/kit"
+	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/mcp"
+	"github.com/genai-io/san/internal/reminder"
+)
+
+// contextUsage measures the running agent wherever there is one: System() and
+// Tools() are the values actually being sent, and its chain already carries the
+// harness reminders attached to past user turns. Building the prompt fresh
+// would report what the current settings would produce, which is not
+// necessarily what the live agent is holding — a session keeps its agent until
+// something forces a rebuild. Only before the first message, when no agent
+// exists yet, does the measurement fall back to building.
+//
+// Every category is an estimate — the provider reports one exact prompt size
+// and no breakdown, so the split has to be derived from the text itself.
+func (m *model) contextUsage() conv.ContextUsage {
+	usage := conv.ContextUsage{
+		ModelName: m.env.GetModelDisplayName(),
+		Limit:     kit.GetEffectiveInputLimit(m.services.LLM.Store(), m.env.CurrentModel),
+		Measured:  m.env.InputTokens,
+	}
+
+	sys, tools := m.services.Agent.System(), m.services.Agent.Tools()
+	messages := m.services.Agent.Messages()
+	if sys == nil || tools == nil {
+		m.addUnstartedAgentUsage(&usage)
+		messages = m.seedAgentMessages("")
+	} else {
+		usage.SystemPrompt = kit.EstimateTokens(sys.Prompt())
+		for _, t := range tools.All() {
+			size := kit.EstimateTokens(toolSchemaWire(t.Schema()))
+			if mcp.IsMCPTool(t.Name()) {
+				usage.MCPTools += size
+				continue
+			}
+			usage.Tools += size
+		}
+	}
+
+	// Skills and memory ride inside user turns as <system-reminder> blocks, so
+	// the chain is scanned for them instead of measuring the providers
+	// separately — otherwise every one of them would be counted twice, once on
+	// its own and once as part of Messages.
+	for _, msg := range messages {
+		addContextUsage(&usage, messageWire(msg))
+	}
+	// Reminders queued for the next turn are not in the chain yet. Counting
+	// them keeps a fresh session from reporting zero skills and zero memory
+	// when both are about to be injected on the very next message.
+	for _, pending := range m.services.Reminder.Pending() {
+		addContextUsage(&usage, pending)
+	}
+
+	return usage
+}
+
+// addUnstartedAgentUsage fills in the prompt and toolset for a session whose
+// agent has not been built yet. The agent starts on the first message, so
+// until then there is nothing to read System() and Tools() off of, and
+// reporting zero would understate a fresh window by everything the very next
+// request is about to carry.
+//
+// It goes through BuildParams so the prompt and the toolset come from the same
+// code the real session builds from, and it fills in only the fields those two
+// depend on: unlike buildAgentParams, this has to stay free of side effects —
+// no recorder, no reviewer rebuild, no hook wiring.
+func (m *model) addUnstartedAgentUsage(usage *conv.ContextUsage) {
+	params := agent.BuildParams{
+		CWD:            m.env.CWD,
+		Persona:        m.personaPrompt(),
+		DisabledTools:  m.services.Setting.DisabledTools(),
+		AgentDirectory: func() string { return m.services.Subagent.PromptSection() },
+		ExtraTools:     m.selfLearnExtraTools(),
+	}
+
+	usage.SystemPrompt = kit.EstimateTokens(params.System().Prompt())
+	for _, schema := range params.Schemas() {
+		usage.Tools += kit.EstimateTokens(toolSchemaWire(schema))
+	}
+	for _, schema := range m.services.MCP.GetToolSchemas() {
+		usage.MCPTools += kit.EstimateTokens(toolSchemaWire(schema))
+	}
+}
+
+// addContextUsage attributes one message's wire text: each <system-reminder>
+// block is credited to the provider that emitted it, and whatever is left over
+// counts as conversation.
+func addContextUsage(usage *conv.ContextUsage, text string) {
+	conversation := kit.EstimateTokens(text)
+	for _, block := range reminder.Blocks(text) {
+		size := kit.EstimateTokens(block.Text)
+		switch block.Source {
+		case reminder.ProviderSkillsDirectory:
+			usage.Skills += size
+			conversation -= size
+		case reminder.ProviderMemoryUser, reminder.ProviderMemoryProject, reminder.ProviderMemoryAuto:
+			usage.MemoryFiles += size
+			conversation -= size
+		}
+		// A block with no source is a one-time notice (a cancel notice, hook
+		// output). It belongs to the turn that carried it, so it stays in
+		// Messages rather than earning a category of its own.
+	}
+	usage.Messages += max(conversation, 0)
+}
+
+// messageWire concatenates the parts of a message that reach the provider.
+// Display-only fields (DisplayContent, the rendered view state) are left out;
+// images are not text and are not estimated.
+func messageWire(msg core.Message) string {
+	var b strings.Builder
+	b.WriteString(msg.Content)
+	b.WriteString(msg.Thinking)
+	for _, call := range msg.ToolCalls {
+		b.WriteString(call.Name)
+		b.WriteString(call.Input)
+	}
+	if msg.ToolResult != nil {
+		b.WriteString(msg.ToolResult.Content)
+	}
+	return b.String()
+}
+
+// toolSchemaWire renders a tool definition the way it is sent — name,
+// description, and JSON Schema — so the estimate covers the whole definition
+// and not just its prose.
+func toolSchemaWire(schema core.ToolSchema) string {
+	encoded, err := json.Marshal(schema)
+	if err != nil {
+		return schema.Name + schema.Description
+	}
+	return string(encoded)
+}

--- a/internal/app/context_usage.go
+++ b/internal/app/context_usage.go
@@ -6,10 +6,14 @@ import (
 	"encoding/json"
 	"strings"
 
+	"go.uber.org/zap"
+
 	"github.com/genai-io/san/internal/agent"
 	"github.com/genai-io/san/internal/app/conv"
 	"github.com/genai-io/san/internal/app/kit"
 	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/llm"
+	"github.com/genai-io/san/internal/log"
 	"github.com/genai-io/san/internal/mcp"
 	"github.com/genai-io/san/internal/reminder"
 )
@@ -62,7 +66,48 @@ func (m *model) contextUsage() conv.ContextUsage {
 		addContextUsage(&usage, pending)
 	}
 
+	usage.CachedPrefix = m.measuredPromptPrefix(usage)
 	return usage
+}
+
+// measuredPromptPrefix returns the provider's exact token count for the system
+// prompt plus the tool definitions, or 0 when no trustworthy count is
+// available. Anthropic marks the system block as its cache breakpoint and
+// renders tools ahead of system, so the cached prefix it reports is exactly
+// those two — the one part of the window San can measure rather than estimate.
+//
+// The reading is corroborated against the estimate before being used, rather
+// than trusted on the strength of how the request happens to be built today.
+// A provider that caches on its own boundary, a moved breakpoint, or a prefix
+// that grew to include conversation would all report a number that is real but
+// measures something else; the estimate is crude but it is not wrong by
+// multiples, so disagreement on that scale means the assumption no longer
+// holds. Returning 0 then falls the display back to scaling everything to the
+// measured total, which is the same honest answer every other provider gets.
+func (m *model) measuredPromptPrefix(usage conv.ContextUsage) int {
+	prefix := m.env.CachedPrefixTokens
+	if prefix <= 0 || prefix >= usage.Measured {
+		// Nothing cached — no turn yet, or a prefix below the model's
+		// cacheable minimum (512–4096 tokens, depending on the model, so
+		// small toolsets routinely miss it). A prefix at or above the whole
+		// prompt would leave the conversation nothing and is not a prefix.
+		return 0
+	}
+	if !llm.CachesToolsAndSystemPrompt(m.env.LLMProvider) {
+		return 0
+	}
+
+	estimated := usage.SystemPrompt + usage.Tools + usage.MCPTools
+	if estimated <= 0 {
+		return 0
+	}
+	if ratio := float64(prefix) / float64(estimated); ratio < 0.5 || ratio > 2 {
+		log.Logger().Warn("cached prefix disagrees with the estimated prompt size; falling back to estimation",
+			zap.Int("cached_prefix_tokens", prefix),
+			zap.Int("estimated_tokens", estimated))
+		return 0
+	}
+	return prefix
 }
 
 // addUnstartedAgentUsage fills in the prompt and toolset for a session whose

--- a/internal/app/context_usage_test.go
+++ b/internal/app/context_usage_test.go
@@ -1,0 +1,88 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/genai-io/san/internal/app/conv"
+	"github.com/genai-io/san/internal/app/kit"
+	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/reminder"
+)
+
+// A user turn carries the skills directory and memory files inline, so the
+// same bytes are reachable two ways. They must be credited to their own
+// category and removed from Messages — counting them twice would inflate the
+// conversation and hide where the window actually went.
+func TestAddContextUsageAttributesRemindersOnce(t *testing.T) {
+	skills := reminder.WrapWithSource("skills directory body", reminder.ProviderSkillsDirectory)
+	memory := reminder.WrapWithSource(reminder.WrapMemory("project", "project memory body"), reminder.ProviderMemoryProject)
+	turn := reminder.AttachToContent("what the user typed", []string{skills, memory})
+
+	var usage conv.ContextUsage
+	addContextUsage(&usage, turn)
+
+	if usage.Skills != kit.EstimateTokens(skills) {
+		t.Errorf("Skills = %d, want %d", usage.Skills, kit.EstimateTokens(skills))
+	}
+	if usage.MemoryFiles != kit.EstimateTokens(memory) {
+		t.Errorf("MemoryFiles = %d, want %d", usage.MemoryFiles, kit.EstimateTokens(memory))
+	}
+	if whole := kit.EstimateTokens(turn); usage.Messages >= whole {
+		t.Errorf("Messages = %d counts the reminders again; the whole turn is only %d", usage.Messages, whole)
+	}
+	if usage.Messages == 0 {
+		t.Error("the user's own text was dropped from Messages")
+	}
+}
+
+// A one-time notice belongs to the turn that carried it, not to a category of
+// its own — there is nothing the user can configure to make it smaller.
+func TestAddContextUsageKeepsNoticesInMessages(t *testing.T) {
+	turn := reminder.AttachToContent("what the user typed", []string{reminder.Wrap("a cancel notice")})
+
+	var usage conv.ContextUsage
+	addContextUsage(&usage, turn)
+
+	if usage.Skills != 0 || usage.MemoryFiles != 0 {
+		t.Errorf("an unsourced notice was filed as skills=%d memory=%d", usage.Skills, usage.MemoryFiles)
+	}
+	if want := kit.EstimateTokens(turn); usage.Messages != want {
+		t.Errorf("Messages = %d, want the whole turn %d", usage.Messages, want)
+	}
+}
+
+func TestMessageWireCoversEveryFieldSentToTheProvider(t *testing.T) {
+	msg := core.Message{
+		Role:           core.RoleAssistant,
+		Content:        "visible answer",
+		DisplayContent: "rendered for the TUI only",
+		Thinking:       "reasoning text",
+		ToolCalls:      []core.ToolCall{{ID: "1", Name: "Bash", Input: `{"command":"ls"}`}},
+		ToolResult:     &core.ToolResult{ToolCallID: "1", Content: "tool output"},
+	}
+
+	wire := messageWire(msg)
+	for _, want := range []string{"visible answer", "reasoning text", "Bash", `{"command":"ls"}`, "tool output"} {
+		if !strings.Contains(wire, want) {
+			t.Errorf("wire text is missing %q: %q", want, wire)
+		}
+	}
+	if strings.Contains(wire, "rendered for the TUI only") {
+		t.Errorf("display-only content is not sent and must not be counted: %q", wire)
+	}
+}
+
+func TestToolSchemaWireCoversTheWholeDefinition(t *testing.T) {
+	wire := toolSchemaWire(core.ToolSchema{
+		Name:        "Bash",
+		Description: "run a command",
+		Parameters:  map[string]any{"type": "object"},
+	})
+
+	for _, want := range []string{"Bash", "run a command", "input_schema"} {
+		if !strings.Contains(wire, want) {
+			t.Errorf("schema text is missing %q: %q", want, wire)
+		}
+	}
+}

--- a/internal/app/context_usage_test.go
+++ b/internal/app/context_usage_test.go
@@ -1,12 +1,14 @@
 package app
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	"github.com/genai-io/san/internal/app/conv"
 	"github.com/genai-io/san/internal/app/kit"
 	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/reminder"
 )
 
@@ -84,5 +86,76 @@ func TestToolSchemaWireCoversTheWholeDefinition(t *testing.T) {
 		if !strings.Contains(wire, want) {
 			t.Errorf("schema text is missing %q: %q", want, wire)
 		}
+	}
+}
+
+// automaticCachingProvider stands in for the majority: it reports cache tokens
+// but chooses its own prefix boundary, so it does not declare
+// llm.PromptPrefixCacheProvider.
+type automaticCachingProvider struct{}
+
+func (automaticCachingProvider) Stream(context.Context, llm.CompletionOptions) <-chan llm.StreamChunk {
+	return nil
+}
+func (automaticCachingProvider) ListModels(context.Context) ([]llm.ModelInfo, error) { return nil, nil }
+func (automaticCachingProvider) Name() string                                        { return "stub" }
+
+// prefixCachingProvider stands in for Anthropic: its cache breakpoint sits at
+// the end of the system prompt, so the reported prefix is the prompt and tools.
+type prefixCachingProvider struct{ automaticCachingProvider }
+
+func (prefixCachingProvider) CachesToolsAndSystemPrompt() bool { return true }
+
+// measuredPromptPrefix decides whether to believe the provider's cache
+// accounting. The guard exists because a real number can measure the wrong
+// thing: a moved breakpoint or a provider caching on its own boundary reports
+// a prefix that covers more than the prompt. The estimate is crude but not
+// wrong by multiples, so a reading that disagrees on that scale is rejected
+// and the display falls back to estimation.
+func TestMeasuredPromptPrefixRejectsImplausibleReadings(t *testing.T) {
+	usage := conv.ContextUsage{
+		Measured:     41200,
+		SystemPrompt: 5000,
+		Tools:        19000,
+		MCPTools:     3000,
+	}
+	const estimated = 27000 // the three cached categories
+
+	for name, tc := range map[string]struct {
+		cachedPrefix int
+		want         int
+	}{
+		"agrees with the estimate":  {26000, 26000},
+		"estimate ran a little low": {estimated * 3 / 2, estimated * 3 / 2},
+		"covers far more than the prompt": {
+			// A prefix that swallowed the conversation too.
+			estimated * 3, 0,
+		},
+		"implausibly small":     {estimated / 4, 0},
+		"nothing cached":        {0, 0},
+		"at the measured total": {usage.Measured, 0},
+		"beyond the total":      {usage.Measured + 1, 0},
+	} {
+		m := &model{}
+		m.env.CachedPrefixTokens = tc.cachedPrefix
+		m.env.LLMProvider = prefixCachingProvider{}
+
+		if got := m.measuredPromptPrefix(usage); got != tc.want {
+			t.Errorf("%s: measuredPromptPrefix(%d) = %d, want %d", name, tc.cachedPrefix, got, tc.want)
+		}
+	}
+}
+
+// Providers that cache on a boundary they choose report a real number that
+// measures an unknown span — believing it would overstate the prompt.
+func TestMeasuredPromptPrefixIgnoresProvidersWithoutAKnownBreakpoint(t *testing.T) {
+	usage := conv.ContextUsage{Measured: 41200, SystemPrompt: 5000, Tools: 19000, MCPTools: 3000}
+
+	m := &model{}
+	m.env.CachedPrefixTokens = 26000 // plausible, but not a prompt-prefix measurement
+	m.env.LLMProvider = automaticCachingProvider{}
+
+	if got := m.measuredPromptPrefix(usage); got != 0 {
+		t.Errorf("measuredPromptPrefix = %d, want 0 for a provider with no declared breakpoint", got)
 	}
 }

--- a/internal/app/conv/context_usage.go
+++ b/internal/app/conv/context_usage.go
@@ -37,6 +37,14 @@ type ContextUsage struct {
 	// completes, which falls the total back to the estimate.
 	Measured int
 
+	// CachedPrefix is the exact token count of the system prompt and the tool
+	// definitions together, read from the provider's cache accounting. When it
+	// is set, those categories and the conversation are each scaled to their
+	// own exact total instead of sharing one — which stops an estimation error
+	// in the tool schemas from being pushed onto Messages. Zero means no exact
+	// prefix was available and the whole split scales to Measured.
+	CachedPrefix int
+
 	SystemPrompt int
 	Tools        int
 	MCPTools     int
@@ -50,6 +58,11 @@ type contextCategory struct {
 	label  string
 	tokens int
 	color  kit.AdaptiveColor
+	// cached marks a category that sits inside the provider's cached prompt
+	// prefix, and so is covered by ContextUsage.CachedPrefix. These come first
+	// in render order, matching the order the provider renders the request in
+	// (tools and system ahead of the conversation).
+	cached bool
 }
 
 // categories lists the breakdown in render order, darkest to brightest. The
@@ -60,13 +73,25 @@ type contextCategory struct {
 func (u ContextUsage) categories() []contextCategory {
 	t := kit.CurrentTheme
 	return []contextCategory{
-		{"System prompt", u.SystemPrompt, t.Separator},
-		{"Tools", u.Tools, t.Accent},
-		{"MCP tools", u.MCPTools, t.TextDim},
-		{"Skills", u.Skills, t.Primary},
-		{"Memory files", u.MemoryFiles, t.Text},
-		{"Messages", u.Messages, t.Focus},
+		{label: "System prompt", tokens: u.SystemPrompt, color: t.Separator, cached: true},
+		{label: "Tools", tokens: u.Tools, color: t.Accent, cached: true},
+		{label: "MCP tools", tokens: u.MCPTools, color: t.TextDim, cached: true},
+		{label: "Skills", tokens: u.Skills, color: t.Primary},
+		{label: "Memory files", tokens: u.MemoryFiles, color: t.Text},
+		{label: "Messages", tokens: u.Messages, color: t.Focus},
 	}
+}
+
+// cachedPrefixEnd returns how many leading categories the provider's cached
+// prefix covers. Derived from the cached flag rather than a fixed index so
+// reordering or adding a category can't silently shift the boundary.
+func cachedPrefixEnd(cats []contextCategory) int {
+	for i, c := range cats {
+		if !c.cached {
+			return i
+		}
+	}
+	return len(cats)
 }
 
 // RenderContextUsage renders the /context body: a header naming the model and
@@ -75,17 +100,13 @@ func (u ContextUsage) categories() []contextCategory {
 func RenderContextUsage(u ContextUsage) string {
 	cats := u.categories()
 
-	estimated := 0
+	used := 0
 	for _, c := range cats {
-		estimated += c.tokens
+		used += c.tokens
 	}
-
-	used := estimated
 	if u.Measured > 0 {
+		cats = scaleToProvider(cats, u.Measured, u.CachedPrefix)
 		used = u.Measured
-		if estimated > 0 {
-			cats = scaleToMeasured(cats, estimated, u.Measured)
-		}
 	}
 
 	free := max(u.Limit-used, 0)
@@ -100,7 +121,7 @@ func RenderContextUsage(u ContextUsage) string {
 	}
 	b.WriteString(renderContextLegend(cats, free, u.Limit))
 	b.WriteString("\n")
-	b.WriteString(muted.Render(contextUsageFooter(u.Measured > 0)))
+	b.WriteString(muted.Render(u.footer()))
 	return b.String()
 }
 
@@ -121,31 +142,65 @@ func contextUsageHeader(modelName string, used, limit int) string {
 	return strings.Join(parts, " · ")
 }
 
-func contextUsageFooter(measured bool) string {
-	if measured {
+// footer names which numbers above it are measured and which are estimated, so
+// the reading is never taken for more than it is.
+func (u ContextUsage) footer() string {
+	switch {
+	case u.CachedPrefix > 0:
+		return "prompt and tools measured last turn · conversation split estimated"
+	case u.Measured > 0:
 		return "total measured last turn · split estimated"
+	default:
+		return "estimated · no turn sent yet this session"
 	}
-	return "estimated · no turn sent yet this session"
 }
 
-// scaleToMeasured spreads the provider's measured prompt size across the
-// estimated split, so the headline total matches the status bar exactly while
-// the parts still add up to it. Rounding drift lands on the largest category,
-// where it is proportionally smallest.
-func scaleToMeasured(cats []contextCategory, estimated, measured int) []contextCategory {
+// scaleToProvider fits the estimated split onto what the provider actually
+// reported, so the headline total matches the status bar exactly and the parts
+// still add up to it.
+//
+// With an exact prefix, the two groups are scaled separately — the cached
+// categories to the prefix, the conversation to what remains. That containment
+// is the point: scaling everything to one total spreads each category's
+// estimation error across all of them, so an underestimated tool schema (JSON
+// is punctuation-dense, and estimators read it low) quietly inflates Messages —
+// the one category the user acts on. Two groups keep each error inside the
+// group that produced it.
+func scaleToProvider(cats []contextCategory, measured, cachedPrefix int) []contextCategory {
 	scaled := make([]contextCategory, len(cats))
 	copy(scaled, cats)
 
-	total, largest := 0, 0
-	for i, c := range scaled {
-		scaled[i].tokens = int(float64(c.tokens) / float64(estimated) * float64(measured))
-		total += scaled[i].tokens
-		if scaled[i].tokens > scaled[largest].tokens {
+	if boundary := cachedPrefixEnd(scaled); cachedPrefix > 0 && cachedPrefix < measured {
+		scaleGroup(scaled[:boundary], cachedPrefix)
+		scaleGroup(scaled[boundary:], measured-cachedPrefix)
+		return scaled
+	}
+	scaleGroup(scaled, measured)
+	return scaled
+}
+
+// scaleGroup rescales one group of categories to sum to total. Rounding drift
+// lands on the largest member, where it is proportionally smallest; an empty
+// group is left alone rather than inventing tokens for categories the session
+// does not have.
+func scaleGroup(cats []contextCategory, total int) {
+	estimated := 0
+	for _, c := range cats {
+		estimated += c.tokens
+	}
+	if estimated <= 0 {
+		return
+	}
+
+	assigned, largest := 0, 0
+	for i, c := range cats {
+		cats[i].tokens = int(float64(c.tokens) / float64(estimated) * float64(total))
+		assigned += cats[i].tokens
+		if cats[i].tokens > cats[largest].tokens {
 			largest = i
 		}
 	}
-	scaled[largest].tokens = max(scaled[largest].tokens+measured-total, 0)
-	return scaled
+	cats[largest].tokens = max(cats[largest].tokens+total-assigned, 0)
 }
 
 // renderStackedBar draws every category end to end in its own color and fills
@@ -226,7 +281,7 @@ func renderContextLegend(cats []contextCategory, free, limit int) string {
 		}
 	}
 	if limit > 0 {
-		rows = append(rows, contextCategory{"Free space", free, kit.CurrentTheme.TextDisabled})
+		rows = append(rows, contextCategory{label: "Free space", tokens: free, color: kit.CurrentTheme.TextDisabled})
 	}
 
 	labelWidth := 0

--- a/internal/app/conv/context_usage.go
+++ b/internal/app/conv/context_usage.go
@@ -58,56 +58,53 @@ type contextCategory struct {
 	label  string
 	tokens int
 	color  kit.AdaptiveColor
-	// cached marks a category that sits inside the provider's cached prompt
-	// prefix, and so is covered by ContextUsage.CachedPrefix. These come first
-	// in render order, matching the order the provider renders the request in
-	// (tools and system ahead of the conversation).
-	cached bool
 }
 
-// categories lists the breakdown in render order, darkest to brightest. The
-// ramp is the point: the leading segments are fixed session overhead the user
-// configures once, and it brightens toward Messages — the one segment that
-// grows every turn and the one /compact acts on — which takes the theme's
-// single vivid accent.
-func (u ContextUsage) categories() []contextCategory {
+// categories splits the breakdown into the two groups that scale independently:
+// prompt is what the provider's cached prefix covers, conversation is the rest.
+// Returning them separately rather than as one slice with a flag is what keeps
+// a category from landing in the wrong group — a new prompt-side category has
+// nowhere to go but the prompt return value, where a flag could simply be
+// forgotten and the category would silently scale against the conversation.
+//
+// Within each group the order is darkest to brightest, and the ramp is the
+// point: it starts at fixed session overhead the user configures once and
+// brightens toward Messages — the one segment that grows every turn and the one
+// /compact acts on — which takes the theme's single vivid accent.
+func (u ContextUsage) categories() (prompt, conversation []contextCategory) {
 	t := kit.CurrentTheme
 	return []contextCategory{
-		{label: "System prompt", tokens: u.SystemPrompt, color: t.Separator, cached: true},
-		{label: "Tools", tokens: u.Tools, color: t.Accent, cached: true},
-		{label: "MCP tools", tokens: u.MCPTools, color: t.TextDim, cached: true},
-		{label: "Skills", tokens: u.Skills, color: t.Primary},
-		{label: "Memory files", tokens: u.MemoryFiles, color: t.Text},
-		{label: "Messages", tokens: u.Messages, color: t.Focus},
-	}
+			{label: "System prompt", tokens: u.SystemPrompt, color: t.Separator},
+			{label: "Tools", tokens: u.Tools, color: t.Accent},
+			{label: "MCP tools", tokens: u.MCPTools, color: t.TextDim},
+		}, []contextCategory{
+			{label: "Skills", tokens: u.Skills, color: t.Primary},
+			{label: "Memory files", tokens: u.MemoryFiles, color: t.Text},
+			{label: "Messages", tokens: u.Messages, color: t.Focus},
+		}
 }
 
-// cachedPrefixEnd returns how many leading categories the provider's cached
-// prefix covers. Derived from the cached flag rather than a fixed index so
-// reordering or adding a category can't silently shift the boundary.
-func cachedPrefixEnd(cats []contextCategory) int {
-	for i, c := range cats {
-		if !c.cached {
-			return i
-		}
+// totalTokens sums a group of categories.
+func totalTokens(cats []contextCategory) int {
+	total := 0
+	for _, c := range cats {
+		total += c.tokens
 	}
-	return len(cats)
+	return total
 }
 
 // RenderContextUsage renders the /context body: a header naming the model and
 // the fill, the stacked bar, one row per category, and a footer stating which
 // numbers are measured and which are estimated.
 func RenderContextUsage(u ContextUsage) string {
-	cats := u.categories()
+	prompt, conversation := u.categories()
 
-	used := 0
-	for _, c := range cats {
-		used += c.tokens
-	}
+	used := totalTokens(prompt) + totalTokens(conversation)
 	if u.Measured > 0 {
-		cats = scaleToProvider(cats, u.Measured, u.CachedPrefix)
+		u.scaleToProvider(prompt, conversation)
 		used = u.Measured
 	}
+	cats := append(prompt, conversation...)
 
 	free := max(u.Limit-used, 0)
 	muted := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
@@ -166,41 +163,67 @@ func (u ContextUsage) footer() string {
 // is punctuation-dense, and estimators read it low) quietly inflates Messages —
 // the one category the user acts on. Two groups keep each error inside the
 // group that produced it.
-func scaleToProvider(cats []contextCategory, measured, cachedPrefix int) []contextCategory {
-	scaled := make([]contextCategory, len(cats))
-	copy(scaled, cats)
-
-	if boundary := cachedPrefixEnd(scaled); cachedPrefix > 0 && cachedPrefix < measured {
-		scaleGroup(scaled[:boundary], cachedPrefix)
-		scaleGroup(scaled[boundary:], measured-cachedPrefix)
-		return scaled
-	}
-	scaleGroup(scaled, measured)
-	return scaled
-}
-
-// scaleGroup rescales one group of categories to sum to total. Rounding drift
-// lands on the largest member, where it is proportionally smallest; an empty
-// group is left alone rather than inventing tokens for categories the session
-// does not have.
-func scaleGroup(cats []contextCategory, total int) {
-	estimated := 0
-	for _, c := range cats {
-		estimated += c.tokens
-	}
-	if estimated <= 0 {
+// It rescales in place.
+func (u ContextUsage) scaleToProvider(prompt, conversation []contextCategory) {
+	if u.CachedPrefix > 0 && u.CachedPrefix < u.Measured {
+		scaleGroup(prompt, u.CachedPrefix)
+		scaleGroup(conversation, u.Measured-u.CachedPrefix)
 		return
 	}
-
-	assigned, largest := 0, 0
-	for i, c := range cats {
-		cats[i].tokens = int(float64(c.tokens) / float64(estimated) * float64(total))
-		assigned += cats[i].tokens
-		if cats[i].tokens > cats[largest].tokens {
-			largest = i
-		}
+	// No exact prefix: one pool, so the groups have to be apportioned against
+	// their combined estimate rather than each on its own.
+	total := totalTokens(prompt) + totalTokens(conversation)
+	if total <= 0 {
+		return
 	}
-	cats[largest].tokens = max(cats[largest].tokens+total-assigned, 0)
+	promptShare := u.Measured * totalTokens(prompt) / total
+	scaleGroup(prompt, promptShare)
+	scaleGroup(conversation, u.Measured-promptShare)
+}
+
+// scaleGroup rescales one group of categories to sum to total, by the same
+// largest-remainder apportionment the bar uses. An empty group is left alone
+// rather than inventing tokens for categories the session does not have.
+func scaleGroup(cats []contextCategory, total int) {
+	for i, n := range apportion(cats, total) {
+		cats[i].tokens = n
+	}
+}
+
+// apportion distributes total across cats in proportion to their token counts,
+// by largest remainder: floor each share, then hand the leftover cells to the
+// categories with the strongest fractional claim. Parts always sum to total
+// (or to 0 for an empty group), and a category holding nothing always gets
+// nothing — its remainder is 0, so it can never be a claimant.
+func apportion(cats []contextCategory, total int) []int {
+	shares := make([]int, len(cats))
+
+	estimated := totalTokens(cats)
+	if estimated <= 0 || total <= 0 {
+		return shares
+	}
+
+	remainders := make([]float64, len(cats))
+	assigned := 0
+	for i, c := range cats {
+		exact := float64(c.tokens) / float64(estimated) * float64(total)
+		shares[i] = int(exact)
+		remainders[i] = exact - float64(shares[i])
+		assigned += shares[i]
+	}
+	// Flooring loses less than one unit per category, so there are strictly
+	// fewer leftovers than categories and each can claim at most one.
+	for ; assigned < total; assigned++ {
+		claimant := 0
+		for i := range remainders {
+			if remainders[i] > remainders[claimant] {
+				claimant = i
+			}
+		}
+		shares[claimant]++
+		remainders[claimant] = -1
+	}
+	return shares
 }
 
 // renderStackedBar draws every category end to end in its own color and fills
@@ -218,7 +241,7 @@ func renderStackedBar(cats []contextCategory, limit int) string {
 		filled += cells[i]
 	}
 	if free := contextUsageBarWidth - filled; free > 0 {
-		b.WriteString(freeStyle().Render(strings.Repeat("░", free)))
+		b.WriteString(lipgloss.NewStyle().Foreground(freeColor()).Render(strings.Repeat("░", free)))
 	}
 	return b.String()
 }
@@ -227,43 +250,13 @@ func renderStackedBar(cats []contextCategory, limit int) string {
 //
 // The total fill is pinned to the header's percentage first: a bar that reads
 // fuller than the number printed above it is a worse lie than one that hides a
-// small category. Those cells are then handed out by largest remainder, so a
-// category earns a cell only against the competing claims — a 263-token memory
-// file appears in the legend but not in the bar, which is the honest picture
-// of what it costs.
+// small category. Those cells are then handed out by apportion, so a category
+// earns a cell only against the competing claims — a 263-token memory file
+// appears in the legend but not in the bar, which is the honest picture of what
+// it costs.
 func barCells(cats []contextCategory, limit, width int) []int {
-	cells := make([]int, len(cats))
-
-	used := 0
-	for _, c := range cats {
-		used += c.tokens
-	}
-	target := min(int(float64(used)/float64(limit)*float64(width)+0.5), width)
-	if used <= 0 || target <= 0 {
-		return cells
-	}
-
-	remainders := make([]float64, len(cats))
-	assigned := 0
-	for i, c := range cats {
-		exact := float64(c.tokens) / float64(used) * float64(target)
-		cells[i] = int(exact)
-		remainders[i] = exact - float64(cells[i])
-		assigned += cells[i]
-	}
-	// Flooring above loses less than one cell per category, so there are
-	// strictly fewer leftovers than categories and each can claim at most one.
-	for ; assigned < target; assigned++ {
-		claimant := 0
-		for i := range remainders {
-			if remainders[i] > remainders[claimant] {
-				claimant = i
-			}
-		}
-		cells[claimant]++
-		remainders[claimant] = -1
-	}
-	return cells
+	target := min(int(float64(totalTokens(cats))/float64(limit)*float64(width)+0.5), width)
+	return apportion(cats, target)
 }
 
 // renderContextLegend renders one row per category, then the free-space row,
@@ -280,47 +273,49 @@ func renderContextLegend(cats []contextCategory, free, limit int) string {
 			rows = append(rows, c)
 		}
 	}
+	// Remembered rather than re-derived from the row's position at render time,
+	// so the glyph stays attached to the row it was appended for.
+	freeRow := -1
 	if limit > 0 {
-		rows = append(rows, contextCategory{label: "Free space", tokens: free, color: kit.CurrentTheme.TextDisabled})
+		freeRow = len(rows)
+		rows = append(rows, contextCategory{label: "Free space", tokens: free, color: freeColor()})
 	}
 
 	labelWidth := 0
 	for _, r := range rows {
-		labelWidth = max(labelWidth, len(r.label))
+		labelWidth = max(labelWidth, lipgloss.Width(r.label))
 	}
 
 	var b strings.Builder
 	for i, r := range rows {
 		glyph := "█"
-		if limit > 0 && i == len(rows)-1 {
-			glyph = "░" // the free-space row, matching the bar's tail
+		if i == freeRow {
+			glyph = "░" // matching the bar's tail
 		}
-		b.WriteString(contextLegendRow(glyph, r.color, r.label, labelWidth, r.tokens, limit))
+		b.WriteString(contextLegendRow(r, glyph, labelWidth, limit))
 	}
 	return b.String()
 }
 
-func contextLegendRow(glyph string, color kit.AdaptiveColor, label string, labelWidth, tokens, limit int) string {
-	row := fmt.Sprintf("%s  %-*s %8s",
-		lipgloss.NewStyle().Foreground(color).Render(glyph),
-		labelWidth, label,
-		kit.FormatTokenCount(tokens))
+func contextLegendRow(c contextCategory, glyph string, labelWidth, limit int) string {
+	numbers := fmt.Sprintf("%8s", kit.FormatTokenCount(c.tokens))
 	if limit > 0 {
 		// One decimal, unlike the header's whole percent: a memory file worth
 		// 0.1% of the window should not round away to nothing.
-		row += fmt.Sprintf(" %6.1f%%", float64(tokens)/float64(limit)*100)
+		numbers += fmt.Sprintf(" %6.1f%%", float64(c.tokens)/float64(limit)*100)
 	}
-	return row + "\n"
+	chip := lipgloss.NewStyle().Foreground(c.color).Render(glyph)
+	// FormatAlignedRow keeps a minimum gap after the label, so the widest label
+	// would be pushed past the column that shorter ones land on. Adding that
+	// minimum to the column width puts every row's numbers at the same offset.
+	return kit.FormatAlignedRow(chip, c.label, labelWidth+kit.AlignedRowMinGap, numbers) + "\n"
 }
 
-func freeStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(kit.CurrentTheme.TextDisabled)
-}
+// freeColor is the unfilled remainder's color, shared by the bar's tail and the
+// legend's free-space row so the two always read as the same thing.
+func freeColor() kit.AdaptiveColor { return kit.CurrentTheme.TextDisabled }
 
 // percentOf rounds a share of the window to a whole percent for display.
 func percentOf(part, whole int) int {
-	if whole <= 0 {
-		return 0
-	}
 	return int(float64(part)/float64(whole)*100 + 0.5)
 }

--- a/internal/app/conv/context_usage.go
+++ b/internal/app/conv/context_usage.go
@@ -1,0 +1,271 @@
+// Package conv: the /context breakdown — which parts of the prompt occupy
+// the model's context window, as a stacked bar plus a legend. The status bar
+// answers "how full is it"; this answers "what filled it".
+package conv
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/genai-io/san/internal/app/kit"
+)
+
+// contextUsageBarWidth is the cell count of the stacked bar. Wider than the
+// status bar's contextBarWidth because this bar carries six distinguishable
+// segments rather than one fill level.
+const contextUsageBarWidth = 40
+
+// ContextUsage is one /context snapshot: the window being filled, the size
+// the provider measured for the last turn, and the estimated split by
+// category.
+//
+// The categories are named fields rather than a slice so a caller cannot
+// reorder or relabel them by accident — render order, labels, and colors are
+// decided once, in categories() below.
+type ContextUsage struct {
+	ModelName string
+
+	// Limit is the model's context window, or 0 when San cannot size the
+	// model. A zero limit drops the bar and the percentages; the token
+	// counts still render.
+	Limit int
+
+	// Measured is the prompt size the provider reported for the last turn —
+	// the same number the status bar shows as `ctx X/…`. It is 0 until a turn
+	// completes, which falls the total back to the estimate.
+	Measured int
+
+	SystemPrompt int
+	Tools        int
+	MCPTools     int
+	Skills       int
+	MemoryFiles  int
+	Messages     int
+}
+
+// contextCategory is one legend row and its slice of the stacked bar.
+type contextCategory struct {
+	label  string
+	tokens int
+	color  kit.AdaptiveColor
+}
+
+// categories lists the breakdown in render order, darkest to brightest. The
+// ramp is the point: the leading segments are fixed session overhead the user
+// configures once, and it brightens toward Messages — the one segment that
+// grows every turn and the one /compact acts on — which takes the theme's
+// single vivid accent.
+func (u ContextUsage) categories() []contextCategory {
+	t := kit.CurrentTheme
+	return []contextCategory{
+		{"System prompt", u.SystemPrompt, t.Separator},
+		{"Tools", u.Tools, t.Accent},
+		{"MCP tools", u.MCPTools, t.TextDim},
+		{"Skills", u.Skills, t.Primary},
+		{"Memory files", u.MemoryFiles, t.Text},
+		{"Messages", u.Messages, t.Focus},
+	}
+}
+
+// RenderContextUsage renders the /context body: a header naming the model and
+// the fill, the stacked bar, one row per category, and a footer stating which
+// numbers are measured and which are estimated.
+func RenderContextUsage(u ContextUsage) string {
+	cats := u.categories()
+
+	estimated := 0
+	for _, c := range cats {
+		estimated += c.tokens
+	}
+
+	used := estimated
+	if u.Measured > 0 {
+		used = u.Measured
+		if estimated > 0 {
+			cats = scaleToMeasured(cats, estimated, u.Measured)
+		}
+	}
+
+	free := max(u.Limit-used, 0)
+	muted := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
+
+	var b strings.Builder
+	b.WriteString(muted.Render(contextUsageHeader(u.ModelName, used, u.Limit)))
+	b.WriteString("\n\n")
+	if u.Limit > 0 {
+		b.WriteString(renderStackedBar(cats, u.Limit))
+		b.WriteString("\n\n")
+	}
+	b.WriteString(renderContextLegend(cats, free, u.Limit))
+	b.WriteString("\n")
+	b.WriteString(muted.Render(contextUsageFooter(u.Measured > 0)))
+	return b.String()
+}
+
+// contextUsageHeader is the "Context · <model> · 41.2k / 200k (21%)" line. An
+// unknown window renders as "--" rather than a percentage of a guess, matching
+// RenderContextLabel.
+func contextUsageHeader(modelName string, used, limit int) string {
+	parts := []string{"Context"}
+	if modelName != "" {
+		parts = append(parts, modelName)
+	}
+	if limit <= 0 {
+		parts = append(parts, kit.FormatTokenCount(used)+" / --")
+	} else {
+		parts = append(parts, fmt.Sprintf("%s / %s (%d%%)",
+			kit.FormatTokenCount(used), kit.FormatTokenCount(limit), percentOf(used, limit)))
+	}
+	return strings.Join(parts, " · ")
+}
+
+func contextUsageFooter(measured bool) string {
+	if measured {
+		return "total measured last turn · split estimated"
+	}
+	return "estimated · no turn sent yet this session"
+}
+
+// scaleToMeasured spreads the provider's measured prompt size across the
+// estimated split, so the headline total matches the status bar exactly while
+// the parts still add up to it. Rounding drift lands on the largest category,
+// where it is proportionally smallest.
+func scaleToMeasured(cats []contextCategory, estimated, measured int) []contextCategory {
+	scaled := make([]contextCategory, len(cats))
+	copy(scaled, cats)
+
+	total, largest := 0, 0
+	for i, c := range scaled {
+		scaled[i].tokens = int(float64(c.tokens) / float64(estimated) * float64(measured))
+		total += scaled[i].tokens
+		if scaled[i].tokens > scaled[largest].tokens {
+			largest = i
+		}
+	}
+	scaled[largest].tokens = max(scaled[largest].tokens+measured-total, 0)
+	return scaled
+}
+
+// renderStackedBar draws every category end to end in its own color and fills
+// the remainder with the free-space glyph.
+func renderStackedBar(cats []contextCategory, limit int) string {
+	cells := barCells(cats, limit, contextUsageBarWidth)
+
+	var b strings.Builder
+	filled := 0
+	for i, c := range cats {
+		if cells[i] == 0 {
+			continue
+		}
+		b.WriteString(lipgloss.NewStyle().Foreground(c.color).Render(strings.Repeat("█", cells[i])))
+		filled += cells[i]
+	}
+	if free := contextUsageBarWidth - filled; free > 0 {
+		b.WriteString(freeStyle().Render(strings.Repeat("░", free)))
+	}
+	return b.String()
+}
+
+// barCells apportions the filled part of the bar across the categories.
+//
+// The total fill is pinned to the header's percentage first: a bar that reads
+// fuller than the number printed above it is a worse lie than one that hides a
+// small category. Those cells are then handed out by largest remainder, so a
+// category earns a cell only against the competing claims — a 263-token memory
+// file appears in the legend but not in the bar, which is the honest picture
+// of what it costs.
+func barCells(cats []contextCategory, limit, width int) []int {
+	cells := make([]int, len(cats))
+
+	used := 0
+	for _, c := range cats {
+		used += c.tokens
+	}
+	target := min(int(float64(used)/float64(limit)*float64(width)+0.5), width)
+	if used <= 0 || target <= 0 {
+		return cells
+	}
+
+	remainders := make([]float64, len(cats))
+	assigned := 0
+	for i, c := range cats {
+		exact := float64(c.tokens) / float64(used) * float64(target)
+		cells[i] = int(exact)
+		remainders[i] = exact - float64(cells[i])
+		assigned += cells[i]
+	}
+	// Flooring above loses less than one cell per category, so there are
+	// strictly fewer leftovers than categories and each can claim at most one.
+	for ; assigned < target; assigned++ {
+		claimant := 0
+		for i := range remainders {
+			if remainders[i] > remainders[claimant] {
+				claimant = i
+			}
+		}
+		cells[claimant]++
+		remainders[claimant] = -1
+	}
+	return cells
+}
+
+// renderContextLegend renders one row per category, then the free-space row,
+// with the token and percentage columns right-aligned so the numbers stack.
+//
+// Empty categories are left out: a session with no MCP server and no memory
+// file should read as a short list, not as a fixed form with zeros in it.
+// Free space is only meaningful against a known window, so an unknown limit
+// drops that row and the whole percentage column with it.
+func renderContextLegend(cats []contextCategory, free, limit int) string {
+	rows := make([]contextCategory, 0, len(cats)+1)
+	for _, c := range cats {
+		if c.tokens > 0 {
+			rows = append(rows, c)
+		}
+	}
+	if limit > 0 {
+		rows = append(rows, contextCategory{"Free space", free, kit.CurrentTheme.TextDisabled})
+	}
+
+	labelWidth := 0
+	for _, r := range rows {
+		labelWidth = max(labelWidth, len(r.label))
+	}
+
+	var b strings.Builder
+	for i, r := range rows {
+		glyph := "█"
+		if limit > 0 && i == len(rows)-1 {
+			glyph = "░" // the free-space row, matching the bar's tail
+		}
+		b.WriteString(contextLegendRow(glyph, r.color, r.label, labelWidth, r.tokens, limit))
+	}
+	return b.String()
+}
+
+func contextLegendRow(glyph string, color kit.AdaptiveColor, label string, labelWidth, tokens, limit int) string {
+	row := fmt.Sprintf("%s  %-*s %8s",
+		lipgloss.NewStyle().Foreground(color).Render(glyph),
+		labelWidth, label,
+		kit.FormatTokenCount(tokens))
+	if limit > 0 {
+		// One decimal, unlike the header's whole percent: a memory file worth
+		// 0.1% of the window should not round away to nothing.
+		row += fmt.Sprintf(" %6.1f%%", float64(tokens)/float64(limit)*100)
+	}
+	return row + "\n"
+}
+
+func freeStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(kit.CurrentTheme.TextDisabled)
+}
+
+// percentOf rounds a share of the window to a whole percent for display.
+func percentOf(part, whole int) int {
+	if whole <= 0 {
+		return 0
+	}
+	return int(float64(part)/float64(whole)*100 + 0.5)
+}

--- a/internal/app/conv/context_usage_test.go
+++ b/internal/app/conv/context_usage_test.go
@@ -1,0 +1,141 @@
+package conv
+
+import (
+	"strings"
+	"testing"
+
+	xansi "github.com/charmbracelet/x/ansi"
+)
+
+// midSession is a representative snapshot: a measured total, every category
+// populated, and one category (memory) far too small to earn a bar cell.
+func midSession() ContextUsage {
+	return ContextUsage{
+		ModelName:    "claude-sonnet-5",
+		Limit:        200000,
+		Measured:     41200,
+		SystemPrompt: 5300,
+		Tools:        19700,
+		MCPTools:     3100,
+		Skills:       2200,
+		MemoryFiles:  263,
+		Messages:     13700,
+	}
+}
+
+func TestScaleToMeasuredPartsSumToMeasured(t *testing.T) {
+	u := midSession()
+	cats := u.categories()
+
+	estimated := 0
+	for _, c := range cats {
+		estimated += c.tokens
+	}
+
+	scaled := scaleToMeasured(cats, estimated, u.Measured)
+	total := 0
+	for _, c := range scaled {
+		total += c.tokens
+	}
+	if total != u.Measured {
+		t.Errorf("scaled parts sum to %d, want the measured total %d", total, u.Measured)
+	}
+}
+
+// The rounding remainder must land somewhere real, not on a category that
+// holds nothing — an empty category picking up stray tokens would render a
+// row for a thing the session does not have.
+func TestScaleToMeasuredKeepsEmptyCategoriesEmpty(t *testing.T) {
+	u := ContextUsage{Limit: 200000, Measured: 41201, SystemPrompt: 5300, Messages: 13700}
+	cats := u.categories()
+
+	scaled := scaleToMeasured(cats, 19000, u.Measured)
+	for i, c := range scaled {
+		if cats[i].tokens == 0 && c.tokens != 0 {
+			t.Errorf("%s was empty but scaled to %d", c.label, c.tokens)
+		}
+	}
+}
+
+// The bar's fill has to agree with the percentage printed above it. Giving
+// every non-empty category a guaranteed cell is what breaks this: five tiny
+// categories would show five cells the window is not actually holding.
+func TestBarCellsFillMatchesHeaderPercent(t *testing.T) {
+	u := midSession()
+	cells := barCells(u.categories(), u.Limit, contextUsageBarWidth)
+
+	filled := 0
+	for _, n := range cells {
+		filled += n
+	}
+	want := percentOf(filled, contextUsageBarWidth)
+	got := percentOf(u.SystemPrompt+u.Tools+u.MCPTools+u.Skills+u.MemoryFiles+u.Messages, u.Limit)
+	if diff := want - got; diff > 2 || diff < -2 {
+		t.Errorf("bar reads %d%% full but the categories fill %d%%", want, got)
+	}
+}
+
+func TestBarCellsNeverExceedWidth(t *testing.T) {
+	full := ContextUsage{Limit: 100, Measured: 100, SystemPrompt: 40, Tools: 40, Messages: 40}
+	cells := barCells(full.categories(), full.Limit, contextUsageBarWidth)
+
+	filled := 0
+	for _, n := range cells {
+		filled += n
+	}
+	if filled > contextUsageBarWidth {
+		t.Errorf("over-full context allocated %d cells, want at most %d", filled, contextUsageBarWidth)
+	}
+}
+
+func TestRenderContextUsageShowsPopulatedCategoriesOnly(t *testing.T) {
+	out := xansi.Strip(RenderContextUsage(midSession()))
+
+	for _, label := range []string{"System prompt", "Tools", "MCP tools", "Skills", "Memory files", "Messages", "Free space"} {
+		if !strings.Contains(out, label) {
+			t.Errorf("missing category %q in:\n%s", label, out)
+		}
+	}
+	if !strings.Contains(out, "41.2k") {
+		t.Errorf("header should carry the measured total, got:\n%s", out)
+	}
+	if !strings.Contains(out, "total measured last turn") {
+		t.Errorf("footer should name the measured total, got:\n%s", out)
+	}
+}
+
+func TestRenderContextUsageOmitsEmptyCategories(t *testing.T) {
+	out := xansi.Strip(RenderContextUsage(ContextUsage{
+		ModelName: "gpt-5.5", Limit: 400000, SystemPrompt: 5300, Tools: 19700,
+	}))
+
+	if strings.Contains(out, "MCP tools") {
+		t.Errorf("a session with no MCP server should not list MCP tools:\n%s", out)
+	}
+	if !strings.Contains(out, "no turn sent yet") {
+		t.Errorf("an unmeasured session should say so, got:\n%s", out)
+	}
+}
+
+// An unknown window has nothing to take a percentage of, so the bar, the
+// percentage column, and free space all drop out rather than render against
+// a guessed denominator.
+func TestRenderContextUsageWithoutLimitDropsPercentages(t *testing.T) {
+	out := xansi.Strip(RenderContextUsage(ContextUsage{
+		ModelName: "some-local-model", Measured: 41200, SystemPrompt: 5300, Messages: 13700,
+	}))
+
+	if strings.Contains(out, "%") {
+		t.Errorf("no window means no percentages, got:\n%s", out)
+	}
+	if strings.Contains(out, "Free space") {
+		t.Errorf("free space is unknowable without a window, got:\n%s", out)
+	}
+	// Legend rows keep their single-cell color chip; only the bar goes away.
+	if strings.Contains(out, "██") || strings.Contains(out, "░") {
+		t.Errorf("the bar needs a window to fill, got:\n%s", out)
+	}
+	if !strings.Contains(out, "41.2k / --") {
+		t.Errorf("unknown window should render as --, got:\n%s", out)
+	}
+}

--- a/internal/app/conv/context_usage_test.go
+++ b/internal/app/conv/context_usage_test.go
@@ -23,21 +23,19 @@ func midSession() ContextUsage {
 	}
 }
 
-func TestScaleToMeasuredPartsSumToMeasured(t *testing.T) {
-	u := midSession()
-	cats := u.categories()
-
-	estimated := 0
-	for _, c := range cats {
-		estimated += c.tokens
-	}
-
-	scaled := scaleToMeasured(cats, estimated, u.Measured)
+func sumTokens(cats []contextCategory) int {
 	total := 0
-	for _, c := range scaled {
+	for _, c := range cats {
 		total += c.tokens
 	}
-	if total != u.Measured {
+	return total
+}
+
+func TestScaleToProviderPartsSumToMeasured(t *testing.T) {
+	u := midSession()
+
+	scaled := scaleToProvider(u.categories(), u.Measured, 0)
+	if total := sumTokens(scaled); total != u.Measured {
 		t.Errorf("scaled parts sum to %d, want the measured total %d", total, u.Measured)
 	}
 }
@@ -45,14 +43,68 @@ func TestScaleToMeasuredPartsSumToMeasured(t *testing.T) {
 // The rounding remainder must land somewhere real, not on a category that
 // holds nothing — an empty category picking up stray tokens would render a
 // row for a thing the session does not have.
-func TestScaleToMeasuredKeepsEmptyCategoriesEmpty(t *testing.T) {
+func TestScaleToProviderKeepsEmptyCategoriesEmpty(t *testing.T) {
 	u := ContextUsage{Limit: 200000, Measured: 41201, SystemPrompt: 5300, Messages: 13700}
 	cats := u.categories()
 
-	scaled := scaleToMeasured(cats, 19000, u.Measured)
+	scaled := scaleToProvider(cats, u.Measured, 0)
 	for i, c := range scaled {
 		if cats[i].tokens == 0 && c.tokens != 0 {
 			t.Errorf("%s was empty but scaled to %d", c.label, c.tokens)
+		}
+	}
+}
+
+// An exact prefix pins the cached categories to it exactly, and the
+// conversation to the remainder — the whole point of scaling two groups
+// instead of one.
+func TestScaleToProviderPinsEachGroupToItsOwnTotal(t *testing.T) {
+	u := midSession()
+	const cachedPrefix = 30000
+
+	scaled := scaleToProvider(u.categories(), u.Measured, cachedPrefix)
+	boundary := cachedPrefixEnd(scaled)
+
+	if got := sumTokens(scaled[:boundary]); got != cachedPrefix {
+		t.Errorf("cached categories sum to %d, want the exact prefix %d", got, cachedPrefix)
+	}
+	if got, want := sumTokens(scaled[boundary:]), u.Measured-cachedPrefix; got != want {
+		t.Errorf("conversation categories sum to %d, want %d", got, want)
+	}
+}
+
+// The regression the two-group split exists to prevent: an underestimated
+// toolset must not push its error onto Messages. With the prompt pinned to an
+// exact prefix, Messages is unaffected by how wrong the tool estimate was.
+func TestScaleToProviderKeepsPrefixErrorOutOfMessages(t *testing.T) {
+	u := midSession()
+	const cachedPrefix = 30000
+
+	underestimated := u
+	underestimated.Tools /= 3 // the estimator reading punctuation-dense JSON low
+
+	messagesFor := func(usage ContextUsage) int {
+		scaled := scaleToProvider(usage.categories(), usage.Measured, cachedPrefix)
+		return scaled[len(scaled)-1].tokens
+	}
+	if got, want := messagesFor(underestimated), messagesFor(u); got != want {
+		t.Errorf("Messages moved to %d (from %d) because the tool estimate changed", got, want)
+	}
+}
+
+// The cached categories have to be the leading run: scaleToProvider slices at
+// the boundary, so a cached category sitting after an uncached one would be
+// scaled against the wrong total.
+func TestCachedCategoriesAreLeading(t *testing.T) {
+	cats := midSession().categories()
+
+	boundary := cachedPrefixEnd(cats)
+	if boundary == 0 || boundary == len(cats) {
+		t.Fatalf("boundary at %d leaves one group empty", boundary)
+	}
+	for _, c := range cats[boundary:] {
+		if c.cached {
+			t.Errorf("%s is cached but sits after the boundary", c.label)
 		}
 	}
 }
@@ -101,6 +153,26 @@ func TestRenderContextUsageShowsPopulatedCategoriesOnly(t *testing.T) {
 	}
 	if !strings.Contains(out, "total measured last turn") {
 		t.Errorf("footer should name the measured total, got:\n%s", out)
+	}
+}
+
+// The footer is the only thing telling the reader how much of the panel is
+// measured, so it has to track which measurement actually landed.
+func TestRenderContextUsageFooterNamesWhatWasMeasured(t *testing.T) {
+	measuredPrefix := midSession()
+	measuredPrefix.CachedPrefix = 30000
+
+	for name, tc := range map[string]struct {
+		usage ContextUsage
+		want  string
+	}{
+		"nothing measured":     {ContextUsage{Limit: 200000, SystemPrompt: 5300}, "no turn sent yet"},
+		"total measured":       {midSession(), "total measured last turn"},
+		"prompt also measured": {measuredPrefix, "prompt and tools measured last turn"},
+	} {
+		if out := xansi.Strip(RenderContextUsage(tc.usage)); !strings.Contains(out, tc.want) {
+			t.Errorf("%s: footer missing %q in:\n%s", name, tc.want, out)
+		}
 	}
 }
 

--- a/internal/app/conv/context_usage_test.go
+++ b/internal/app/conv/context_usage_test.go
@@ -31,11 +31,19 @@ func sumTokens(cats []contextCategory) int {
 	return total
 }
 
+// scaled applies the provider fit and returns both groups, mirroring what
+// RenderContextUsage does.
+func scaled(u ContextUsage) (prompt, conversation []contextCategory) {
+	prompt, conversation = u.categories()
+	u.scaleToProvider(prompt, conversation)
+	return prompt, conversation
+}
+
 func TestScaleToProviderPartsSumToMeasured(t *testing.T) {
 	u := midSession()
 
-	scaled := scaleToProvider(u.categories(), u.Measured, 0)
-	if total := sumTokens(scaled); total != u.Measured {
+	prompt, conversation := scaled(u)
+	if total := sumTokens(prompt) + sumTokens(conversation); total != u.Measured {
 		t.Errorf("scaled parts sum to %d, want the measured total %d", total, u.Measured)
 	}
 }
@@ -45,30 +53,33 @@ func TestScaleToProviderPartsSumToMeasured(t *testing.T) {
 // row for a thing the session does not have.
 func TestScaleToProviderKeepsEmptyCategoriesEmpty(t *testing.T) {
 	u := ContextUsage{Limit: 200000, Measured: 41201, SystemPrompt: 5300, Messages: 13700}
-	cats := u.categories()
+	beforePrompt, beforeConversation := u.categories()
 
-	scaled := scaleToProvider(cats, u.Measured, 0)
-	for i, c := range scaled {
-		if cats[i].tokens == 0 && c.tokens != 0 {
-			t.Errorf("%s was empty but scaled to %d", c.label, c.tokens)
+	prompt, conversation := scaled(u)
+	for _, group := range []struct{ before, after []contextCategory }{
+		{beforePrompt, prompt}, {beforeConversation, conversation},
+	} {
+		for i, c := range group.after {
+			if group.before[i].tokens == 0 && c.tokens != 0 {
+				t.Errorf("%s was empty but scaled to %d", c.label, c.tokens)
+			}
 		}
 	}
 }
 
-// An exact prefix pins the cached categories to it exactly, and the
+// An exact prefix pins the prompt categories to it exactly, and the
 // conversation to the remainder — the whole point of scaling two groups
 // instead of one.
 func TestScaleToProviderPinsEachGroupToItsOwnTotal(t *testing.T) {
 	u := midSession()
-	const cachedPrefix = 30000
+	u.CachedPrefix = 30000
 
-	scaled := scaleToProvider(u.categories(), u.Measured, cachedPrefix)
-	boundary := cachedPrefixEnd(scaled)
+	prompt, conversation := scaled(u)
 
-	if got := sumTokens(scaled[:boundary]); got != cachedPrefix {
-		t.Errorf("cached categories sum to %d, want the exact prefix %d", got, cachedPrefix)
+	if got := sumTokens(prompt); got != u.CachedPrefix {
+		t.Errorf("prompt categories sum to %d, want the exact prefix %d", got, u.CachedPrefix)
 	}
-	if got, want := sumTokens(scaled[boundary:]), u.Measured-cachedPrefix; got != want {
+	if got, want := sumTokens(conversation), u.Measured-u.CachedPrefix; got != want {
 		t.Errorf("conversation categories sum to %d, want %d", got, want)
 	}
 }
@@ -78,34 +89,32 @@ func TestScaleToProviderPinsEachGroupToItsOwnTotal(t *testing.T) {
 // exact prefix, Messages is unaffected by how wrong the tool estimate was.
 func TestScaleToProviderKeepsPrefixErrorOutOfMessages(t *testing.T) {
 	u := midSession()
-	const cachedPrefix = 30000
+	u.CachedPrefix = 30000
 
 	underestimated := u
 	underestimated.Tools /= 3 // the estimator reading punctuation-dense JSON low
 
 	messagesFor := func(usage ContextUsage) int {
-		scaled := scaleToProvider(usage.categories(), usage.Measured, cachedPrefix)
-		return scaled[len(scaled)-1].tokens
+		_, conversation := scaled(usage)
+		return conversation[len(conversation)-1].tokens
 	}
 	if got, want := messagesFor(underestimated), messagesFor(u); got != want {
 		t.Errorf("Messages moved to %d (from %d) because the tool estimate changed", got, want)
 	}
 }
 
-// The cached categories have to be the leading run: scaleToProvider slices at
-// the boundary, so a cached category sitting after an uncached one would be
-// scaled against the wrong total.
-func TestCachedCategoriesAreLeading(t *testing.T) {
-	cats := midSession().categories()
+// Without an exact prefix there is one pool, and the parts must still sum to
+// the measured total across both groups rather than each group being scaled to
+// the whole of it.
+func TestScaleToProviderWithoutPrefixSharesOnePool(t *testing.T) {
+	u := midSession()
 
-	boundary := cachedPrefixEnd(cats)
-	if boundary == 0 || boundary == len(cats) {
-		t.Fatalf("boundary at %d leaves one group empty", boundary)
+	prompt, conversation := scaled(u)
+	if total := sumTokens(prompt) + sumTokens(conversation); total != u.Measured {
+		t.Errorf("parts sum to %d, want %d", total, u.Measured)
 	}
-	for _, c := range cats[boundary:] {
-		if c.cached {
-			t.Errorf("%s is cached but sits after the boundary", c.label)
-		}
+	if sumTokens(prompt) >= u.Measured {
+		t.Errorf("prompt group took the whole measured total (%d)", sumTokens(prompt))
 	}
 }
 
@@ -114,7 +123,8 @@ func TestCachedCategoriesAreLeading(t *testing.T) {
 // categories would show five cells the window is not actually holding.
 func TestBarCellsFillMatchesHeaderPercent(t *testing.T) {
 	u := midSession()
-	cells := barCells(u.categories(), u.Limit, contextUsageBarWidth)
+	prompt, conversation := u.categories()
+	cells := barCells(append(prompt, conversation...), u.Limit, contextUsageBarWidth)
 
 	filled := 0
 	for _, n := range cells {
@@ -129,7 +139,8 @@ func TestBarCellsFillMatchesHeaderPercent(t *testing.T) {
 
 func TestBarCellsNeverExceedWidth(t *testing.T) {
 	full := ContextUsage{Limit: 100, Measured: 100, SystemPrompt: 40, Tools: 40, Messages: 40}
-	cells := barCells(full.categories(), full.Limit, contextUsageBarWidth)
+	prompt, conversation := full.categories()
+	cells := barCells(append(prompt, conversation...), full.Limit, contextUsageBarWidth)
 
 	filled := 0
 	for _, n := range cells {

--- a/internal/app/env.go
+++ b/internal/app/env.go
@@ -33,6 +33,15 @@ type env struct {
 	// active — see InferResponse.TotalInputTokens.
 	InputTokens  int
 	OutputTokens int
+	// CachedPrefixTokens is the latest infer call's cached prompt prefix
+	// (creation + read). On a provider whose breakpoint sits at the end of the
+	// system prompt, that prefix is exactly the tool definitions plus the
+	// system prompt — an exact measurement /context uses in place of its
+	// estimate. Zero when nothing cached: no turn yet, a provider that caches
+	// on its own boundary, or a prefix below the model's cacheable minimum
+	// (512–4096 tokens depending on the model), which is why the reading is
+	// always corroborated rather than trusted outright.
+	CachedPrefixTokens int
 	// ConversationCost is the session-cumulative spend shown in the status
 	// bar. It survives ResetContextDisplay (per-compaction) so compaction
 	// doesn't erase prior spend; only ResetTokens (/clear, /new) zeroes it.
@@ -289,6 +298,10 @@ func parseSessionMode(mode string) setting.OperationMode {
 func (m *env) ResetContextDisplay() {
 	m.InputTokens = 0
 	m.OutputTokens = 0
+	// The prefix measurement belongs to the same infer call as InputTokens;
+	// keeping it past the reset would pair an exact prefix with an estimated
+	// total and report a split neither number supports.
+	m.CachedPrefixTokens = 0
 }
 
 // ResetTokens clears all token/cost accounting for a fresh session (/clear,

--- a/internal/app/input/slash_command.go
+++ b/internal/app/input/slash_command.go
@@ -70,6 +70,9 @@ type SlashCommandEnv struct {
 	// GetGoal reads the autopilot mission the session is currently driving
 	// toward, so bare /goal can report it. Empty when no goal is set.
 	GetGoal func() string
+	// ContextUsage measures what currently occupies the model's context
+	// window. It lives on the model because it reads the live agent session.
+	ContextUsage func() conv.ContextUsage
 
 	// Model-level action callbacks. These compose multiple services or
 	// touch UI state on `m`, so commands invoke them via the model.
@@ -112,6 +115,7 @@ func builtinCommandHandlers() map[string]slashCommandHandler {
 		"skills":         (*SlashCommandController).handleSkillCommand,
 		"agents":         (*SlashCommandController).handleAgentCommand,
 		"tokenlimit":     (*SlashCommandController).handleTokenLimitCommand,
+		"context":        (*SlashCommandController).handleContextCommand,
 		"compact":        (*SlashCommandController).handleCompactCommand,
 		"init":           (*SlashCommandController).handleInitCommand,
 		"memory":         (*SlashCommandController).handleMemoryCommand,
@@ -675,6 +679,13 @@ func (c *SlashCommandController) handleTokenLimitCommand(_ context.Context, args
 		c.env.Input.Provider.FetchingLimits = true
 	}
 	return result, cmd, err
+}
+
+// handleContextCommand reports what is filling the model's context window,
+// broken down by category. It is the "what" to the status bar's "how much" —
+// the reading you take before deciding whether /compact is worth it.
+func (c *SlashCommandController) handleContextCommand(_ context.Context, _ string) (string, tea.Cmd, error) {
+	return conv.RenderContextUsage(c.env.ContextUsage()), nil, nil
 }
 
 func (c *SlashCommandController) handleCompactCommand(_ context.Context, args string) (string, tea.Cmd, error) {

--- a/internal/app/kit/token.go
+++ b/internal/app/kit/token.go
@@ -63,12 +63,13 @@ func runTokens(class runeClass, n int) int {
 	switch class {
 	case classLetter:
 		return max((n+2)/4, 1)
-	case classDigit:
-		return max((n+2)/3, 1)
-	case classPunct:
-		// JSON and code are dominated by short runs a tokenizer has learned as
-		// single units — `":"`, `":{"`, `!=`, `:=`, `))` — so punctuation
-		// merges more than one-token-per-character but far less than prose.
+	case classDigit, classPunct:
+		// Both merge, but only in short groups: tokenizers chunk digits about
+		// three at a time, and JSON and code are dominated by short punctuation
+		// runs learned as single units — `":"`, `":{"`, `!=`, `:=`, `))`. So
+		// each sits well above one-token-per-character and well below prose.
+		// (The classes stay separate because they decide where runs break —
+		// `12+34` is three runs, not one — only the ratio is shared.)
 		return max((n+2)/3, 1)
 	case classWide:
 		return n

--- a/internal/app/kit/token.go
+++ b/internal/app/kit/token.go
@@ -24,28 +24,97 @@ func FormatTokenCount(count int) string {
 	}
 }
 
-// EstimateTokens approximates what a string costs in tokens without running a
-// tokenizer. Latin text averages roughly 4 characters per token; CJK and other
-// non-ASCII scripts sit closer to one token per character, so the two are
-// counted on their own ratios instead of applying one average to the whole
-// string — a Chinese SAN.md would otherwise read as a quarter of its real size.
-//
-// The result is an estimate and is always presented as one: only the provider's
-// reported prompt size is exact, and /context labels which is which.
-func EstimateTokens(s string) int {
-	asciiChars, otherRunes := 0, 0
-	for _, r := range s {
-		if r < 0x80 {
-			asciiChars++
-			continue
+// runeClass groups characters the way a BPE tokenizer's pre-tokenizer splits
+// them: it breaks text into runs of letters, digits, punctuation, and
+// whitespace before merging anything, so a run never spans two classes.
+type runeClass int
+
+const (
+	classLetter runeClass = iota
+	classDigit
+	classPunct
+	classSpace
+	// classWide is CJK and every other non-ASCII rune. Held apart because
+	// these carry roughly a token each rather than merging into long runs.
+	classWide
+)
+
+func classify(r rune) runeClass {
+	switch {
+	case r >= 0x80:
+		return classWide
+	case r == ' ' || r == '\t' || r == '\n' || r == '\r':
+		return classSpace
+	case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z'):
+		return classLetter
+	case r >= '0' && r <= '9':
+		return classDigit
+	default:
+		return classPunct
+	}
+}
+
+// runTokens estimates how many tokens a single run of n same-class characters
+// becomes. The ratios approximate what BPE merging does within each class:
+// words merge aggressively (a five-letter word is one token), digits merge in
+// groups of about three, punctuation merges only in short common pairs, and
+// every non-ASCII rune stands roughly on its own.
+func runTokens(class runeClass, n int) int {
+	switch class {
+	case classLetter:
+		return max((n+2)/4, 1)
+	case classDigit:
+		return max((n+2)/3, 1)
+	case classPunct:
+		// JSON and code are dominated by short runs a tokenizer has learned as
+		// single units — `":"`, `":{"`, `!=`, `:=`, `))` — so punctuation
+		// merges more than one-token-per-character but far less than prose.
+		return max((n+2)/3, 1)
+	case classWide:
+		return n
+	default: // classSpace
+		// A lone space is absorbed into the token that follows it — " the" is
+		// one token, not two. Longer runs (indentation, blank lines) do cost.
+		if n <= 1 {
+			return 0
 		}
-		otherRunes++
+		return max((n+3)/4, 1)
 	}
-	tokens := asciiChars/4 + otherRunes
-	if tokens == 0 && s != "" {
-		return 1
+}
+
+// EstimateTokens approximates what a string costs in tokens without running a
+// tokenizer.
+//
+// It counts by pre-token run rather than by a flat characters-per-token ratio,
+// because a flat ratio is wrong in exactly the places /context cares about
+// most. The familiar "4 characters per token" holds for English prose, but tool
+// schemas and tool results are punctuation-dense JSON and code, where BPE emits
+// far more tokens per character — measuring those against a prose ratio
+// understates the two largest categories in the breakdown. The same reasoning
+// separates CJK, which sits near one token per character; a single ratio reads
+// a Chinese SAN.md as a quarter of its real size.
+//
+// The result is an estimate and is always presented as one: only the provider
+// reports exact counts, and /context labels which numbers are which.
+func EstimateTokens(s string) int {
+	if s == "" {
+		return 0
 	}
-	return tokens
+
+	// runLength == 0 means no run has opened yet, so the seeded class is
+	// never used to close one.
+	tokens, runLength, runClass := 0, 0, classLetter
+	for _, r := range s {
+		class := classify(r)
+		if runLength > 0 && class != runClass {
+			tokens += runTokens(runClass, runLength)
+			runLength = 0
+		}
+		runClass, runLength = class, runLength+1
+	}
+	tokens += runTokens(runClass, runLength)
+
+	return max(tokens, 1)
 }
 
 // GetMaxTokens returns the effective output limit, falling back to defaultMaxTokens.

--- a/internal/app/kit/token.go
+++ b/internal/app/kit/token.go
@@ -24,6 +24,30 @@ func FormatTokenCount(count int) string {
 	}
 }
 
+// EstimateTokens approximates what a string costs in tokens without running a
+// tokenizer. Latin text averages roughly 4 characters per token; CJK and other
+// non-ASCII scripts sit closer to one token per character, so the two are
+// counted on their own ratios instead of applying one average to the whole
+// string — a Chinese SAN.md would otherwise read as a quarter of its real size.
+//
+// The result is an estimate and is always presented as one: only the provider's
+// reported prompt size is exact, and /context labels which is which.
+func EstimateTokens(s string) int {
+	asciiChars, otherRunes := 0, 0
+	for _, r := range s {
+		if r < 0x80 {
+			asciiChars++
+			continue
+		}
+		otherRunes++
+	}
+	tokens := asciiChars/4 + otherRunes
+	if tokens == 0 && s != "" {
+		return 1
+	}
+	return tokens
+}
+
 // GetMaxTokens returns the effective output limit, falling back to defaultMaxTokens.
 func GetMaxTokens(store *llm.Store, currentModel *llm.CurrentModelInfo, defaultMaxTokens int) int {
 	if limit := getEffectiveOutputLimit(store, currentModel); limit > 0 {

--- a/internal/app/kit/token_test.go
+++ b/internal/app/kit/token_test.go
@@ -1,6 +1,7 @@
 package kit
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/genai-io/san/internal/llm"
@@ -124,5 +125,33 @@ func TestGetEffectiveInputLimitWithoutModelIsZero(t *testing.T) {
 	t.Setenv(llm.InputLimitEnvVar, "500000")
 	if got := GetEffectiveInputLimit(nil, nil); got != 0 {
 		t.Fatalf("GetEffectiveInputLimit(nil, nil) = %d, want 0", got)
+	}
+}
+
+// A single ratio over the whole string is what makes a Chinese SAN.md read as
+// a quarter of its real cost, so the two scripts are checked against each
+// other rather than against exact numbers a tokenizer would have to confirm.
+func TestEstimateTokensCountsCJKHeavierThanASCII(t *testing.T) {
+	const runes = 40
+	ascii := strings.Repeat("a", runes)
+	chinese := strings.Repeat("中", runes)
+
+	if got := EstimateTokens(ascii); got != runes/4 {
+		t.Errorf("EstimateTokens(%d ascii chars) = %d, want %d", runes, got, runes/4)
+	}
+	if EstimateTokens(chinese) <= EstimateTokens(ascii) {
+		t.Errorf("%d Chinese characters (%d) should cost more than %d ASCII (%d)",
+			runes, EstimateTokens(chinese), runes, EstimateTokens(ascii))
+	}
+}
+
+// Short strings must not vanish: a legend row that reports 0 for content that
+// exists reads as "this is not loaded".
+func TestEstimateTokensNeverRoundsNonEmptyToZero(t *testing.T) {
+	if got := EstimateTokens("hi"); got != 1 {
+		t.Errorf(`EstimateTokens("hi") = %d, want 1`, got)
+	}
+	if got := EstimateTokens(""); got != 0 {
+		t.Errorf(`EstimateTokens("") = %d, want 0`, got)
 	}
 }

--- a/internal/app/kit/util.go
+++ b/internal/app/kit/util.go
@@ -130,16 +130,16 @@ func RenderPanelRow(line string, isSelected bool, width int) string {
 	return SelectorItemLabelStyle().Width(width).Render("  " + line)
 }
 
-// alignedRowMinGap is the minimum spacing kept between the name and info
+// AlignedRowMinGap is the minimum spacing kept between the name and info
 // columns, so names longer than colWidth never collide with the info column.
-const alignedRowMinGap = 2
+const AlignedRowMinGap = 2
 
 // FormatAlignedRow formats "icon  name<padding>info" with name padded to
-// colWidth and always separated from info by at least alignedRowMinGap spaces.
+// colWidth and always separated from info by at least AlignedRowMinGap spaces.
 func FormatAlignedRow(icon, name string, colWidth int, info string) string {
 	gap := colWidth - lipgloss.Width(name) // display width, ANSI/Unicode safe
-	if gap < alignedRowMinGap {
-		gap = alignedRowMinGap
+	if gap < AlignedRowMinGap {
+		gap = AlignedRowMinGap
 	}
 	return fmt.Sprintf("%s  %s%s%s", icon, name, strings.Repeat(" ", gap), info)
 }

--- a/internal/app/model_agent_events.go
+++ b/internal/app/model_agent_events.go
@@ -37,6 +37,10 @@ func (m *model) OnInference(resp *core.InferResponse) {
 	// context-window occupancy rather than just the uncached delta.
 	m.env.InputTokens = resp.TotalInputTokens()
 	m.env.OutputTokens = resp.OutputTokens
+	// Both halves of the cached prefix count toward it: the first turn writes
+	// it (creation), later turns read it (read), and a turn that invalidated it
+	// writes it again — the sum is the prefix size either way.
+	m.env.CachedPrefixTokens = resp.CacheCreationInputTokens + resp.CacheReadInputTokens
 
 	if m.env.CurrentModel != nil {
 		usage := llm.Usage{

--- a/internal/app/model_session.go
+++ b/internal/app/model_session.go
@@ -148,8 +148,7 @@ func (m *model) loadSessionByID(id string) error {
 		m.services.Tracker.Reset()
 	}
 
-	m.env.InputTokens = 0
-	m.env.OutputTokens = 0
+	m.env.ResetContextDisplay()
 
 	return nil
 }

--- a/internal/app/update_command.go
+++ b/internal/app/update_command.go
@@ -39,6 +39,7 @@ func (m *model) slashCommandEnv() input.SlashCommandEnv {
 		SetThinkingEffort: m.env.SetThinkingEffort,
 		ResetTokens:       m.env.ResetTokens,
 		GetGoal:           func() string { return strings.TrimSpace(m.env.AutoPilot.Mission) },
+		ContextUsage:      m.contextUsage,
 
 		// Model actions
 		CommitMessages:          m.CommitMessages,

--- a/internal/command/registry.go
+++ b/internal/command/registry.go
@@ -37,6 +37,7 @@ func builtinCommands() []Info {
 		{Name: "identity", Description: "Alias of /persona — switch the active persona (/identity <name>, or /identity to open the picker)"},
 		{Name: "persona", Description: "Switch the active persona (/persona <name>, or /persona to open the picker)"},
 		{Name: "tokenlimit", Description: "View or set token limits for current model"},
+		{Name: "context", Description: "Show what is filling the context window, by category"},
 		{Name: "compact", Description: "Summarize conversation to reduce context size"},
 		{Name: "init", Description: "Initialize memory files (SAN.md, local, rules)"},
 		{Name: "memory", Description: "View and manage memory files (list/show/edit) with @import support"},

--- a/internal/llm/anthropic/client.go
+++ b/internal/llm/anthropic/client.go
@@ -187,12 +187,19 @@ func (c *Client) Stream(ctx context.Context, opts llm.CompletionOptions) <-chan 
 		}
 
 		if opts.SystemPrompt != "" {
+			block := anthropic.TextBlockParam{Text: opts.SystemPrompt}
 			// Mark the last system block as ephemeral to enable prompt caching.
 			// This lets Anthropic cache the system prompt across requests, reducing
 			// cost and latency for long system prompts (tools, memory, CLAUDE.md).
-			params.System = []anthropic.TextBlockParam{
-				{Text: opts.SystemPrompt, CacheControl: anthropic.NewCacheControlEphemeralParam()},
+			//
+			// Gated on the capability rather than set unconditionally so the
+			// breakpoint and the claim made about it cannot drift: dropping the
+			// breakpoint means returning false there, which is what stops
+			// /context reading the cache counts as a prompt measurement.
+			if c.CachesToolsAndSystemPrompt() {
+				block.CacheControl = anthropic.NewCacheControlEphemeralParam()
 			}
+			params.System = []anthropic.TextBlockParam{block}
 		}
 
 		// Add tools if provided

--- a/internal/llm/anthropic/client.go
+++ b/internal/llm/anthropic/client.go
@@ -67,6 +67,14 @@ func (c *Client) Name() string {
 	return c.name
 }
 
+// CachesToolsAndSystemPrompt implements llm.PromptPrefixCacheProvider. Stream
+// marks the system block ephemeral and nothing else, and Anthropic renders a
+// request as tools → system → messages, so the cached prefix is exactly the
+// tool definitions plus the system prompt. That makes the reported cache tokens
+// an exact measurement of those two — which is what /context reads them as.
+// Moving or adding a breakpoint in Stream invalidates that reading.
+func (c *Client) CachesToolsAndSystemPrompt() bool { return true }
+
 // Stream sends a completion request and returns a channel of streaming chunks
 func (c *Client) Stream(ctx context.Context, opts llm.CompletionOptions) <-chan llm.StreamChunk {
 	ch := make(chan llm.StreamChunk)

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -123,6 +123,29 @@ func SupportsImages(p Provider, model string) bool {
 	return true
 }
 
+// PromptPrefixCacheProvider is implemented by providers that place their
+// prompt-cache breakpoint at the end of the system prompt. Anthropic renders a
+// request as tools → system → messages, so a breakpoint there makes the cached
+// prefix exactly the tool definitions plus the system prompt — and the cache
+// token counts an exact measurement of those two.
+type PromptPrefixCacheProvider interface {
+	CachesToolsAndSystemPrompt() bool
+}
+
+// CachesToolsAndSystemPrompt reports whether the provider's reported cache
+// tokens (creation plus read) count exactly the tool definitions plus the
+// system prompt.
+//
+// It defaults to false, which is the honest answer for everyone else: providers
+// that cache automatically pick their own prefix boundary, so their cache
+// counts cover an unknown span — usually rather more than the prompt, since a
+// stable conversation head caches too. Reading those as a measurement of the
+// prompt would silently overstate it.
+func CachesToolsAndSystemPrompt(p Provider) bool {
+	cp, ok := p.(PromptPrefixCacheProvider)
+	return ok && cp.CachesToolsAndSystemPrompt()
+}
+
 func ThinkingEfforts(p Provider, model string) []string {
 	ep, ok := p.(ThinkingEffortProvider)
 	if !ok {

--- a/internal/reminder/reminder.go
+++ b/internal/reminder/reminder.go
@@ -17,6 +17,7 @@
 package reminder
 
 import (
+	"regexp"
 	"strings"
 	"sync"
 )
@@ -229,13 +230,7 @@ func (s *Service) RequeueSystemReminders() {
 func (s *Service) Drain() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if len(s.pending) == 0 {
-		return nil
-	}
-	out := make([]string, len(s.pending))
-	for i, e := range s.pending {
-		out[i] = e.wrapped
-	}
+	out := s.wrappedLocked()
 	s.pending = nil
 	return out
 }
@@ -246,6 +241,13 @@ func (s *Service) Drain() []string {
 func (s *Service) Pending() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.wrappedLocked()
+}
+
+// wrappedLocked returns the queue's wire strings. Shared by Drain and Pending
+// so the two views of the same queue cannot disagree about what an entry
+// renders as. Caller holds s.mu.
+func (s *Service) wrappedLocked() []string {
 	if len(s.pending) == 0 {
 		return nil
 	}
@@ -263,6 +265,28 @@ func (s *Service) Empty() bool {
 	return len(s.pending) == 0
 }
 
+// The one spelling of the <system-reminder> tag. Every producer and consumer
+// in the tree builds from these — WrapWithSource writes them, Blocks reads
+// them through Pattern, and the transcript splitter in internal/session
+// compiles Pattern into its own combined regexp. A change here therefore
+// reaches every reader; spelling the tag out a second time somewhere else is
+// how a reader silently stops recognizing what the writer emits.
+const (
+	tagOpen        = "<system-reminder"
+	tagClose       = "</system-reminder>"
+	sourceAttrName = "source"
+	quoteEscape    = "&quot;"
+
+	// Pattern matches one whole reminder, capturing the source attribute (empty
+	// for a one-time notice) in group 1. Callers that need it inside a larger
+	// alternation compile it themselves; Blocks uses it directly.
+	Pattern = tagOpen + `(?:\s+` + sourceAttrName + `="([^"]*)")?>.*?` + tagClose
+)
+
+// blockRe matches a whole reminder across newlines — bodies are multi-line, and
+// the non-greedy body must not run past the first closing tag.
+var blockRe = regexp.MustCompile(`(?s)` + Pattern)
+
 // Wrap returns body wrapped in <system-reminder>...</system-reminder>. Empty
 // body returns "".
 func Wrap(body string) string {
@@ -279,12 +303,12 @@ func WrapWithSource(body, source string) string {
 		return ""
 	}
 	if source == "" {
-		return "<system-reminder>\n" + body + "\n</system-reminder>"
+		return tagOpen + ">\n" + body + "\n" + tagClose
 	}
 	// Escape any quotes in source defensively; provider IDs are constants
 	// today but the surface is public.
-	src := strings.ReplaceAll(source, `"`, `&quot;`)
-	return "<system-reminder source=\"" + src + "\">\n" + body + "\n</system-reminder>"
+	src := strings.ReplaceAll(source, `"`, quoteEscape)
+	return tagOpen + " " + sourceAttrName + `="` + src + `">` + "\n" + body + "\n" + tagClose
 }
 
 // WrapMemory returns the main agent's memory reminder body: a short
@@ -351,52 +375,22 @@ type Block struct {
 }
 
 // Blocks extracts the <system-reminder> blocks embedded in a message's
-// content — the inverse of AttachToContent. It lives here so the tag shape
-// has exactly one definition: WrapWithSource writes it, Blocks reads it.
+// content — the inverse of AttachToContent, reading through the same Pattern
+// the writer above is built from.
 //
 // Callers use this to attribute the harness-injected bytes (the skills
 // directory, memory files) apart from what the user and the model actually
-// said. Unterminated or malformed blocks are skipped rather than guessed at.
+// said. An unterminated or malformed block simply does not match, so it counts
+// as ordinary content rather than being guessed at.
 func Blocks(content string) []Block {
-	const (
-		openTag  = "<system-reminder"
-		closeTag = "</system-reminder>"
-	)
-
-	var blocks []Block
-	for rest := content; ; {
-		start := strings.Index(rest, openTag)
-		if start < 0 {
-			return blocks
+	matches := blockRe.FindAllStringSubmatchIndex(content, -1)
+	blocks := make([]Block, 0, len(matches))
+	for _, m := range matches {
+		source := ""
+		if m[2] >= 0 {
+			source = strings.ReplaceAll(content[m[2]:m[3]], quoteEscape, `"`)
 		}
-		tagEnd := strings.Index(rest[start:], ">")
-		if tagEnd < 0 {
-			return blocks
-		}
-		end := strings.Index(rest[start:], closeTag)
-		if end < 0 {
-			return blocks
-		}
-		end += start + len(closeTag)
-
-		blocks = append(blocks, Block{
-			Source: sourceAttr(rest[start : start+tagEnd]),
-			Text:   rest[start:end],
-		})
-		rest = rest[end:]
+		blocks = append(blocks, Block{Source: source, Text: content[m[0]:m[1]]})
 	}
-}
-
-// sourceAttr reads the source="..." value out of an opening tag, or "" when
-// the tag carries no source (Wrap / Enqueue output).
-func sourceAttr(openTag string) string {
-	_, value, found := strings.Cut(openTag, `source="`)
-	if !found {
-		return ""
-	}
-	source, _, closed := strings.Cut(value, `"`)
-	if !closed {
-		return ""
-	}
-	return strings.ReplaceAll(source, "&quot;", `"`)
+	return blocks
 }

--- a/internal/reminder/reminder.go
+++ b/internal/reminder/reminder.go
@@ -240,6 +240,22 @@ func (s *Service) Drain() []string {
 	return out
 }
 
+// Pending returns the queued reminders (already wrapped) without clearing the
+// queue. Use it to inspect what the next user message will carry; use Drain
+// when you are the one attaching them.
+func (s *Service) Pending() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.pending) == 0 {
+		return nil
+	}
+	out := make([]string, len(s.pending))
+	for i, e := range s.pending {
+		out[i] = e.wrapped
+	}
+	return out
+}
+
 // Empty reports whether there are no pending reminders.
 func (s *Service) Empty() bool {
 	s.mu.Lock()
@@ -324,4 +340,63 @@ func AttachToContent(content string, reminders []string) string {
 		sb.WriteString(r)
 	}
 	return sb.String()
+}
+
+// Block is one <system-reminder> found inside a message: the provider that
+// emitted it (empty for a one-time notice) and the full wrapped text,
+// including the tags.
+type Block struct {
+	Source string
+	Text   string
+}
+
+// Blocks extracts the <system-reminder> blocks embedded in a message's
+// content — the inverse of AttachToContent. It lives here so the tag shape
+// has exactly one definition: WrapWithSource writes it, Blocks reads it.
+//
+// Callers use this to attribute the harness-injected bytes (the skills
+// directory, memory files) apart from what the user and the model actually
+// said. Unterminated or malformed blocks are skipped rather than guessed at.
+func Blocks(content string) []Block {
+	const (
+		openTag  = "<system-reminder"
+		closeTag = "</system-reminder>"
+	)
+
+	var blocks []Block
+	for rest := content; ; {
+		start := strings.Index(rest, openTag)
+		if start < 0 {
+			return blocks
+		}
+		tagEnd := strings.Index(rest[start:], ">")
+		if tagEnd < 0 {
+			return blocks
+		}
+		end := strings.Index(rest[start:], closeTag)
+		if end < 0 {
+			return blocks
+		}
+		end += start + len(closeTag)
+
+		blocks = append(blocks, Block{
+			Source: sourceAttr(rest[start : start+tagEnd]),
+			Text:   rest[start:end],
+		})
+		rest = rest[end:]
+	}
+}
+
+// sourceAttr reads the source="..." value out of an opening tag, or "" when
+// the tag carries no source (Wrap / Enqueue output).
+func sourceAttr(openTag string) string {
+	_, value, found := strings.Cut(openTag, `source="`)
+	if !found {
+		return ""
+	}
+	source, _, closed := strings.Cut(value, `"`)
+	if !closed {
+		return ""
+	}
+	return strings.ReplaceAll(source, "&quot;", `"`)
 }

--- a/internal/reminder/reminder_test.go
+++ b/internal/reminder/reminder_test.go
@@ -284,3 +284,63 @@ func TestServiceConcurrentAccess(t *testing.T) {
 		t.Errorf("expected 50 enqueued items, got %d", len(out))
 	}
 }
+
+// Blocks is the inverse of AttachToContent: whatever the harness attached to a
+// user turn has to be recoverable from that turn's content, with the emitting
+// provider intact, so /context can attribute those bytes to the right source.
+func TestBlocksRecoversAttachedReminders(t *testing.T) {
+	s := NewService()
+	s.Register(NewProvider(ProviderSkillsDirectory, func() string { return "skills body" }))
+	s.Register(NewProvider(ProviderMemoryProject, func() string { return "project memory body" }))
+	s.RequeueSystemReminders()
+	s.Enqueue("a one-time notice")
+
+	content := AttachToContent("what the user typed", s.Drain())
+
+	blocks := Blocks(content)
+	if len(blocks) != 3 {
+		t.Fatalf("expected 3 blocks, got %d from:\n%s", len(blocks), content)
+	}
+	wantSources := []string{ProviderSkillsDirectory, ProviderMemoryProject, ""}
+	for i, want := range wantSources {
+		if blocks[i].Source != want {
+			t.Errorf("block %d: source = %q, want %q", i, blocks[i].Source, want)
+		}
+		if !strings.HasPrefix(blocks[i].Text, "<system-reminder") ||
+			!strings.HasSuffix(blocks[i].Text, "</system-reminder>") {
+			t.Errorf("block %d text is not a whole reminder: %q", i, blocks[i].Text)
+		}
+	}
+	if strings.Contains(blocks[0].Text, "project memory body") {
+		t.Error("blocks ran together; the skills block swallowed the memory block")
+	}
+}
+
+func TestBlocksIgnoresMalformedTags(t *testing.T) {
+	for name, content := range map[string]string{
+		"no reminder at all": "plain user text",
+		"unterminated":       "text <system-reminder>body with no close",
+		"close only":         "text </system-reminder>",
+	} {
+		if got := Blocks(content); len(got) != 0 {
+			t.Errorf("%s: expected no blocks, got %d", name, len(got))
+		}
+	}
+}
+
+// Pending has to leave the queue intact — /context inspects what the next turn
+// will carry, it does not consume it.
+func TestPendingDoesNotDrain(t *testing.T) {
+	s := NewService()
+	s.Enqueue("queued")
+
+	if got := s.Pending(); len(got) != 1 {
+		t.Fatalf("Pending returned %d entries, want 1", len(got))
+	}
+	if s.Empty() {
+		t.Error("Pending consumed the queue")
+	}
+	if got := s.Drain(); len(got) != 1 {
+		t.Errorf("Drain after Pending returned %d entries, want 1", len(got))
+	}
+}

--- a/internal/session/message_convert.go
+++ b/internal/session/message_convert.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/reminder"
 	"github.com/genai-io/san/internal/tool/toolresult"
 )
 
@@ -26,14 +27,14 @@ import (
 // Persisting these with a Source lets a resumed session keep them out of the
 // visible message while preserving them in Content for the model — the same
 // split RenderUserMessage draws live from DisplayContent vs Content.
-const (
-	reminderPattern        = `<system-reminder(?:\s+source="([^"]*)")?>.*?</system-reminder>`
-	commandEnvelopePattern = `<command-name>.*?</command-name>\s*(?:<skill-invocation\b.*?</skill-invocation>|<custom-command\b.*?</custom-command>)\n*`
-)
+// The reminder half comes from internal/reminder, which is also what writes
+// the tag — spelling it out again here is how this splitter would silently
+// stop recognizing reminders after a change to the wrapper.
+const commandEnvelopePattern = `<command-name>.*?</command-name>\s*(?:<skill-invocation\b.*?</skill-invocation>|<custom-command\b.*?</custom-command>)\n*`
 
 // harnessInjectedRe matches any harness-injected span. The command envelope only
 // ever leads the message, so it's anchored; reminders can appear anywhere.
-var harnessInjectedRe = regexp.MustCompile(`(?s)` + reminderPattern + `|^` + commandEnvelopePattern)
+var harnessInjectedRe = regexp.MustCompile(`(?s)` + reminder.Pattern + `|^` + commandEnvelopePattern)
 
 const (
 	SourceReminder = "reminder"


### PR DESCRIPTION
The status bar says how full the context window is; `/context` says what filled it — a stacked bar plus a per-category breakdown.

```
Context · claude-sonnet-5 · 41.2k / 200k (21%)

████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

█  System prompt      5.3k    2.7%
█  Tools             19.7k    9.9%
█  Skills             2.2k    1.1%
█  Memory files        263    0.1%
█  Messages          13.7k    6.9%
░  Free space      158.8k   79.4%

prompt and tools measured last turn · conversation split estimated
```

### How the numbers are derived

- **The total is measured**, not estimated — the provider's reported prompt size for the last turn, so the header matches the status bar's `ctx X/Y` exactly.
- **The system prompt and toolset are measured too, where the provider allows it.** Anthropic renders a request as tools → system → messages, and San's client puts its only cache breakpoint on the system block — so the reported cache tokens (creation + read) are an exact count of exactly those two. Those categories scale to that exact prefix and the conversation to the remainder.
- **Two groups, not one.** Scaling every category to a single total spreads each one's estimation error across all of them, so an underestimated toolset quietly inflates Messages — the one category the user acts on. Two groups keep each error inside the group that produced it.
- **The cache reading is corroborated before use.** A provider caching on its own boundary, or a future moved breakpoint, would report a real number measuring something else. Disagreement with the estimate by more than 2× falls back to estimation rather than reporting a confident wrong number. It also declines when nothing cached — the cacheable minimum is 512–4096 tokens depending on the model, so small toolsets routinely miss it.
- **What stays estimated** is counted by BPE pre-token run (letters / digits / punctuation / whitespace / CJK each on their own ratio) rather than a flat chars-per-token average. A flat ratio is wrong exactly where it matters: tool schemas and tool results are punctuation-dense JSON and code, where BPE emits far more tokens per character. The footer always names which numbers are measured and which are estimated.

### Presentation

- **The bar's fill is pinned to the header percentage** and apportioned by largest remainder. Guaranteeing every non-empty category a cell would render a 21% window as a 27% bar; a 263-token memory file shows in the legend but not the bar.
- **No 200-cell grid.** `⛁ ⛀ ⛶` are East-Asian ambiguous-width and render double-wide in CJK terminals, which would break the layout. This reuses San's existing `█ / ░`.
- Empty categories and unknown windows drop out rather than rendering zeros or percentages of a guessed denominator.

### Notes

- Skills and memory reach the model as `<system-reminder source="...">` blocks inside user turns, so the chain is scanned and those bytes subtracted from Messages rather than measured separately. The tag now has one spelling in `internal/reminder` that the wrapper, `Blocks`, and the transcript splitter in `internal/session` all build from.
- Measures the running agent's `System()`/`Tools()`; only before the first message does it fall back to building, via the same side-effect-free `promptParams()` that `buildAgentParams` starts from.
- The Anthropic cache breakpoint is gated on the capability `/context` reads it by, so removing the breakpoint has to go through that declaration.
- **Not verified against a live Anthropic turn** — I have no Anthropic connection configured, so the cached-prefix path is covered by unit tests and the corroboration guard rather than a real request. Worth one manual check before merge: two turns, then confirm the footer reads "prompt and tools measured last turn".