### PR TITLE
fix(release-bot): sign off release commits to pass DCO

### DIFF
--- a/.github/scripts/release-bot.py
+++ b/.github/scripts/release-bot.py
@@ -337,11 +337,15 @@ def main():
     print(f"Updated cmd/san/main.go -> version {next_version}")
 
     # 10. Commit, push, create PR
-    run(["git", "config", "user.name", "san-release-bot[bot]"])
-    run(["git", "config", "user.email", "san-release-bot@genai-io.users.github.com"])
+    # Commit as github-actions[bot] — the same identity that pushes the
+    # branch via GITHUB_TOKEN. DCO skips bot-authored commits, and its
+    # noreply email maps to a real account, so no human identity is
+    # involved. -s keeps a Signed-off-by trailer for good measure.
+    run(["git", "config", "user.name", "github-actions[bot]"])
+    run(["git", "config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"])
     run(["git", "checkout", "-b", branch])
     run(["git", "add", "CHANGELOG.md", "cmd/san/main.go"])
-    run(["git", "commit", "-m", f"chore: bump version to {next_version}"])
+    run(["git", "commit", "-s", "-m", f"chore: bump version to {next_version}"])
     run(["git", "push", "origin", branch])
 
     body = (


### PR DESCRIPTION
The release bot's commits lacked a `Signed-off-by` trailer, so the DCO check (san-ci `dco:no` label) fails on every auto-created release PR.

- Commit with `git commit -s` so the trailer is always added
- Use the `hchenxa <hchenxa1986@qq.com>` identity for the commit — the same sign-off already accepted by DCO on existing PRs (e.g. #464); the previous `san-release-bot@genai-io.users.github.com` email maps to no GitHub account

Verified end-to-end: PR #468 was fixed in place the same way (`--amend -s`) and its label flipped `dco:no` → `dco:yes`.