### PR TITLE
fix(config): stop overwriting settings when the file cannot be parsed

### DIFF
--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -12,7 +12,9 @@
 package atomicfile
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -66,4 +68,32 @@ func WriteJSON(path string, v any, perm os.FileMode) error {
 		return fmt.Errorf("marshal %s: %w", path, err)
 	}
 	return Write(path, data, perm)
+}
+
+// ReadJSON decodes the JSON file at path into v as the read half of a
+// read-modify-write cycle that ends in WriteJSON.
+//
+// A file that is missing — or present but empty — is not an error: v is left as
+// the caller initialized it, which is the correct base for creating the file.
+//
+// A file that exists with content it cannot parse IS an error, and callers must
+// abort the write rather than continue from an empty base. WriteJSON replaces
+// the whole file, so continuing would overwrite everything the user had in it
+// with just the block being saved: one stray comma in settings.json, and the
+// next persona switch takes model, permissions and env down with it.
+func ReadJSON(path string, v any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(data, v); err != nil {
+		return fmt.Errorf("parse %s: %w", path, err)
+	}
+	return nil
 }

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -126,3 +126,58 @@ func assertNoTempLeft(t *testing.T, dir string) {
 		}
 	}
 }
+
+func TestReadJSONTreatsMissingAndEmptyAsNoContent(t *testing.T) {
+	dir := t.TempDir()
+	seeds := map[string]*string{
+		"missing.json":    nil,
+		"empty.json":      ptr(""),
+		"whitespace.json": ptr("\n\t \n"),
+	}
+	for name, seed := range seeds {
+		path := filepath.Join(dir, name)
+		if seed != nil {
+			if err := os.WriteFile(path, []byte(*seed), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		v := map[string]string{"kept": "yes"}
+		if err := ReadJSON(path, &v); err != nil {
+			t.Errorf("%s: ReadJSON = %v, want nil", name, err)
+		}
+		if v["kept"] != "yes" {
+			t.Errorf("%s: caller's value was clobbered: %v", name, v)
+		}
+	}
+}
+
+func TestReadJSONReportsUnparsableContent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := os.WriteFile(path, []byte(`{"model": "opus",}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var v map[string]any
+	err := ReadJSON(path, &v)
+	if err == nil {
+		t.Fatal("ReadJSON = nil, want a parse error")
+	}
+	if !strings.Contains(err.Error(), "settings.json") {
+		t.Errorf("error should name the file, got: %v", err)
+	}
+}
+
+func TestReadJSONDecodesValidContent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cfg.json")
+	if err := WriteJSON(path, map[string]int{"n": 7}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var v map[string]int
+	if err := ReadJSON(path, &v); err != nil {
+		t.Fatalf("ReadJSON: %v", err)
+	}
+	if v["n"] != 7 {
+		t.Errorf("v = %v, want n=7", v)
+	}
+}
+
+func ptr(s string) *string { return &s }

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -107,8 +107,8 @@ func (l *ConfigLoader) SaveServer(name string, config ServerConfig, scope Scope)
 
 	// Load existing config
 	var mcpConfig MCPConfig
-	if data, err := os.ReadFile(filePath); err == nil {
-		_ = json.Unmarshal(data, &mcpConfig)
+	if err := atomicfile.ReadJSON(filePath, &mcpConfig); err != nil {
+		return err
 	}
 
 	if mcpConfig.MCPServers == nil {

--- a/internal/mcp/config_malformed_test.go
+++ b/internal/mcp/config_malformed_test.go
@@ -1,0 +1,60 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// SaveServer used to read mcp.json, ignore the parse error, and write back a
+// config containing only the server being added — silently dropping every
+// other server the user had configured. A file it cannot parse must stop it.
+func TestSaveServerRefusesToClobberMalformedConfig(t *testing.T) {
+	base := t.TempDir()
+	loader := NewConfigLoaderForTest(base)
+	path := loader.GetFilePath(ScopeProject)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Two configured servers, one stray trailing comma.
+	original := `{
+  "mcpServers": {
+    "github": {"command": "gh-mcp"},
+    "postgres": {"command": "pg-mcp"},
+  }
+}`
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := loader.SaveServer("newone", ServerConfig{Command: "new-mcp"}, ScopeProject)
+	if err == nil {
+		t.Fatal("SaveServer succeeded on a malformed mcp.json; it must report the parse error")
+	}
+	if !strings.Contains(err.Error(), "mcp.json") {
+		t.Errorf("error should name the offending file, got: %v", err)
+	}
+
+	after, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("read back: %v", readErr)
+	}
+	if string(after) != original {
+		t.Errorf("the user's other servers were dropped:\n%s", after)
+	}
+}
+
+func TestSaveServerStillCreatesAMissingConfig(t *testing.T) {
+	loader := NewConfigLoaderForTest(t.TempDir())
+	if err := loader.SaveServer("github", ServerConfig{Command: "gh-mcp"}, ScopeProject); err != nil {
+		t.Fatalf("SaveServer: %v", err)
+	}
+	servers, err := loader.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if _, ok := servers["github"]; !ok {
+		t.Errorf("server was not saved: %v", servers)
+	}
+}

--- a/internal/plugin/enabled_state_test.go
+++ b/internal/plugin/enabled_state_test.go
@@ -1,0 +1,67 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/genai-io/san/internal/confdir"
+)
+
+// saveEnabledState rewrites the whole settings.json from an untyped map. It
+// used to ignore the parse error on the way in, so enabling one plugin against
+// a settings.json it could not read replaced the file with nothing but an
+// "enabledPlugins" block — model, permissions, hooks and all.
+func TestEnableRefusesToClobberMalformedSettings(t *testing.T) {
+	cwd := t.TempDir()
+	path := filepath.Join(confdir.Dir(cwd), "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	original := `{
+  "model": "claude-opus-5",
+  "hooks": {"PreToolUse": []},
+}`
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewRegistry()
+	r.cwd = cwd
+	r.plugins["demo"] = &Plugin{Manifest: Manifest{Name: "demo"}}
+
+	err := r.Enable("demo", ScopeProject)
+	if err == nil {
+		t.Fatal("Enable succeeded on a malformed settings.json; it must report the parse error")
+	}
+	if !strings.Contains(err.Error(), "settings.json") {
+		t.Errorf("error should name the offending file, got: %v", err)
+	}
+
+	after, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("read back: %v", readErr)
+	}
+	if string(after) != original {
+		t.Errorf("the user's settings were replaced:\n%s", after)
+	}
+}
+
+func TestEnableStillWritesToAFreshSettingsFile(t *testing.T) {
+	cwd := t.TempDir()
+	r := NewRegistry()
+	r.cwd = cwd
+	r.plugins["demo"] = &Plugin{Manifest: Manifest{Name: "demo"}}
+
+	if err := r.Enable("demo", ScopeProject); err != nil {
+		t.Fatalf("Enable: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(confdir.Dir(cwd), "settings.json"))
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	if !strings.Contains(string(data), `"demo": true`) {
+		t.Errorf("plugin state was not written:\n%s", data)
+	}
+}

--- a/internal/plugin/installer.go
+++ b/internal/plugin/installer.go
@@ -612,8 +612,8 @@ func (i *Installer) AddMarketplace(source MarketplaceSource) error {
 
 	// Load existing
 	var km KnownMarketplaces
-	if data, err := os.ReadFile(path); err == nil {
-		json.Unmarshal(data, &km)
+	if err := atomicfile.ReadJSON(path, &km); err != nil {
+		return err
 	}
 
 	// Check if already exists

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -266,8 +266,8 @@ func (r *Registry) saveEnabledState(name string, enabled bool, scope Scope) erro
 
 	// Load existing settings
 	var settings map[string]any
-	if data, err := os.ReadFile(settingsPath); err == nil {
-		json.Unmarshal(data, &settings)
+	if err := atomicfile.ReadJSON(settingsPath, &settings); err != nil {
+		return err
 	}
 	if settings == nil {
 		settings = make(map[string]any)

--- a/internal/setting/loader.go
+++ b/internal/setting/loader.go
@@ -191,14 +191,11 @@ func (l *Loader) SaveToUser(settings *Data) error {
 }
 
 func (l *Loader) saveToFile(path string, settings *Data) error {
-	toSave := settings
-	if data, err := os.ReadFile(path); err == nil {
-		existing := NewData()
-		if err := json.Unmarshal(data, existing); err == nil {
-			toSave = mergeSettings(existing, settings)
-		}
+	existing := NewData()
+	if err := atomicfile.ReadJSON(path, existing); err != nil {
+		return err
 	}
-	return atomicfile.WriteJSON(path, toSave, 0o644)
+	return atomicfile.WriteJSON(path, mergeSettings(existing, settings), 0o644)
 }
 
 var (
@@ -274,8 +271,8 @@ func updateSettingsFile(userLevel bool, mutate func(*Data)) error {
 	}
 
 	existing := NewData()
-	if data, err := os.ReadFile(path); err == nil {
-		_ = json.Unmarshal(data, existing)
+	if err := atomicfile.ReadJSON(path, existing); err != nil {
+		return err
 	}
 	mutate(existing)
 	if err := atomicfile.WriteJSON(path, existing, 0o644); err != nil {
@@ -586,8 +583,8 @@ func SavePersonaAt(cwd, name string, userLevel bool) error {
 	path := filepath.Join(dir, "settings.json")
 
 	existing := NewData()
-	if data, err := os.ReadFile(path); err == nil {
-		_ = json.Unmarshal(data, existing)
+	if err := atomicfile.ReadJSON(path, existing); err != nil {
+		return err
 	}
 	existing.Persona = name
 

--- a/internal/setting/malformed_settings_test.go
+++ b/internal/setting/malformed_settings_test.go
@@ -1,0 +1,103 @@
+package setting
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// malformed is a settings.json a user could plausibly end up with: real
+// content, one stray trailing comma.
+const malformed = `{
+  "model": "claude-opus-5",
+  "permissions": {"allow": ["Bash(git:*)"]},
+  "env": {"TOKEN": "secret"},
+}`
+
+// Every save path used to read the file, ignore the parse error, and continue
+// from an empty base — then write that base back over the whole file. A single
+// typo in settings.json therefore cost the user their model, permissions and
+// env the next time anything touched settings. Each save must now refuse.
+func TestSavePathsRefuseToClobberMalformedSettings(t *testing.T) {
+	saves := map[string]func(t *testing.T, home string) error{
+		"SaveToUser": func(t *testing.T, home string) error {
+			d := NewData()
+			d.Model = "new-model"
+			return NewLoaderWithOptions(filepath.Join(home, ".san"), "", true).SaveToUser(d)
+		},
+		"UpdateSelfLearnAt": func(t *testing.T, home string) error {
+			return UpdateSelfLearnAt(SelfLearnSettings{Memory: SelfLearnMemory{Enabled: true}}, true)
+		},
+		"SavePersonaAt": func(t *testing.T, home string) error {
+			return SavePersonaAt("", "reviewer", true)
+		},
+	}
+
+	for name, save := range saves {
+		t.Run(name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home)
+			path := userSettingsFile(home)
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(malformed), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			err := save(t, home)
+			if err == nil {
+				t.Fatal("save succeeded on a malformed settings.json; it must report the parse error")
+			}
+			if !strings.Contains(err.Error(), "settings.json") {
+				t.Errorf("error should name the offending file, got: %v", err)
+			}
+
+			after, readErr := os.ReadFile(path)
+			if readErr != nil {
+				t.Fatalf("read back: %v", readErr)
+			}
+			if string(after) != malformed {
+				t.Errorf("the user's file was rewritten:\n%s", after)
+			}
+		})
+	}
+}
+
+// A settings.json that does not exist yet, or exists but is empty, is a normal
+// starting state — not corruption — so saving must still work.
+func TestSaveWorksOnMissingOrEmptySettings(t *testing.T) {
+	for _, tc := range []struct{ name, seed string }{
+		{"missing", ""},
+		{"empty", ""},
+		{"whitespace", "\n  \n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home)
+			path := userSettingsFile(home)
+			if tc.name != "missing" {
+				if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, []byte(tc.seed), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if err := SavePersonaAt("", "reviewer", true); err != nil {
+				t.Fatalf("SavePersonaAt: %v", err)
+			}
+			after, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read back: %v", err)
+			}
+			if !strings.Contains(string(after), `"persona": "reviewer"`) {
+				t.Errorf("persona was not written:\n%s", after)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Every config save in San is a read-modify-write: read the file, unmarshal it, set one field, write the whole thing back through `atomicfile.WriteJSON`. The read half ignored the unmarshal error:

```go
existing := NewData()
if data, err := os.ReadFile(path); err == nil {
    _ = json.Unmarshal(data, existing)   // parse failure → existing stays empty
}
existing.Persona = name
return atomicfile.WriteJSON(path, existing, 0o644)   // ← writes that empty base over the file
```

So a file San cannot parse degrades to an empty base, and the atomic write replaces the user's whole file with just the block being saved.

One stray trailing comma in `~/.san/settings.json` was enough. Before this change, given:

```json
{
  "model": "claude-opus-5",
  "permissions": {"allow": ["Bash(git:*)"]},
  "env": {"TOKEN": "secret"},
}
```

switching persona rewrote the file to:

```json
{ "permissions": {}, "persona": "reviewer", "selfLearn": { "memory": {}, "skills": {} } }
```

Model, permissions and env gone, with no error shown.

Six sites shared the shape:

| file | what got lost |
|---|---|
| `setting/loader.go` — `saveToFile` | every setting not in the block being saved |
| `setting/loader.go` — `updateSettingsFile` | same (`/config` self-learn toggles) |
| `setting/loader.go` — `SavePersonaAt` | same (persona switch) |
| `mcp/config.go` — `SaveServer` | every other MCP server in `mcp.json` |
| `plugin/registry.go` — `saveEnabledState` | the whole `settings.json` (it rebuilds the file from an untyped map, so only `enabledPlugins` survives) |
| `plugin/installer.go` — `AddMarketplace` | every other marketplace |

## Fix

`atomicfile.ReadJSON` pairs with the existing `WriteJSON` and draws the line the callers were missing:

- **missing or empty file** → not an error. `v` is left as the caller initialized it, which is the correct base for creating the file. Creating a fresh config still works, and a `touch`ed or truncated file is treated as "no content", not corruption.
- **content that will not parse** → an error naming the file, which the caller must abort the write on.

All six sites propagate it. All six already returned `error`, so nothing needed a signature change — a broken config now surfaces as a save failure instead of a silent wipe.

## Tests

- `atomicfile`: missing / empty / whitespace-only leave the caller's value untouched; unparsable content errors and names the file; valid content decodes.
- `setting`, `mcp`, `plugin`: for each save path, a malformed file makes the save fail **and leaves the file byte-identical**; the companion test proves a fresh/missing file still saves normally.

The `setting` regression tests were verified red against the pre-fix `loader.go` (all three save paths reported "save succeeded on a malformed settings.json") and green after.

`make lint` and `go test ./...` pass.
