### PR TITLE
docs: add Homebrew tap installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ Three properties, and San refuses to trade any one of them for the others.
 
 ## Installation
 
+**Homebrew (macOS / Linux)**
+
+```bash
+brew tap genai-io/san
+brew install san
+```
+
 **macOS / Linux**
 
 ```bash
@@ -72,7 +79,7 @@ curl -fsSL https://raw.githubusercontent.com/genai-io/san/main/install.sh | bash
 irm https://raw.githubusercontent.com/genai-io/san/main/install.ps1 | iex
 ```
 
-Start with `san`. On first launch, choose a model and add its API key when prompted. To update later, run `san update`.
+Start with `san`. On first launch, choose a model and add its API key when prompted. To update later, run `san update` — or `brew upgrade san` if you installed via Homebrew.
 
 <details>
 <summary><b>Other methods</b></summary>

--- a/README.zh.md
+++ b/README.zh.md
@@ -58,6 +58,13 @@ San 是一个开源的终端 Agent 运行时：一个原生 Go 二进制，不�
 
 ## 安装
 
+**Homebrew (macOS / Linux)**
+
+```bash
+brew tap genai-io/san
+brew install san
+```
+
 **macOS / Linux**
 
 ```bash
@@ -70,7 +77,7 @@ curl -fsSL https://raw.githubusercontent.com/genai-io/san/main/install.sh | bash
 irm https://raw.githubusercontent.com/genai-io/san/main/install.ps1 | iex
 ```
 
-升级直接重新执行同样的命令。
+升级直接重新执行同样的命令;通过 Homebrew 安装的用 `brew upgrade san`。
 
 <details>
 <summary><b>其他方式</b></summary>

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -13,6 +13,9 @@ Re-run the same command to upgrade. To uninstall, append `-s uninstall`.
 Alternatives:
 
 ```bash
+# via Homebrew
+brew tap genai-io/san && brew install san
+
 # via Go toolchain
 go install github.com/genai-io/san/cmd/san@latest
 


### PR DESCRIPTION
## Why

`san` installs via curl script / `go install` / build from source — no package-manager path on macOS. This documents the Homebrew option.

## What changed

Docs only (no code changes): README / README.zh / getting-started gain the Homebrew install path:

```bash
brew tap genai-io/san
brew install san
```

and `brew upgrade san` for brew-managed installs (instead of the built-in `san update`, which would overwrite the Cellar binary).

## Where the formula lives

The formula is hosted in the self-contained tap repo **[genai-io/homebrew-san](https://github.com/genai-io/homebrew-san)**, pinned to v1.22.2 with real sha256s. A daily workflow there ([sync-formula.yml](https://github.com/genai-io/homebrew-san/blob/main/.github/workflows/sync-formula.yml)) re-checks the latest `v*` tag on genai-io/san and regenerates the formula with fresh sha256s — `brew upgrade san` picks up a release within a day. No secrets, no cross-repo automation.

## Verification

- `brew tap genai-io/san && brew install san && san version` works end-to-end on arm64 macOS
- `brew audit --strict --new`, `brew test`, `brew livecheck` all pass
- The tap's sync workflow was exercised via `workflow_dispatch` (correctly detects "up to date" and skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)