### PR TITLE
feat(tui): rename bypass permissions to YOLO mode, gate it from /config

### DIFF
--- a/docs/concepts/permission-model.md
+++ b/docs/concepts/permission-model.md
@@ -27,7 +27,7 @@ For the Claude-Code-compatible rule syntax see
 | `ModeNormal` | `normal` | Safe tools auto-allow; everything else prompts. |
 | `ModeAutoAccept` | `accept edits` | Edit/Write auto-allow; other gated tools prompt. |
 | `ModeAutoPilot` | `autopilot` | Edits auto-allow; every other gated call becomes a **reviewable** prompt the judge may answer. |
-| `ModeBypassPermissions` | `yolo` | Allow everything except deny rules and the circuit breaker. Shown in the status bar as **YOLO mode**. |
+| `ModeBypassPermissions` | `YOLO` | Allow everything except deny rules and the circuit breaker. |
 | `ModeDontAsk` | `don't ask` | Coerce `ask` → `deny`; never prompt. |
 | `ModeReadOnly` | `read-only` | Safe tools only; everything else denied. |
 

--- a/docs/concepts/permission-model.md
+++ b/docs/concepts/permission-model.md
@@ -27,15 +27,26 @@ For the Claude-Code-compatible rule syntax see
 | `ModeNormal` | `normal` | Safe tools auto-allow; everything else prompts. |
 | `ModeAutoAccept` | `accept edits` | Edit/Write auto-allow; other gated tools prompt. |
 | `ModeAutoPilot` | `autopilot` | Edits auto-allow; every other gated call becomes a **reviewable** prompt the judge may answer. |
-| `ModeBypassPermissions` | `bypass permissions` | Allow everything except deny rules and the circuit breaker. |
+| `ModeBypassPermissions` | `yolo` | Allow everything except deny rules and the circuit breaker. Shown in the status bar as **YOLO mode**. |
 | `ModeDontAsk` | `don't ask` | Coerce `ask` → `deny`; never prompt. |
 | `ModeReadOnly` | `read-only` | Safe tools only; everything else denied. |
 
 The first four make up the user-facing cycle: `cycleModes` steps through
-normal / accept-edits / autopilot, and `cycleModesWithBypass` adds bypass
-when it is explicitly enabled. `ModeDontAsk` and `ModeReadOnly` are
-entered programmatically (headless runs, the subagent explore mode), not
-by cycling.
+normal / accept-edits / autopilot, and `cycleModesWithBypass` adds YOLO
+mode. `ModeDontAsk` and `ModeReadOnly` are entered programmatically
+(headless runs, the subagent explore mode), not by cycling.
+
+Which of the two cycles applies is the `allowBypass` user setting, toggled
+from `/config › permissions`. It is opt-out: unset means YOLO mode is in
+the cycle. Locking it removes that step, downgrades a `bypassPermissions`
+defaultMode to normal at startup, and drops a session already running in
+YOLO mode back to normal.
+
+That gate covers the foreground cycle only. `allowBypass` is read in two
+places — `OperationMode.NextWithBypass` and `env.ApplyDefaultPermissionMode`
+— and the subagent path (`subagent.NormalizePermissionMode`) is not one of
+them, so an agent declaring `mode: bypassPermissions` runs unrestricted
+even while the gate is locked.
 
 ## Decision Pipeline
 

--- a/docs/guides/autopilot.md
+++ b/docs/guides/autopilot.md
@@ -11,7 +11,7 @@ tool calls, answering a command's interactive prompts, answering
 input suggestions and gray-zone permission judging are on by default.
 
 Enter Autopilot mode with `shift+tab` (cycle until the amber
-`⏵⏵ autopilot on`), and configure it with the `/autopilot` panel. A resumed
+`⏵⏵ autopilot`), and configure it with the `/autopilot` panel. A resumed
 session (`san -r <id>`) comes back in the mode it was saved in. If you just want
 to see it drive, [`/goal`](#goal) is the shortest path in — it is one preset of
 everything below.

--- a/docs/guides/autopilot.zh.md
+++ b/docs/guides/autopilot.zh.md
@@ -8,7 +8,7 @@ Autopilot 是 San 的自动驾驶系统,旨在最大限度减少人工介入:由
 工具调用、回答命令的交互问询、回答 `AskUserQuestion`,以及在回合结束后朝
 mission 继续推进。默认开启自动输入提示和灰区权限判定。
 
-用 `shift+tab` 切换到 Autopilot 模式(循环到琥珀色的 `⏵⏵ autopilot on`),
+用 `shift+tab` 切换到 Autopilot 模式(循环到琥珀色的 `⏵⏵ autopilot`),
 用 `/autopilot` 面板配置。恢复会话(`san -r <id>`)会回到保存时所在的模式。
 只想先看它跑起来的话,[`/goal`](#goal) 是最短的入口 —— 它就是下面这一整套的
 一个预设。

--- a/internal/app/conv/status_bar.go
+++ b/internal/app/conv/status_bar.go
@@ -210,8 +210,6 @@ type OperationModeParams struct {
 	Compressions      int  // session compact count, drives the "compacted ×N" badge
 	ShowContextBar    bool // render the visual [██████░░░░] 71% bar (opt-in)
 	Width             int
-	ThinkingEffort    string
-	ShowThinking      bool
 	ReviewApprovals   int  // auto-review approvals this session, shown next to the mode
 	ReviewEscalations int  // auto-review escalations to the user this session
 	AutopilotThinking bool // the copilot is mid-decision — show "thinking…" on the mode indicator
@@ -219,19 +217,7 @@ type OperationModeParams struct {
 
 // RenderModeStatus renders the combined mode status line.
 func RenderModeStatus(params OperationModeParams) string {
-	var leftParts []string
-
-	if modeStatus := RenderOperationModeIndicator(params.Mode, params.ReviewApprovals, params.ReviewEscalations, params.AutopilotThinking); modeStatus != "" {
-		leftParts = append(leftParts, modeStatus)
-	}
-
-	if params.ShowThinking {
-		if thinkingStatus := RenderThinkingIndicator(params.ThinkingEffort); thinkingStatus != "" {
-			leftParts = append(leftParts, thinkingStatus)
-		}
-	}
-
-	left := strings.Join(leftParts, "  ")
+	left := RenderOperationModeIndicator(params.Mode, params.ReviewApprovals, params.ReviewEscalations, params.AutopilotThinking)
 
 	right := renderStatusCluster(params)
 	if right == "" || params.Width <= 0 {
@@ -305,7 +291,7 @@ func compactStatusHint(percent float64) string {
 	}
 }
 
-// RenderOperationModeIndicator returns the mode status indicator for auto-accept, auto-review, or bypass mode.
+// RenderOperationModeIndicator returns the mode status indicator for auto-accept, auto-review, or YOLO mode.
 func RenderOperationModeIndicator(mode setting.OperationMode, reviewApprovals, reviewEscalations int, autopilotThinking bool) string {
 	var icon, label string
 	var clr kit.AdaptiveColor
@@ -313,16 +299,16 @@ func RenderOperationModeIndicator(mode setting.OperationMode, reviewApprovals, r
 	switch mode {
 	case setting.ModeAutoAccept:
 		icon = "⏵⏵"
-		label = " accept edits on"
+		label = " accept edits"
 		clr = kit.CurrentTheme.Success
 	case setting.ModeAutoPilot:
 		icon = "⏵⏵"
-		label = " autopilot on"
+		label = " autopilot"
 		clr = kit.CurrentTheme.Warning
 	case setting.ModeBypassPermissions:
 		icon = "⏵⏵"
-		label = " bypass permissions on"
-		clr = kit.CurrentTheme.Error
+		label = " YOLO"
+		clr = kit.CurrentTheme.Yolo
 	default:
 		return ""
 	}
@@ -346,11 +332,13 @@ func RenderOperationModeIndicator(mode setting.OperationMode, reviewApprovals, r
 	return "  " + style.Render(icon+label) + hint
 }
 
-func RenderThinkingIndicator(effort string) string {
+// ModelStatusLabel composes the status line's model segment: the model name
+// with its thinking effort in parentheses, e.g. "Opus 5 (high)". Effort is a
+// property of the model, so it rides along with the name instead of claiming
+// its own segment — one shape for every provider.
+func ModelStatusLabel(modelName, effort string) string {
 	if effort == "" || effort == "off" || effort == "none" {
-		return ""
+		return modelName
 	}
-	style := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted)
-	hint := lipgloss.NewStyle().Foreground(kit.CurrentTheme.Muted).Render(" (ctrl+t to cycle)")
-	return "  " + style.Render("✦ "+effort) + hint
+	return modelName + " (" + effort + ")"
 }

--- a/internal/app/conv/status_bar_test.go
+++ b/internal/app/conv/status_bar_test.go
@@ -283,7 +283,6 @@ func TestModelStatusLabel(t *testing.T) {
 		want   string
 	}{
 		{"effort appended", "Opus 5", "high", "Opus 5 (high)"},
-		{"non-openai model too", "DeepSeek V4 Pro", "high", "DeepSeek V4 Pro (high)"},
 		{"empty effort", "Opus 5", "", "Opus 5"},
 		{"off suppressed", "Opus 5", "off", "Opus 5"},
 		{"none suppressed", "Opus 5", "none", "Opus 5"},

--- a/internal/app/conv/status_bar_test.go
+++ b/internal/app/conv/status_bar_test.go
@@ -240,7 +240,7 @@ func TestRenderOperationModeIndicator_AutoPilotCounts(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			out := stripANSI(RenderOperationModeIndicator(setting.ModeAutoPilot, c.approvals, c.escalations, false))
-			if !strings.Contains(out, "autopilot on") {
+			if !strings.Contains(out, "autopilot") {
 				t.Fatalf("missing base label: %q", out)
 			}
 			if got := strings.Contains(out, "approved"); got != c.wantApprove {
@@ -263,12 +263,36 @@ func TestRenderOperationModeIndicator_CountsOnlyInAutoPilot(t *testing.T) {
 
 func TestRenderOperationModeIndicator_Thinking(t *testing.T) {
 	// While the copilot decides, the indicator shows "thinking…" and drops the
-	// "on"/counts so the transient state lives here, not in a transcript line.
+	// counts so the transient state lives here, not in a transcript line.
 	out := stripANSI(RenderOperationModeIndicator(setting.ModeAutoPilot, 3, 1, true))
 	if !strings.Contains(out, "thinking…") {
 		t.Fatalf("missing thinking label: %q", out)
 	}
 	if strings.Contains(out, "approved") || strings.Contains(out, "escalated") {
 		t.Errorf("thinking must suppress the counts: %q", out)
+	}
+}
+
+func TestModelStatusLabel(t *testing.T) {
+	// Effort rides in the model segment for every provider — the OpenAI-only
+	// special case this replaced is gone.
+	cases := []struct {
+		name   string
+		model  string
+		effort string
+		want   string
+	}{
+		{"effort appended", "Opus 5", "high", "Opus 5 (high)"},
+		{"non-openai model too", "DeepSeek V4 Pro", "high", "DeepSeek V4 Pro (high)"},
+		{"empty effort", "Opus 5", "", "Opus 5"},
+		{"off suppressed", "Opus 5", "off", "Opus 5"},
+		{"none suppressed", "Opus 5", "none", "Opus 5"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ModelStatusLabel(c.model, c.effort); got != c.want {
+				t.Errorf("ModelStatusLabel(%q, %q) = %q, want %q", c.model, c.effort, got, c.want)
+			}
+		})
 	}
 }

--- a/internal/app/input/config_appearance.go
+++ b/internal/app/input/config_appearance.go
@@ -164,9 +164,7 @@ func (p *appearancePanel) apply(opt appearanceOption) (tea.Cmd, bool) {
 	return nil, false
 }
 
-func (p *appearancePanel) HintLine() string {
-	return keycap("↑↓") + " navigate  " + keycap("enter") + " apply"
-}
+func (p *appearancePanel) HintLine() string { return radioHintLine() }
 
 func (p *appearancePanel) Render(width, _ int) string {
 	var b strings.Builder
@@ -181,7 +179,7 @@ func (p *appearancePanel) Render(width, _ int) string {
 			b.WriteString("\n\n")
 			prevSection = opt.section
 		}
-		b.WriteString(p.renderOption(i, opt))
+		b.WriteString(renderRadioRow(opt.label, opt.desc, i == p.cursor, p.isCurrent(opt)))
 		b.WriteString("\n")
 	}
 
@@ -200,24 +198,32 @@ func renderAppearanceSection(title string, width int) string {
 	return appearanceSectionStyle.Render(title) + " " + appearanceRuleStyle.Render(strings.Repeat("─", ruleLen))
 }
 
-func (p *appearancePanel) renderOption(i int, opt appearanceOption) string {
+// renderRadioRow renders one selectable row of a /config radio group: the
+// hover caret, the ○/● radio, a label padded to a common column so the
+// descriptions line up, and the "current" tag on the persisted choice.
+// Shared by every panel with a radio group so the tabs cannot drift apart.
+func renderRadioRow(label, desc string, hovered, current bool) string {
 	caret := "  "
-	label := appearanceLabelStyle.Render(opt.label)
-	if i == p.cursor {
+	rendered := appearanceLabelStyle.Render(label)
+	if hovered {
 		caret = appearanceCursorStyle.Render("▸ ")
-		label = appearanceCursorStyle.Render(opt.label)
+		rendered = appearanceCursorStyle.Render(label)
 	}
 
 	radio := appearanceRadioOffStyle.Render("○")
-	current := ""
-	if p.isCurrent(opt) {
+	tag := ""
+	if current {
 		radio = appearanceRadioOnStyle.Render("●")
-		current = "  " + appearanceCurrentStyle.Render("current")
+		tag = "  " + appearanceCurrentStyle.Render("current")
 	}
 
-	// Pad labels to a common column so the descriptions line up.
-	labelCell := label + strings.Repeat(" ", max(8-len(opt.label), 1))
-	return caret + radio + " " + labelCell + appearanceDescStyle.Render(opt.desc) + current
+	labelCell := rendered + strings.Repeat(" ", max(8-lipgloss.Width(label), 1))
+	return caret + radio + " " + labelCell + appearanceDescStyle.Render(desc) + tag
+}
+
+// radioHintLine is the shared bottom hint for a radio-group panel.
+func radioHintLine() string {
+	return keycap("↑↓") + " navigate  " + keycap("enter") + " apply"
 }
 
 // isCurrent reports whether opt matches the persisted value for its group.

--- a/internal/app/input/config_appearance_test.go
+++ b/internal/app/input/config_appearance_test.go
@@ -167,6 +167,26 @@ func TestAppearancePanelContextBarSavesAndEmits(t *testing.T) {
 	}
 }
 
-// /config and /evolve each host a single panel today, so the shell's tab
-// switching is dormant; it reactivates untested-code-free when a second
-// panel is registered (see PanelPopup.HandleKeypress's tab handling).
+// TestConfigSelectorTabSwitchesPanels confirms tab / shift+tab cycle
+// /config's panels (and wrap). The shell's tab switching was dormant while
+// /config hosted a single panel; registering Permissions alongside
+// Appearance puts it back in play.
+func TestConfigSelectorTabSwitchesPanels(t *testing.T) {
+	c := NewConfigSelector(nil)
+	c.Enter(120, 40)
+	if got := c.ActivePanel().Title(); got != "appearance" {
+		t.Fatalf("default panel = %q, want appearance", got)
+	}
+	c.HandleKeypress(tea.KeyPressMsg{Code: tea.KeyTab})
+	if got := c.ActivePanel().Title(); got != "permissions" {
+		t.Fatalf("after tab = %q, want permissions", got)
+	}
+	c.HandleKeypress(tea.KeyPressMsg{Code: tea.KeyTab}) // wrap
+	if got := c.ActivePanel().Title(); got != "appearance" {
+		t.Fatalf("after tab wrap = %q, want appearance", got)
+	}
+	c.HandleKeypress(tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift}) // wrap back
+	if got := c.ActivePanel().Title(); got != "permissions" {
+		t.Fatalf("after shift+tab wrap = %q, want permissions", got)
+	}
+}

--- a/internal/app/input/config_permissions.go
+++ b/internal/app/input/config_permissions.go
@@ -8,13 +8,11 @@
 // how you take it away without hand-editing settings.json. It persists to
 // the user settings file, matching the appearance panel's user-level scope.
 //
-// Scope, precisely: `allowBypass` is read in exactly two places — the
-// shift+tab cycle (OperationMode.NextWithBypass) and the startup default
-// (env.ApplyDefaultPermissionMode). A subagent that declares
-// `mode: bypassPermissions` resolves through subagent.NormalizePermissionMode,
-// which never consults it, and still runs unrestricted. So this is a lock on
-// how *you* reach the mode, not a session-wide guarantee that nothing runs
-// unprompted — don't describe it as one.
+// Scope: `allowBypass` is read by OperationMode.NextWithBypass and
+// env.ApplyDefaultPermissionMode, and nowhere else — subagent.
+// NormalizePermissionMode never consults it, so an agent declaring
+// `mode: bypassPermissions` runs unrestricted with the gate locked. This
+// gates how you reach the mode, not what the session as a whole may do.
 package input
 
 import (
@@ -40,18 +38,17 @@ type yoloOption struct {
 	allowed bool
 }
 
-func yoloOptions() []yoloOption {
-	return []yoloOption{
-		{label: "Allowed", desc: "shift+tab reaches YOLO mode — no permission prompts", allowed: true},
-		{label: "Locked", desc: "shift+tab stops at autopilot", allowed: false},
-	}
+// yoloOptions is the row list, in display order. Allowed comes first so the
+// cursor parks on the default at Enter.
+var yoloOptions = []yoloOption{
+	{label: "Allowed", desc: "shift+tab reaches YOLO mode — no permission prompts", allowed: true},
+	{label: "Locked", desc: "shift+tab stops at autopilot", allowed: false},
 }
 
 type permissionsPanel struct {
 	settings *setting.Settings
 
-	options []yoloOption
-	cursor  int
+	cursor int
 
 	// baseline is the effective value on disk, marked "● current".
 	baseline bool
@@ -68,21 +65,21 @@ func newPermissionsPanel(settings *setting.Settings) *permissionsPanel {
 func (p *permissionsPanel) Title() string { return "permissions" }
 
 func (p *permissionsPanel) Enter() {
-	p.options = yoloOptions()
 	// Unset means allowed — mirror Settings.AllowBypass's opt-out default so a
 	// fresh install shows "Allowed ● current" instead of a wrong "Locked".
 	p.baseline = p.settings == nil || p.settings.AllowBypass()
-	p.cursor = indexOfYolo(p.baseline)
+	p.cursor = 0
+	for i, opt := range yoloOptions {
+		if opt.allowed == p.baseline {
+			p.cursor = i
+			break
+		}
+	}
 	p.saveErr = nil
 }
 
 func (p *permissionsPanel) Dirty() bool {
-	// Enter() populates options; guard so a Dirty() consulted before it (e.g.
-	// a shell that polls every tab for an unsaved marker) cannot panic.
-	if len(p.options) == 0 {
-		return false
-	}
-	return p.options[p.cursor].allowed != p.baseline
+	return yoloOptions[p.cursor].allowed != p.baseline
 }
 
 func (p *permissionsPanel) HandleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
@@ -93,12 +90,12 @@ func (p *permissionsPanel) HandleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 		}
 		p.saveErr = nil
 	case "down", "j":
-		if p.cursor < len(p.options)-1 {
+		if p.cursor < len(yoloOptions)-1 {
 			p.cursor++
 		}
 		p.saveErr = nil
 	case "enter", " ":
-		return p.apply(p.options[p.cursor])
+		return p.apply(yoloOptions[p.cursor])
 	}
 	return nil, false
 }
@@ -115,24 +112,18 @@ func (p *permissionsPanel) apply(opt yoloOption) (tea.Cmd, bool) {
 	return func() tea.Msg { return AllowBypassSavedMsg{Allowed: opt.allowed} }, true
 }
 
-func (p *permissionsPanel) HintLine() string {
-	return keycap("↑↓") + " navigate  " + keycap("enter") + " apply"
-}
+func (p *permissionsPanel) HintLine() string { return radioHintLine() }
 
 func (p *permissionsPanel) Render(width, _ int) string {
 	var b strings.Builder
 
 	b.WriteString(renderAppearanceSection("YOLO MODE", width))
 	b.WriteString("\n\n")
-	for i, opt := range p.options {
-		b.WriteString(p.renderOption(i, opt))
+	for i, opt := range yoloOptions {
+		b.WriteString(renderRadioRow(opt.label, opt.desc, i == p.cursor, opt.allowed == p.baseline))
 		b.WriteString("\n")
 	}
 
-	// Two things the labels above would otherwise overpromise: what survives
-	// the mode (deny rules and the / · ~ circuit breaker do; the confirmation
-	// tiers don't), and how far "Locked" reaches — it gates the shift+tab
-	// cycle, not a subagent that declares bypassPermissions for itself.
 	b.WriteString("\n")
 	b.WriteString(appearanceDescStyle.Render(
 		"Deny rules and the / · ~ circuit breaker still hold. Other confirmations do not."))
@@ -147,33 +138,4 @@ func (p *permissionsPanel) Render(width, _ int) string {
 		b.WriteString("\n")
 	}
 	return b.String()
-}
-
-func (p *permissionsPanel) renderOption(i int, opt yoloOption) string {
-	caret := "  "
-	label := appearanceLabelStyle.Render(opt.label)
-	if i == p.cursor {
-		caret = appearanceCursorStyle.Render("▸ ")
-		label = appearanceCursorStyle.Render(opt.label)
-	}
-
-	radio := appearanceRadioOffStyle.Render("○")
-	current := ""
-	if opt.allowed == p.baseline {
-		radio = appearanceRadioOnStyle.Render("●")
-		current = "  " + appearanceCurrentStyle.Render("current")
-	}
-
-	labelCell := label + strings.Repeat(" ", max(8-len(opt.label), 1))
-	return caret + radio + " " + labelCell + appearanceDescStyle.Render(opt.desc) + current
-}
-
-// indexOfYolo returns the row index for an effective value.
-func indexOfYolo(allowed bool) int {
-	for i, opt := range yoloOptions() {
-		if opt.allowed == allowed {
-			return i
-		}
-	}
-	return 0
 }

--- a/internal/app/input/config_permissions.go
+++ b/internal/app/input/config_permissions.go
@@ -1,0 +1,179 @@
+// /config Permissions panel: one radio group gating YOLO mode.
+//
+//   - YOLO MODE — allowed / locked. Allowed (the default) puts the mode in
+//     the shift+tab cycle, one step past autopilot; locked removes it and
+//     downgrades a "bypassPermissions" defaultMode to normal at startup.
+//
+// The setting is opt-out (`allowBypass`, nil = allowed), so this panel is
+// how you take it away without hand-editing settings.json. It persists to
+// the user settings file, matching the appearance panel's user-level scope.
+//
+// Scope, precisely: `allowBypass` is read in exactly two places — the
+// shift+tab cycle (OperationMode.NextWithBypass) and the startup default
+// (env.ApplyDefaultPermissionMode). A subagent that declares
+// `mode: bypassPermissions` resolves through subagent.NormalizePermissionMode,
+// which never consults it, and still runs unrestricted. So this is a lock on
+// how *you* reach the mode, not a session-wide guarantee that nothing runs
+// unprompted — don't describe it as one.
+package input
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/genai-io/san/internal/setting"
+)
+
+// AllowBypassSavedMsg is emitted after the permissions panel persists the
+// YOLO-mode gate so the app can refresh its settings handle, drop a session
+// that is already in YOLO mode when the gate closes, and show a
+// confirmation. The value is already written to disk by the time this fires.
+type AllowBypassSavedMsg struct {
+	Allowed bool
+}
+
+// yoloOption is one selectable row; allowed carries the value it applies.
+type yoloOption struct {
+	label   string
+	desc    string
+	allowed bool
+}
+
+func yoloOptions() []yoloOption {
+	return []yoloOption{
+		{label: "Allowed", desc: "shift+tab reaches YOLO mode — no permission prompts", allowed: true},
+		{label: "Locked", desc: "shift+tab stops at autopilot", allowed: false},
+	}
+}
+
+type permissionsPanel struct {
+	settings *setting.Settings
+
+	options []yoloOption
+	cursor  int
+
+	// baseline is the effective value on disk, marked "● current".
+	baseline bool
+
+	// saveErr holds the last failed persist so Render can surface it inline
+	// instead of silently swallowing it. Cleared on navigation / re-entry.
+	saveErr error
+}
+
+func newPermissionsPanel(settings *setting.Settings) *permissionsPanel {
+	return &permissionsPanel{settings: settings}
+}
+
+func (p *permissionsPanel) Title() string { return "permissions" }
+
+func (p *permissionsPanel) Enter() {
+	p.options = yoloOptions()
+	// Unset means allowed — mirror Settings.AllowBypass's opt-out default so a
+	// fresh install shows "Allowed ● current" instead of a wrong "Locked".
+	p.baseline = p.settings == nil || p.settings.AllowBypass()
+	p.cursor = indexOfYolo(p.baseline)
+	p.saveErr = nil
+}
+
+func (p *permissionsPanel) Dirty() bool {
+	// Enter() populates options; guard so a Dirty() consulted before it (e.g.
+	// a shell that polls every tab for an unsaved marker) cannot panic.
+	if len(p.options) == 0 {
+		return false
+	}
+	return p.options[p.cursor].allowed != p.baseline
+}
+
+func (p *permissionsPanel) HandleKey(msg tea.KeyMsg) (tea.Cmd, bool) {
+	switch msg.String() {
+	case "up", "k":
+		if p.cursor > 0 {
+			p.cursor--
+		}
+		p.saveErr = nil
+	case "down", "j":
+		if p.cursor < len(p.options)-1 {
+			p.cursor++
+		}
+		p.saveErr = nil
+	case "enter", " ":
+		return p.apply(p.options[p.cursor])
+	}
+	return nil, false
+}
+
+// apply persists the hovered choice, advances the baseline, and returns the
+// confirmation command. On failure it sets saveErr, keeps the popup open
+// (done=false), and leaves the baseline untouched.
+func (p *permissionsPanel) apply(opt yoloOption) (tea.Cmd, bool) {
+	if err := setting.SaveAllowBypass(opt.allowed); err != nil {
+		p.saveErr = err
+		return nil, false
+	}
+	p.baseline = opt.allowed
+	return func() tea.Msg { return AllowBypassSavedMsg{Allowed: opt.allowed} }, true
+}
+
+func (p *permissionsPanel) HintLine() string {
+	return keycap("↑↓") + " navigate  " + keycap("enter") + " apply"
+}
+
+func (p *permissionsPanel) Render(width, _ int) string {
+	var b strings.Builder
+
+	b.WriteString(renderAppearanceSection("YOLO MODE", width))
+	b.WriteString("\n\n")
+	for i, opt := range p.options {
+		b.WriteString(p.renderOption(i, opt))
+		b.WriteString("\n")
+	}
+
+	// Two things the labels above would otherwise overpromise: what survives
+	// the mode (deny rules and the / · ~ circuit breaker do; the confirmation
+	// tiers don't), and how far "Locked" reaches — it gates the shift+tab
+	// cycle, not a subagent that declares bypassPermissions for itself.
+	b.WriteString("\n")
+	b.WriteString(appearanceDescStyle.Render(
+		"Deny rules and the / · ~ circuit breaker still hold. Other confirmations do not."))
+	b.WriteString("\n")
+	b.WriteString(appearanceDescStyle.Render(
+		"Locking gates the shift+tab cycle only — subagents set to bypass are unaffected."))
+	b.WriteString("\n")
+
+	if p.saveErr != nil {
+		b.WriteString("\n")
+		b.WriteString(appearanceErrorStyle.Render("⚠ couldn't save: " + p.saveErr.Error()))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func (p *permissionsPanel) renderOption(i int, opt yoloOption) string {
+	caret := "  "
+	label := appearanceLabelStyle.Render(opt.label)
+	if i == p.cursor {
+		caret = appearanceCursorStyle.Render("▸ ")
+		label = appearanceCursorStyle.Render(opt.label)
+	}
+
+	radio := appearanceRadioOffStyle.Render("○")
+	current := ""
+	if opt.allowed == p.baseline {
+		radio = appearanceRadioOnStyle.Render("●")
+		current = "  " + appearanceCurrentStyle.Render("current")
+	}
+
+	labelCell := label + strings.Repeat(" ", max(8-len(opt.label), 1))
+	return caret + radio + " " + labelCell + appearanceDescStyle.Render(opt.desc) + current
+}
+
+// indexOfYolo returns the row index for an effective value.
+func indexOfYolo(allowed bool) int {
+	for i, opt := range yoloOptions() {
+		if opt.allowed == allowed {
+			return i
+		}
+	}
+	return 0
+}

--- a/internal/app/input/config_permissions_test.go
+++ b/internal/app/input/config_permissions_test.go
@@ -1,0 +1,149 @@
+package input
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// TestPermissionsPanelDefaultsAllowed confirms an unset gate reads as open —
+// allowBypass is opt-out, so the cursor parks on "Allowed" and stays clean
+// until it moves.
+func TestPermissionsPanelDefaultsAllowed(t *testing.T) {
+	p := newPermissionsPanel(nil)
+	p.Enter()
+
+	if !p.baseline {
+		t.Fatalf("YOLO mode should default allowed (allowBypass is opt-out)")
+	}
+	if p.cursor != indexOfYolo(true) {
+		t.Fatalf("cursor = %d, want the Allowed row (%d)", p.cursor, indexOfYolo(true))
+	}
+	if p.Dirty() {
+		t.Fatalf("fresh panel parked on the effective value should not be dirty")
+	}
+	p.HandleKey(tea.KeyPressMsg{Code: tea.KeyDown}) // Allowed → Locked
+	if !p.Dirty() {
+		t.Fatalf("after moving off the baseline the panel should be dirty")
+	}
+}
+
+// TestPermissionsPanelLockPersistsExplicitFalse is the load-bearing case for
+// an opt-out setting: locking must write allowBypass=false, not drop the
+// field. A dropped field means "unset", which reads back as allowed — the
+// user would lock the gate and find it open again next launch.
+func TestPermissionsPanelLockPersistsExplicitFalse(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	p := newPermissionsPanel(nil)
+	p.Enter()
+	p.HandleKey(tea.KeyPressMsg{Code: tea.KeyDown}) // Allowed → Locked
+
+	cmd, done := p.HandleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !done {
+		t.Fatalf("enter should dismiss the popup (done=true)")
+	}
+	if p.baseline {
+		t.Fatalf("baseline should be false after locking")
+	}
+	if p.saveErr != nil {
+		t.Fatalf("unexpected saveErr: %v", p.saveErr)
+	}
+	msg, ok := cmd().(AllowBypassSavedMsg)
+	if !ok || msg.Allowed {
+		t.Fatalf("expected AllowBypassSavedMsg{Allowed:false}, got %#v", cmd())
+	}
+
+	data := readPersistedAllowBypass(t, home)
+	if data == nil {
+		t.Fatalf("allowBypass should persist as an explicit false, got null")
+	}
+	if *data {
+		t.Fatalf("persisted allowBypass = true, want false")
+	}
+}
+
+// TestPermissionsPanelReallowPersistsTrue confirms the switch works in both
+// directions: re-allowing after a lock writes true rather than leaving the
+// explicit false behind.
+func TestPermissionsPanelReallowPersistsTrue(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	p := newPermissionsPanel(nil)
+	p.Enter()
+	p.HandleKey(tea.KeyPressMsg{Code: tea.KeyDown}) // Allowed → Locked
+	p.HandleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	p.HandleKey(tea.KeyPressMsg{Code: tea.KeyUp}) // Locked → Allowed
+	cmd, done := p.HandleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !done {
+		t.Fatalf("enter should dismiss the popup (done=true)")
+	}
+	if msg, ok := cmd().(AllowBypassSavedMsg); !ok || !msg.Allowed {
+		t.Fatalf("expected AllowBypassSavedMsg{Allowed:true}, got %#v", cmd())
+	}
+
+	data := readPersistedAllowBypass(t, home)
+	if data == nil || !*data {
+		t.Fatalf("persisted allowBypass = %v, want true", data)
+	}
+}
+
+// TestPermissionsPanelSaveFailureSurfacesError confirms a failed persist keeps
+// the popup open, leaves the baseline untouched, and shows the error inline.
+func TestPermissionsPanelSaveFailureSurfacesError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	// Block the write: a regular file where the .san dir must be makes the
+	// loader's MkdirAll fail.
+	if err := os.WriteFile(filepath.Join(home, ".san"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := newPermissionsPanel(nil)
+	p.Enter()
+	p.HandleKey(tea.KeyPressMsg{Code: tea.KeyDown}) // Allowed → Locked
+
+	cmd, done := p.HandleKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if done {
+		t.Fatalf("a failed save should keep the popup open (done=false)")
+	}
+	if cmd != nil {
+		t.Fatalf("a failed save should not emit AllowBypassSavedMsg, got %#v", cmd())
+	}
+	if p.saveErr == nil {
+		t.Fatalf("a failed save should set saveErr")
+	}
+	if !p.baseline {
+		t.Fatalf("baseline should be untouched on failure")
+	}
+	if out := p.Render(80, 24); !strings.Contains(out, "couldn't save") {
+		t.Fatalf("Render should surface the save error, got:\n%s", out)
+	}
+}
+
+// readPersistedAllowBypass reads back the allowBypass field from the user
+// settings file the panel writes to. A nil return means the field is absent.
+func readPersistedAllowBypass(t *testing.T, home string) *bool {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(home, ".san", "settings.json"))
+	if err != nil {
+		t.Fatalf("settings file not written: %v", err)
+	}
+	var data struct {
+		AllowBypass *bool `json:"allowBypass"`
+	}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		t.Fatalf("settings file not valid JSON: %v\n%s", err, raw)
+	}
+	return data.AllowBypass
+}

--- a/internal/app/input/config_permissions_test.go
+++ b/internal/app/input/config_permissions_test.go
@@ -20,8 +20,8 @@ func TestPermissionsPanelDefaultsAllowed(t *testing.T) {
 	if !p.baseline {
 		t.Fatalf("YOLO mode should default allowed (allowBypass is opt-out)")
 	}
-	if p.cursor != indexOfYolo(true) {
-		t.Fatalf("cursor = %d, want the Allowed row (%d)", p.cursor, indexOfYolo(true))
+	if got := yoloOptions[p.cursor]; !got.allowed {
+		t.Fatalf("cursor should park on the Allowed row, got %q", got.label)
 	}
 	if p.Dirty() {
 		t.Fatalf("fresh panel parked on the effective value should not be dirty")
@@ -37,9 +37,7 @@ func TestPermissionsPanelDefaultsAllowed(t *testing.T) {
 // field. A dropped field means "unset", which reads back as allowed — the
 // user would lock the gate and find it open again next launch.
 func TestPermissionsPanelLockPersistsExplicitFalse(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
+	home := tempHome(t)
 
 	p := newPermissionsPanel(nil)
 	p.Enter()
@@ -73,9 +71,7 @@ func TestPermissionsPanelLockPersistsExplicitFalse(t *testing.T) {
 // directions: re-allowing after a lock writes true rather than leaving the
 // explicit false behind.
 func TestPermissionsPanelReallowPersistsTrue(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
+	home := tempHome(t)
 
 	p := newPermissionsPanel(nil)
 	p.Enter()
@@ -100,9 +96,7 @@ func TestPermissionsPanelReallowPersistsTrue(t *testing.T) {
 // TestPermissionsPanelSaveFailureSurfacesError confirms a failed persist keeps
 // the popup open, leaves the baseline untouched, and shows the error inline.
 func TestPermissionsPanelSaveFailureSurfacesError(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
+	home := tempHome(t)
 	// Block the write: a regular file where the .san dir must be makes the
 	// loader's MkdirAll fail.
 	if err := os.WriteFile(filepath.Join(home, ".san"), []byte("x"), 0o644); err != nil {
@@ -129,6 +123,15 @@ func TestPermissionsPanelSaveFailureSurfacesError(t *testing.T) {
 	if out := p.Render(80, 24); !strings.Contains(out, "couldn't save") {
 		t.Fatalf("Render should surface the save error, got:\n%s", out)
 	}
+}
+
+// tempHome points the settings loader at a throwaway home directory.
+func tempHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	return home
 }
 
 // readPersistedAllowBypass reads back the allowBypass field from the user

--- a/internal/app/input/panel_popup.go
+++ b/internal/app/input/panel_popup.go
@@ -4,7 +4,7 @@
 // panel's body + hint. Each sub-panel implements Panel and owns its body.
 //
 // Two popups are built on this shell today:
-//   - /config  → one Appearance panel (Provider / Permissions planned).
+//   - /config  → Appearance + Permissions panels (Provider planned).
 //   - /evolve  → one self-learning panel covering both arms (skills + memory).
 //
 // To add a panel to either, implement Panel and append it in the popup's
@@ -79,13 +79,15 @@ func newPanelPopup(glyph, title, tagline string, panels ...Panel) PanelPopup {
 	return PanelPopup{glyph: glyph, title: title, tagline: tagline, panels: panels}
 }
 
-// NewConfigSelector builds the /config popup: Appearance today, with Provider
-// / Permissions planned as sibling panels.
+// NewConfigSelector builds the /config popup: Appearance and Permissions,
+// with Provider planned as a sibling panel.
 func NewConfigSelector(settings *setting.Settings) PanelPopup {
-	return newPanelPopup("⚙", "Config", "appearance & settings", newAppearancePanel(settings))
+	return newPanelPopup("⚙", "Config", "appearance & settings",
+		newAppearancePanel(settings), newPermissionsPanel(settings))
 }
 
-// Enter activates the popup with the first panel focused.
+// Enter activates the popup, re-focusing whichever panel was last open (the
+// index survives between openings, so /config reopens where you left it).
 func (c *PanelPopup) Enter(width, height int) {
 	c.width = width
 	c.height = height

--- a/internal/app/input/slash_command.go
+++ b/internal/app/input/slash_command.go
@@ -355,8 +355,8 @@ func (c *SlashCommandController) handleResumeCommand(_ context.Context, _ string
 	return "", nil, nil
 }
 
-// handleConfigCommand opens the /config popup (Appearance today; Provider /
-// Permissions are planned as sibling panels). Self-learning has moved out to
+// handleConfigCommand opens the /config popup (Appearance and Permissions;
+// Provider is planned as a sibling panel). Self-learning has moved out to
 // its own /evolve popup.
 func (c *SlashCommandController) handleConfigCommand(_ context.Context, _ string) (string, tea.Cmd, error) {
 	c.env.Input.Config.Enter(c.env.Width, c.env.Height)

--- a/internal/app/kit/theme.go
+++ b/internal/app/kit/theme.go
@@ -55,6 +55,11 @@ type Theme struct {
 	SuccessBgStrong AdaptiveColor
 	ErrorBgStrong   AdaptiveColor
 
+	// Yolo tints the unrestricted-mode indicator. It is deliberately not
+	// Error: YOLO mode is a choice the user made, not something that went
+	// wrong, and violet keeps red meaning "failure".
+	Yolo AdaptiveColor
+
 	Border     AdaptiveColor
 	Background AdaptiveColor
 }
@@ -81,6 +86,8 @@ var CurrentTheme = Theme{
 
 	SuccessBgStrong: AdaptiveColor{Dark: "#2F5D3E", Light: "#A7F3D0"},
 	ErrorBgStrong:   AdaptiveColor{Dark: "#5E2A2A", Light: "#FCB5B5"},
+
+	Yolo: AdaptiveColor{Dark: "#C4B5FD", Light: "#6D28D9"},
 
 	Border:     AdaptiveColor{Dark: "#52525B", Light: "#D4D4D8"},
 	Background: AdaptiveColor{Dark: "#18181B", Light: "#FAFAFA"},

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -282,9 +282,14 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.applyOperationMode()
 			m.persistOperationMode()
 		}
+		// Report what is in force, not what was written. Either direction can
+		// be outranked by the project level, and saying "allowed" when
+		// shift+tab still stops at autopilot is the same lie as the reverse.
 		switch {
-		case msg.Allowed:
+		case msg.Allowed && allowed:
 			m.conv.AddNotice("YOLO mode allowed — shift+tab to reach it")
+		case msg.Allowed:
+			m.conv.AddNotice("Allowed for your user, but project settings still lock YOLO mode")
 		case allowed:
 			m.conv.AddNotice("Locked for your user, but project settings still allow YOLO mode")
 		default:

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -23,6 +23,7 @@ import (
 	"github.com/genai-io/san/internal/app/kit"
 	"github.com/genai-io/san/internal/app/trigger"
 	"github.com/genai-io/san/internal/log"
+	"github.com/genai-io/san/internal/setting"
 	"github.com/genai-io/san/internal/todo"
 )
 
@@ -258,6 +259,36 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.conv.AddNotice("Context bar on")
 		} else {
 			m.conv.AddNotice("Context bar off")
+		}
+		return m, nil
+	case input.AllowBypassSavedMsg:
+		if err := m.services.Setting.Reload(m.env.CWD); err != nil {
+			// The in-memory handle still holds the pre-save value, and it is
+			// what cycleOperationMode consults — so a lock that cannot be
+			// re-read has not taken effect. Say so instead of claiming it did.
+			log.Logger().Warn("reload settings after YOLO-mode save failed", zap.Error(err))
+			m.conv.AddNotice("Saved, but couldn't re-read settings — restart for it to take effect")
+			return m, nil
+		}
+		// Locking the gate has to drop a session that is already in YOLO mode.
+		// Otherwise the switch reads "locked" while the running session keeps
+		// skipping prompts until the next restart. Go through the shared tail
+		// so the new mode is persisted too — otherwise lastOperationMode stays
+		// "bypass" and the next launch restores YOLO behind the user's back.
+		if !msg.Allowed && m.env.OperationMode == setting.ModeBypassPermissions {
+			m.env.OperationMode = setting.ModeNormal
+			m.applyOperationMode()
+			m.persistOperationMode()
+		}
+		switch {
+		case msg.Allowed:
+			m.conv.AddNotice("YOLO mode allowed — shift+tab to reach it")
+		case m.services.Setting.AllowBypass():
+			// The panel writes the user-level file; a project-level allowBypass
+			// outranks it. The lock did not stick — don't report success.
+			m.conv.AddNotice("Locked for your user, but project settings still allow YOLO mode")
+		default:
+			m.conv.AddNotice("YOLO mode locked")
 		}
 		return m, nil
 	case input.SkillCycleMsg:

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -270,12 +270,14 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.conv.AddNotice("Saved, but couldn't re-read settings — restart for it to take effect")
 			return m, nil
 		}
-		// Locking the gate has to drop a session that is already in YOLO mode.
-		// Otherwise the switch reads "locked" while the running session keeps
-		// skipping prompts until the next restart. Go through the shared tail
-		// so the new mode is persisted too — otherwise lastOperationMode stays
-		// "bypass" and the next launch restores YOLO behind the user's back.
-		if !msg.Allowed && m.env.OperationMode == setting.ModeBypassPermissions {
+		// Reason about the effective setting, not the payload: the panel writes
+		// the user level, but a project-level allowBypass outranks it. Demoting
+		// on msg.Allowed alone would kick a session out of YOLO mode that
+		// shift+tab can walk straight back into.
+		allowed := m.services.Setting.AllowBypass()
+		if !allowed && m.env.OperationMode == setting.ModeBypassPermissions {
+			// persistOperationMode too, or lastOperationMode stays "bypass" and
+			// the next launch restores YOLO behind the user's back.
 			m.env.OperationMode = setting.ModeNormal
 			m.applyOperationMode()
 			m.persistOperationMode()
@@ -283,9 +285,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch {
 		case msg.Allowed:
 			m.conv.AddNotice("YOLO mode allowed — shift+tab to reach it")
-		case m.services.Setting.AllowBypass():
-			// The panel writes the user-level file; a project-level allowBypass
-			// outranks it. The lock did not stick — don't report success.
+		case allowed:
 			m.conv.AddNotice("Locked for your user, but project settings still allow YOLO mode")
 		default:
 			m.conv.AddNotice("YOLO mode locked")

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -10,7 +10,6 @@ import (
 	"github.com/genai-io/san/internal/app/conv"
 	"github.com/genai-io/san/internal/app/input"
 	"github.com/genai-io/san/internal/app/kit"
-	"github.com/genai-io/san/internal/llm"
 	"github.com/genai-io/san/internal/subagent"
 	"github.com/genai-io/san/internal/todo"
 )
@@ -327,13 +326,7 @@ func (m *model) renderTrackerList() string {
 }
 
 func (m model) renderModeStatus() string {
-	modelName := m.env.GetModelDisplayName()
-	thinkingEffort := m.env.EffectiveThinkingEffort()
-	showThinking := true
-	if m.env.CurrentModel != nil && m.env.CurrentModel.Provider == llm.OpenAI && thinkingEffort != "" {
-		modelName += " (" + thinkingEffort + ")"
-		showThinking = false
-	}
+	modelName := conv.ModelStatusLabel(m.env.GetModelDisplayName(), m.env.EffectiveThinkingEffort())
 	if status := m.services.Hook.CurrentStatusMessage(); status != "" {
 		modelName = status
 	}
@@ -355,8 +348,6 @@ func (m model) renderModeStatus() string {
 		Compressions:      m.env.Compressions,
 		ShowContextBar:    m.env.ShowContextBar,
 		Width:             m.env.Width,
-		ThinkingEffort:    thinkingEffort,
-		ShowThinking:      showThinking,
 		ReviewApprovals:   reviewApprovals,
 		ReviewEscalations: reviewEscalations,
 		AutopilotThinking: m.autopilotDeciding,

--- a/internal/setting/loader.go
+++ b/internal/setting/loader.go
@@ -555,17 +555,11 @@ func SaveContextBar(on bool) error {
 }
 
 // SaveAllowBypass persists whether YOLO mode (bypassPermissions) is reachable
-// to ~/.san/settings.json. Written as an explicit pointer for the same reason
-// as ContextBar: an "off" choice must override an inherited "on" rather than
-// being dropped as a zero value.
+// to ~/.san/settings.json. It replaces the field rather than merging it: the
+// setting is opt-out, so locking the gate means persisting an explicit false,
+// which is exactly the toggle updateSettingsFile exists to make stick.
 func SaveAllowBypass(on bool) error {
-	if err := NewLoader().SaveToUser(&Data{AllowBypass: &on}); err != nil {
-		return err
-	}
-	loadedSettingsMu.Lock()
-	loadedSettings = nil
-	loadedSettingsMu.Unlock()
-	return nil
+	return updateSettingsFile(true, func(d *Data) { d.AllowBypass = &on })
 }
 
 // SavePersonaAt persists the chosen persona name at the given scope: the

--- a/internal/setting/loader.go
+++ b/internal/setting/loader.go
@@ -554,6 +554,20 @@ func SaveContextBar(on bool) error {
 	return nil
 }
 
+// SaveAllowBypass persists whether YOLO mode (bypassPermissions) is reachable
+// to ~/.san/settings.json. Written as an explicit pointer for the same reason
+// as ContextBar: an "off" choice must override an inherited "on" rather than
+// being dropped as a zero value.
+func SaveAllowBypass(on bool) error {
+	if err := NewLoader().SaveToUser(&Data{AllowBypass: &on}); err != nil {
+		return err
+	}
+	loadedSettingsMu.Lock()
+	loadedSettings = nil
+	loadedSettingsMu.Unlock()
+	return nil
+}
+
 // SavePersonaAt persists the chosen persona name at the given scope: the
 // project file (.san/settings.json under cwd) when userLevel is false, or the
 // user file (~/.san/settings.json) when true. An empty name clears the field.

--- a/internal/setting/settings.go
+++ b/internal/setting/settings.go
@@ -583,7 +583,7 @@ type OperationMode int
 const (
 	ModeNormal            OperationMode = iota
 	ModeAutoAccept                      // auto-approve edits/writes
-	ModeBypassPermissions               // allow all except deny rules and the root/home-removal circuit breaker
+	ModeBypassPermissions               // "YOLO mode": allow all except deny rules and the root/home-removal circuit breaker
 	ModeDontAsk                         // convert ask → deny (never prompt)
 	ModeReadOnly                        // safe tools only; everything else denied (subagent explore)
 	ModeAutoPilot                       // auto-approve edits; delegate the rest to the review agent
@@ -602,7 +602,7 @@ func (m OperationMode) String() string {
 	case ModeAutoPilot:
 		return "autopilot"
 	case ModeBypassPermissions:
-		return "bypass permissions"
+		return "yolo"
 	case ModeDontAsk:
 		return "don't ask"
 	case ModeReadOnly:
@@ -636,7 +636,9 @@ func OperationModeFromString(mode string) OperationMode {
 		return ModeAutoAccept
 	case "autoPilot", "auto-pilot", "autopilot", "pilot":
 		return ModeAutoPilot
-	case "bypassPermissions", "bypass-permissions", "bypass":
+	// bypassPermissions is the wire name (Claude Code compatible); yolo is
+	// what the UI calls it, accepted here so hand-written settings match.
+	case "bypassPermissions", "bypass-permissions", "bypass", "yolo":
 		return ModeBypassPermissions
 	case "dontAsk", "dont-ask":
 		return ModeDontAsk

--- a/internal/setting/settings.go
+++ b/internal/setting/settings.go
@@ -602,7 +602,7 @@ func (m OperationMode) String() string {
 	case ModeAutoPilot:
 		return "autopilot"
 	case ModeBypassPermissions:
-		return "yolo"
+		return "YOLO"
 	case ModeDontAsk:
 		return "don't ask"
 	case ModeReadOnly:

--- a/internal/setting/settings.go
+++ b/internal/setting/settings.go
@@ -590,8 +590,9 @@ const (
 )
 
 // allModes lists the modes that the user can cycle through with the mode toggle.
-// BypassPermissions is only reachable when explicitly enabled; DontAsk and
-// ReadOnly are entered programmatically (headless subagents), not via cycling.
+// BypassPermissions is in the cycle unless `allowBypass: false` locks it out;
+// DontAsk and ReadOnly are entered programmatically (headless subagents), not
+// via cycling.
 var cycleModes = []OperationMode{ModeNormal, ModeAutoAccept, ModeAutoPilot}
 var cycleModesWithBypass = []OperationMode{ModeNormal, ModeAutoAccept, ModeAutoPilot, ModeBypassPermissions}
 

--- a/internal/subagent/types.go
+++ b/internal/subagent/types.go
@@ -58,7 +58,7 @@ func NormalizePermissionMode(s string) PermissionMode {
 		return PermissionAcceptEdits
 	case "explore", "readonly", "read-only":
 		return PermissionExplore
-	case "bypass", "bypasspermissions":
+	case "bypass", "bypasspermissions", "yolo":
 		return PermissionBypass
 	case "dontask", "dont-ask":
 		return PermissionDontAsk


### PR DESCRIPTION
## Why

The unrestricted mode was named from the implementation's point of view — "bypass permissions" — and painted with the error color. The name describes what the code skips rather than what the user chose, and red is the status line's word for "something went wrong", not for a mode you deliberately turned on.

## What changed

- **`⏵⏵ bypass permissions on` → `⏵⏵ YOLO`**, in a new violet theme token so red keeps meaning failure.
- **The three mode labels now read as a set.** Renaming one exposed the drift; `on` is gone from all of them. The rest of the status line is already bare noun phrases (`Opus 5 (high)`, `ctx 12k/200k`), the `⏵⏵` glyph already says the mode is live, and the indicator only renders outside default mode — so `on` carried no information.
- **Thinking effort had two shapes for one fact:** OpenAI models appended it to the model name, every other provider got a separate `✦ high` indicator. Everyone now gets the model-name form; the standalone indicator is gone. `Ctrl+T` stays in the README shortcut table.
- **New `/config › permissions` panel** — the Permissions panel the popup shell already anticipated. `allowBypass` is opt-out, so taking YOLO away previously meant hand-editing `settings.json`.
- **Three fixes so the lock means something:** demotion now goes through `persistOperationMode` (otherwise `lastOperationMode` stayed `"bypass"` and the next launch restored YOLO unprompted); a failed settings reload no longer reports success while the in-memory gate stays stale; a project-level `allowBypass` outranking the user-level write is reported honestly instead of as a successful lock.

## Scope of the gate — stated, not fixed

`allowBypass` is read in exactly two places: `OperationMode.NextWithBypass` and `env.ApplyDefaultPermissionMode`. The subagent path never consults it, so an agent declaring `mode: bypassPermissions` runs unrestricted even with the gate locked. This PR states that in the panel body, the file comment and `permission-model.md` rather than changing it — aligning the behavior changes what a subagent's declared mode means, and belongs in its own PR.

## Compatibility

`allowBypass` and `bypassPermissions` are unchanged on disk and on the wire; only the display name moves. `"yolo"` is accepted as an input alias in both parsers.

`go build ./...`, `go test ./...` and `make lint` pass.