### PR TITLE
fix(deepseek): correct V4 pricing and default to the API's own thinking effort

### DIFF
--- a/internal/llm/deepseek/catalog.go
+++ b/internal/llm/deepseek/catalog.go
@@ -14,6 +14,10 @@ type modelCatalogEntry struct {
 	pricing pricing
 }
 
+// Prices are USD per million tokens, from
+// https://api-docs.deepseek.com/quick_start/pricing — inputPerMTokens is the
+// cache-miss rate and cacheReadPerMTokens the cache-hit rate. DeepSeek does
+// not bill cache writes separately, so the write rate mirrors the miss rate.
 var catalog = []modelCatalogEntry{
 	{
 		info: llm.ModelInfo{
@@ -23,7 +27,7 @@ var catalog = []modelCatalogEntry{
 			InputTokenLimit:  1_000_000,
 			OutputTokenLimit: 384000,
 		},
-		pricing: pricing{inputPerMTokens: 0.14, outputPerMTokens: 0.28, cacheReadPerMTokens: 0.028, cacheWritePerMTokens: 0.14},
+		pricing: pricing{inputPerMTokens: 0.14, outputPerMTokens: 0.28, cacheReadPerMTokens: 0.0028, cacheWritePerMTokens: 0.14},
 	},
 	{
 		info: llm.ModelInfo{
@@ -33,7 +37,7 @@ var catalog = []modelCatalogEntry{
 			InputTokenLimit:  1_000_000,
 			OutputTokenLimit: 384000,
 		},
-		pricing: pricing{inputPerMTokens: 1.74, outputPerMTokens: 3.48, cacheReadPerMTokens: 0.145, cacheWritePerMTokens: 1.74},
+		pricing: pricing{inputPerMTokens: 0.435, outputPerMTokens: 0.87, cacheReadPerMTokens: 0.003625, cacheWritePerMTokens: 0.435},
 	},
 }
 

--- a/internal/llm/deepseek/client.go
+++ b/internal/llm/deepseek/client.go
@@ -50,11 +50,13 @@ func (c *Client) ThinkingEfforts(model string) []string {
 	return []string{"off", "low", "high", "xhigh", "max"}
 }
 
+// DefaultThinkingEffort mirrors the API's own default: DeepSeek runs thinking
+// unless it is switched off, at effort "high".
 func (c *Client) DefaultThinkingEffort(model string) string {
 	if !supportsThinking(model) {
 		return ""
 	}
-	return "off"
+	return "high"
 }
 
 // Stream sends a completion request and returns a channel of streaming chunks.

--- a/internal/llm/deepseek/client_test.go
+++ b/internal/llm/deepseek/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"math"
 	"net/http"
 	"strings"
 	"testing"
@@ -105,19 +106,36 @@ func TestDeepSeekIsTextOnly(t *testing.T) {
 	}
 }
 
+// Rates come from https://api-docs.deepseek.com/quick_start/pricing; a million
+// tokens of each kind prices one rate per case.
 func TestDeepSeekEstimateCost(t *testing.T) {
-	cost, ok := EstimateCost("deepseek-v4-flash", llm.Usage{
-		InputTokens:  1000000,
-		OutputTokens: 1000000,
-	})
-	if !ok {
-		t.Fatal("expected pricing lookup to succeed")
+	const million = 1000000
+
+	tests := []struct {
+		name  string
+		model string
+		usage llm.Usage
+		want  float64
+	}{
+		{"flash input+output", "deepseek-v4-flash", llm.Usage{InputTokens: million, OutputTokens: million}, 0.42},
+		{"flash cache hit", "deepseek-v4-flash", llm.Usage{CacheReadInputTokens: million}, 0.0028},
+		{"pro input+output", "deepseek-v4-pro", llm.Usage{InputTokens: million, OutputTokens: million}, 1.305},
+		{"pro cache hit", "deepseek-v4-pro", llm.Usage{CacheReadInputTokens: million}, 0.003625},
 	}
-	if cost.Amount < 0.419 || cost.Amount > 0.421 {
-		t.Fatalf("expected ~0.42, got %.6f", cost.Amount)
-	}
-	if cost.Currency != llm.CurrencyUSD {
-		t.Fatalf("expected USD, got %s", cost.Currency)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cost, ok := EstimateCost(tt.model, tt.usage)
+			if !ok {
+				t.Fatal("expected pricing lookup to succeed")
+			}
+			if math.Abs(cost.Amount-tt.want) > 1e-9 {
+				t.Errorf("cost = %.6f, want %.6f", cost.Amount, tt.want)
+			}
+			if cost.Currency != llm.CurrencyUSD {
+				t.Errorf("currency = %s, want USD", cost.Currency)
+			}
+		})
 	}
 }
 
@@ -189,6 +207,18 @@ func TestDeepSeekSupportsThinking(t *testing.T) {
 	for _, model := range tests {
 		if !supportsThinking(model) {
 			t.Errorf("supportsThinking(%q) = false, want true", model)
+		}
+	}
+}
+
+// The API keeps thinking on at effort "high" unless it is switched off, so san
+// leaves models at their strongest documented default rather than opting out.
+func TestDeepSeekDefaultThinkingEffort(t *testing.T) {
+	c := NewClient(openai.NewClient(), "deepseek:test")
+
+	for _, model := range []string{"deepseek-v4-flash", "deepseek-v4-pro"} {
+		if got := c.DefaultThinkingEffort(model); got != "high" {
+			t.Errorf("DefaultThinkingEffort(%q) = %q, want high", model, got)
 		}
 	}
 }


### PR DESCRIPTION
Two DeepSeek defaults were wrong against the published API.

- **Pricing.** V4 Pro was priced at 4x the real rate (1.74/3.48 vs 0.435/0.87 per million tokens), and both models billed cache hits near the cache-miss rate (Pro 0.145 vs 0.003625, Flash 0.028 vs 0.0028). `/cost` overstated DeepSeek spend accordingly. Rates now match [the pricing page](https://api-docs.deepseek.com/quick_start/pricing).
- **Thinking default.** DeepSeek runs thinking by default at effort `high`; san returned `"off"`, which actively sends `thinking:{type:"disabled"}` on every turn. A fresh session now gets what the API advertises.

Cost tests are now a table pinning one rate per case, including the cache-hit rate that regressed.

Not handled here: DeepSeek moves to peak/off-peak billing on 2026-08-16 (off-peak at half rate). The catalog is a single static rate per model, so off-peak turns will read 2x high until that's modelled — worth a follow-up.