### PR TITLE
ci(release-bot): use a PAT for the release PR so CI runs without approval

### DIFF
--- a/.github/scripts/release-bot.py
+++ b/.github/scripts/release-bot.py
@@ -14,9 +14,12 @@ Usage from GitHub Actions workflow:
   python3 .github/scripts/release-bot.py
 
 Environment variables (set by the workflow):
-  GH_TOKEN       — GitHub token with contents:write + pull-requests:write
-  VERSION_BUMP   — "patch" (default) or "minor"
-  DRY_RUN        — "true" to preview without pushing
+  GH_TOKEN          — GitHub token with contents:write + pull-requests:write
+  RELEASE_BOT_TOKEN — optional PAT. When set, the branch push and PR are
+                      performed with it so CI runs on the PR without manual
+                      approval (GITHUB_TOKEN-created PRs are approval-gated)
+  VERSION_BUMP      — "patch" (default) or "minor"
+  DRY_RUN           — "true" to preview without pushing
 """
 
 import json
@@ -37,7 +40,10 @@ def run(cmd, **kwargs):
     """Run a command and return stripped stdout. Exit on failure."""
     result = subprocess.run(cmd, capture_output=True, text=True, **kwargs)
     if result.returncode != 0:
-        print(f"::error:: command failed: {' '.join(cmd)}\n{result.stderr.strip()}")
+        shown = " ".join(cmd)
+        # Never echo credentials embedded in remote URLs to the logs.
+        shown = re.sub(r"(https://[^@\s]*:)[^@\s]*@", r"\1***@", shown)
+        print(f"::error:: command failed: {shown}\n{result.stderr.strip()}")
         sys.exit(result.returncode)
     return result.stdout.strip()
 
@@ -384,10 +390,28 @@ def main():
     print(f"Updated cmd/san/main.go -> version {next_version}")
 
     # 10. Commit, push, create PR
+    # Use a PAT when one is configured: GITHUB_TOKEN pushes never trigger
+    # workflow runs, and PRs created with GITHUB_TOKEN get their CI runs
+    # gated behind manual approval. With a PAT the push and the PR are
+    # treated as user-initiated, so CI runs on the PR head automatically.
+    bot_token = os.environ.get("RELEASE_BOT_TOKEN", "")
+    if bot_token:
+        run([
+            "git", "remote", "set-url", "origin",
+            f"https://x-access-token:{bot_token}@github.com/{REPO}.git",
+        ])
+        os.environ["GH_TOKEN"] = bot_token
+        print("::notice:: Pushing with RELEASE_BOT_TOKEN (PR CI runs without approval)")
+    else:
+        print(
+            "::notice:: No RELEASE_BOT_TOKEN set — using GITHUB_TOKEN "
+            "(PR CI will need manual approval)"
+        )
+
     # Commit as github-actions[bot] — the same identity that pushes the
-    # branch via GITHUB_TOKEN. DCO skips bot-authored commits, and its
-    # noreply email maps to a real account, so no human identity is
-    # involved. -s keeps a Signed-off-by trailer for good measure.
+    # branch. DCO skips bot-authored commits, and its noreply email maps
+    # to a real account, so no human identity is involved. -s keeps a
+    # Signed-off-by trailer for good measure.
     run(["git", "config", "user.name", "github-actions[bot]"])
     run(["git", "config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"])
     run(["git", "checkout", "-b", branch])

--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -11,6 +11,13 @@ name: Release Bot
 #
 # After the PR is merged, pushing the tag triggers
 # .github/workflows/release.yml to build and publish.
+#
+# PRs created with GITHUB_TOKEN have their CI runs gated behind manual
+# approval (and GITHUB_TOKEN pushes never trigger workflows). To have CI
+# run on the release PR without approval, set a RELEASE_BOT_TOKEN secret
+# — a fine-grained PAT with Contents read/write on this repo. The script
+# uses it for the branch push and PR creation, falling back to
+# GITHUB_TOKEN when it is not set.
 
 on:
   schedule:
@@ -48,6 +55,7 @@ jobs:
       - name: Create release PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_BOT_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
           VERSION_BUMP: ${{ inputs.version_bump || 'patch' }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: python3 .github/scripts/release-bot.py


### PR DESCRIPTION
## Problem

Every release PR created by the bot needs a manual "Approve workflows to run" before CI will execute:

- PRs created with `GITHUB_TOKEN` get their `pull_request` workflow runs approval-gated (they land in `action_required`)
- `GITHUB_TOKEN` pushes never trigger workflow runs at all, so CI only ever ran on main *after* the release PR merged

## Changes

- **`release-bot.py`**: when a `RELEASE_BOT_TOKEN` secret is set, use it (via `x-access-token:` remote URL) for the branch push and `gh pr create` — the push and PR are then treated as user-initiated and CI runs on the PR head without approval. Falls back to `GITHUB_TOKEN` when the secret is absent.
- Redact credentials in remote URLs from error output so the PAT never appears in workflow logs.
- **`release-bot.yml`**: pass `RELEASE_BOT_TOKEN` through, with a comment on how to configure it.

## To activate (repo admin)

Create a fine-grained PAT with **Contents: read & write** scoped to genai-io/san (or a classic PAT with `repo` scope), then:

```
gh secret set RELEASE_BOT_TOKEN --repo genai-io/san
```

Note: PRs created with the PAT will be attributed to the PAT owner (e.g. `hchenxa`), who can no longer approve their own PRs — another maintainer's `/lgtm` is still required by the gate.

## Verification

- `python3 -m py_compile` passes
- Credential-redaction regex tested against the real remote URL format

🤖 Generated with [Claude Code](https://claude.com/claude-code)