### PR TITLE
ci(release-bot): run CI on release PRs and request OWNERS review after it passes

### DIFF
--- a/.github/scripts/release-bot.py
+++ b/.github/scripts/release-bot.py
@@ -411,6 +411,21 @@ def main():
     ])
     print(f"\n✅ Release PR created: {result}")
 
+    # Trigger CI directly on the release branch. PRs created with
+    # GITHUB_TOKEN have their pull_request-triggered runs gated behind
+    # manual approval, but workflow_dispatch runs always execute — so the
+    # release PR gets its checks without anyone clicking "Approve
+    # workflows to run". Non-fatal: the PR stays valid without it.
+    trigger = subprocess.run(
+        ["gh", "workflow", "run", "ci.yml", "--repo", REPO, "--ref", branch],
+        capture_output=True,
+        text=True,
+    )
+    if trigger.returncode != 0:
+        print(f"::warning:: could not trigger CI on {branch}: {trigger.stderr.strip()}")
+    else:
+        print(f"🔁 CI triggered on {branch}")
+
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/release-bot.py
+++ b/.github/scripts/release-bot.py
@@ -9,6 +9,9 @@ On each run:
   4. Bumps the version (patch by default)
   5. Rewrites CHANGELOG.md and cmd/san/main.go
   6. Creates (or updates) a release/vX.Y.Z PR against main
+  7. Triggers CI on the release branch via workflow_dispatch (PRs created
+     with GITHUB_TOKEN are approval-gated, workflow_dispatch is not)
+  8. Waits for CI to pass, then requests review from the OWNERS
 
 Usage from GitHub Actions workflow:
   python3 .github/scripts/release-bot.py
@@ -24,6 +27,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 from datetime import datetime, timezone, date, timedelta
 from pathlib import Path
 
@@ -222,6 +226,87 @@ def read_version_from_main_go():
     """Read the current version string from cmd/san/main.go."""
     m = re.search(r'var version = "(.*?)"', Path("cmd/san/main.go").read_text())
     return m.group(1) if m else None
+
+
+def read_owners():
+    """
+    Parse reviewer usernames from the OWNERS file — the YAML `reviewers:`
+    list, falling back to `approvers:`, then plain line-per-username.
+    """
+    try:
+        raw = Path("OWNERS").read_text()
+    except FileNotFoundError:
+        return []
+    for key in ("reviewers", "approvers"):
+        m = re.search(rf"^{key}:\s*$([\s\S]*?)(?=^[a-z]+:\s*$|\Z)", raw, re.MULTILINE)
+        if m:
+            users = re.findall(r"^\s*-\s*(\S+)", m.group(1), re.MULTILINE)
+            if users:
+                return users
+    # Plain text: one username per line, skip empty lines, comments, and keys
+    return [
+        line.strip()
+        for line in raw.splitlines()
+        if line.strip() and not line.strip().startswith("#") and ":" not in line
+    ]
+
+
+def wait_for_ci_and_request_review(pr_number, branch, owners):
+    """
+    Poll the dispatched CI run on the release branch until it finishes.
+    When it passes, request review from the OWNERS list so maintainers are
+    notified to review the release PR.
+    """
+    deadline = time.time() + 30 * 60  # give CI up to 30 minutes
+    state = None
+    while time.time() < deadline:
+        query = subprocess.run(
+            [
+                "gh", "run", "list", "--repo", REPO, "--workflow", "ci.yml",
+                "--branch", branch,
+                "--json", "databaseId,event,status,conclusion",
+                "--limit", "5",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if query.returncode == 0 and query.stdout.strip():
+            runs = json.loads(query.stdout)
+            # Only the run we dispatched — pull_request runs on this branch
+            # may exist and are approval-gated, so ignore them.
+            mine = [r for r in runs if r.get("event") == "workflow_dispatch"]
+            if mine:
+                state = mine[0]
+                if state["status"] == "completed":
+                    break
+        time.sleep(30)
+
+    if not state or state["status"] != "completed":
+        print(f"::warning:: Timed out waiting for CI on {branch} — review not requested")
+        return
+    if state["conclusion"] != "success":
+        print(
+            f"::warning:: CI on {branch} concluded {state['conclusion']} "
+            f"— review not requested"
+        )
+        return
+    if not owners:
+        print("::warning:: OWNERS list is empty — no reviewers to request")
+        return
+
+    reviewers = ",".join(owners)
+    edit = subprocess.run(
+        ["gh", "pr", "edit", str(pr_number), "--repo", REPO, "--add-reviewer", reviewers],
+        capture_output=True,
+        text=True,
+    )
+    if edit.returncode != 0:
+        print(
+            f"::warning:: could not request review on PR #{pr_number}: "
+            f"{edit.stderr.strip()}"
+        )
+    else:
+        print(f"👀 CI passed — requested review from OWNERS: {reviewers}")
 
 
 def main():
@@ -425,6 +510,8 @@ def main():
         print(f"::warning:: could not trigger CI on {branch}: {trigger.stderr.strip()}")
     else:
         print(f"🔁 CI triggered on {branch}")
+        # Once CI passes, notify the OWNERS so the release PR gets reviewed.
+        wait_for_ci_and_request_review(result.split("/")[-1], branch, read_owners())
 
 
 if __name__ == "__main__":

--- a/.github/scripts/release-bot.py
+++ b/.github/scripts/release-bot.py
@@ -11,7 +11,8 @@ On each run:
   6. Creates (or updates) a release/vX.Y.Z PR against main
   7. Triggers CI on the release branch via workflow_dispatch (PRs created
      with GITHUB_TOKEN are approval-gated, workflow_dispatch is not)
-  8. Waits for CI to pass, then requests review from the OWNERS
+  8. Waits for CI to pass, then requests review from REVIEW_REQUESTEE
+     (a single OWNERS member — pinging the whole team is noisy)
 
 Usage from GitHub Actions workflow:
   python3 .github/scripts/release-bot.py
@@ -33,6 +34,10 @@ from pathlib import Path
 
 REPO = "genai-io/san"
 MAIN_BRANCH = "main"
+
+# Only this OWNERS member gets a review request on release PRs — pinging
+# the whole team on every weekly release is noisy.
+REVIEW_REQUESTEE = "yanmxa"
 
 # ── helpers ──────────────────────────────────────────────────────────────
 
@@ -254,8 +259,8 @@ def read_owners():
 def wait_for_ci_and_request_review(pr_number, branch, owners):
     """
     Poll the dispatched CI run on the release branch until it finishes.
-    When it passes, request review from the OWNERS list so maintainers are
-    notified to review the release PR.
+    When it passes, request review from the designated OWNERS member so
+    the release PR gets noticed.
     """
     deadline = time.time() + 30 * 60  # give CI up to 30 minutes
     state = None
@@ -293,10 +298,18 @@ def wait_for_ci_and_request_review(pr_number, branch, owners):
     if not owners:
         print("::warning:: OWNERS list is empty — no reviewers to request")
         return
+    if REVIEW_REQUESTEE not in owners:
+        print(
+            f"::warning:: {REVIEW_REQUESTEE} is not in OWNERS "
+            f"— review not requested"
+        )
+        return
 
-    reviewers = ",".join(owners)
     edit = subprocess.run(
-        ["gh", "pr", "edit", str(pr_number), "--repo", REPO, "--add-reviewer", reviewers],
+        [
+            "gh", "pr", "edit", str(pr_number), "--repo", REPO,
+            "--add-reviewer", REVIEW_REQUESTEE,
+        ],
         capture_output=True,
         text=True,
     )
@@ -306,7 +319,7 @@ def wait_for_ci_and_request_review(pr_number, branch, owners):
             f"{edit.stderr.strip()}"
         )
     else:
-        print(f"👀 CI passed — requested review from OWNERS: {reviewers}")
+        print(f"👀 CI passed — requested review from {REVIEW_REQUESTEE}")
 
 
 def main():

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # The release bot triggers CI on release/vX.Y.Z branches this way:
+  # workflow_dispatch runs always execute, unlike pull_request runs on
+  # GITHUB_TOKEN-created PRs (which are gated behind manual approval).
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

Release PRs created by the bot never ran CI before merge:

- `pull_request` workflow runs on PRs created with `GITHUB_TOKEN` are gated behind manual approval (`action_required`) — the "Approve workflows to run" prompt
- `GITHUB_TOKEN` pushes never trigger workflow runs at all, so `push`-triggered CI is also a dead end
- CI only ran on `main` after the release PR merged, and no one was explicitly asked to review the release

## Solution

`workflow_dispatch` runs **always execute**, even when fired with `GITHUB_TOKEN`. The release bot now:

1. Creates the release PR as before
2. Triggers CI on the release branch via `gh workflow run ci.yml --ref release/vX.Y.Z` — checks appear on the PR automatically, no approval needed
3. **Waits for the dispatched CI run to finish** (polls every 30s, 30 min cap)
4. **When CI passes, requests review from the designated OWNERS member** — `REVIEW_REQUESTEE = yanmxa` (`gh pr edit --add-reviewer`), with a guard that the requestee is still in the OWNERS file

Changes:
- **`release-bot.py`**: CI trigger + `wait_for_ci_and_request_review()` + `read_owners()` (parses the OWNERS YAML `reviewers` list, falling back to `approvers`, then plain text)
- **`ci.yml`**: add the `workflow_dispatch` trigger

No new secrets, PR author stays `github-actions[bot]`.

## Behavior notes

- CI failure or timeout → review is not requested, warning is logged (PR stays valid)
- The approval-gated `pull_request` CI run on the branch is ignored — only the dispatched run is polled
- Only `yanmxa` is pinged for review; if they leave the OWNERS list the request is skipped with a warning

## Verification

- `python3 -m py_compile` passes
- `read_owners()` unit-checked against the real OWNERS file and a plain-text fixture
- Dispatch failure path tested locally (422 → graceful `::warning::`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)