### PR TITLE
ci: gate on errcheck and ineffassign

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,15 @@ jobs:
         with:
           go-version: '1.25.8'
           cache: true
-      - name: Install format tools
-        run: make install-format-tools
+      - name: Install dev tools
+        run: make install-format-tools install-lint-tools
       - name: Format check
         run: make format-check
       - name: Build
         run: make build-all
       - name: Unit + integration tests (merged coverage)
         run: make cover
-      - name: Vet
+      - name: Vet + lint + layer check
         run: make lint
 
   test-windows:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,60 @@
+# golangci-lint configuration.
+#
+# `make lint` runs this alongside go vet, the format check, and layercheck.
+#
+# The linter set is deliberately narrow: every linter here reports a defect, not
+# a style preference, so a finding is always worth acting on and the gate never
+# turns into noise a contributor learns to ignore. Style is already settled by
+# gofmt + goimports.
+#
+#   errcheck     — a discarded error is a failure the code decided not to
+#                  notice. This is how config saves silently overwrote user
+#                  files (#480): the parse error was never looked at.
+#   ineffassign  — a value assigned and then overwritten before any read is
+#                  either dead code or a missing use of the first value.
+#
+# Adding a linter means fixing its findings in the same change, so the tree
+# stays clean and `make lint` keeps a zero-tolerance meaning.
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - ineffassign
+
+  settings:
+    errcheck:
+      # Cleanup calls whose failure the caller genuinely cannot act on: the
+      # write already happened (or is being abandoned), and the process is on
+      # its way out of the scope. Everything not listed here must be handled.
+      exclude-functions:
+        - (io.Closer).Close
+        - (io.ReadCloser).Close
+        - (io.WriteCloser).Close
+        - (*os.File).Close
+        - (net.Listener).Close
+        - (*net/http.Server).Close
+        - (*compress/gzip.Reader).Close
+        - (*archive/zip.ReadCloser).Close
+        - os.Remove
+        - os.RemoveAll
+        # os.Setenv/Unsetenv only fail on a name containing "=" or NUL, which no
+        # caller here can produce — every name is a fixed provider env var.
+        - os.Setenv
+        - os.Unsetenv
+        # Writers to stdout/stderr and to in-memory builders. A failed write to
+        # a closed terminal is not something the TUI can report anywhere.
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln
+        - io.WriteString
+
+  exclusions:
+    rules:
+      # Test helpers set up state whose failure surfaces as the test failing.
+      - path: _test\.go
+        linters: [errcheck]
+
+formatters:
+  enable: []

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,9 @@ LDFLAGS := -ldflags "-s -w -X main.version=$(VERSION) -X main.buildTime=$(BUILDT
 export CGO_ENABLED := 0
 GOFILES := $(shell find . -path './vendor' -prune -o -path './.git' -prune -o -name '*.go' -print)
 GOIMPORTS_VERSION := v0.43.0
+GOLANGCI_VERSION := v2.12.2
 
-.PHONY: build build-all install clean release release-push test cover format format-check lint install-format-tools check-format-tools
+.PHONY: build build-all install clean release release-push test cover format format-check lint lint-go install-format-tools install-lint-tools check-format-tools check-lint-tools
 
 build: format
 	@mkdir -p $(BINDIR)
@@ -32,8 +33,14 @@ install: build
 install-format-tools:
 	go install golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION)
 
+install-lint-tools:
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_VERSION)
+
 check-format-tools:
 	@command -v goimports >/dev/null || go install golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION)
+
+check-lint-tools:
+	@command -v golangci-lint >/dev/null || go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_VERSION)
 
 format: check-format-tools
 	@gofmt -w $(GOFILES)
@@ -56,7 +63,14 @@ format-check: check-format-tools
 lint:
 	go vet ./...
 	@$(MAKE) format-check
+	@$(MAKE) lint-go
 	@$(MAKE) lint-layers
+
+# lint-go runs the linters configured in .golangci.yml. They report defects, not
+# style, so the tree is expected to be clean — see the config for the rule on
+# adding one.
+lint-go: check-lint-tools
+	golangci-lint run --timeout 5m ./...
 
 lint-layers:
 	@go run ./tools/layercheck

--- a/cmd/san/main.go
+++ b/cmd/san/main.go
@@ -174,7 +174,10 @@ var versionCmd = &cobra.Command{
 			}
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")
-			enc.Encode(info)
+			if err := enc.Encode(info); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
 			return
 		}
 

--- a/docs/operations/development.md
+++ b/docs/operations/development.md
@@ -25,3 +25,19 @@ GOCACHE=/private/tmp/san-go-build-cache go test ./...
 ```bash
 make install-format-tools
 ```
+
+## Linting
+
+`make lint` runs four checks, and CI runs the same target:
+
+| check | what it catches |
+| --- | --- |
+| `go vet` | the standard suspicious-construct set |
+| `make format-check` | files `gofmt` / `goimports` would rewrite |
+| `make lint-go` | the linters configured in `.golangci.yml` |
+| `make lint-layers` | imports that violate the layer order |
+
+`make lint-go` installs `golangci-lint` on first use; `make install-lint-tools`
+does it ahead of time. The configured linters report defects rather than style,
+so the tree is kept at zero findings — see the comment at the top of
+`.golangci.yml` for the rule on adding one.

--- a/internal/app/init.go
+++ b/internal/app/init.go
@@ -46,7 +46,9 @@ func initInfrastructure() error {
 	// Phase 3: tool infrastructure
 	tool.Initialize(tool.Options{})
 	agent.Initialize(agent.Options{})
-	task.Initialize(task.Options{})
+	if err := task.Initialize(task.Options{}); err != nil {
+		log.Logger().Warn("task output directory unavailable; task output will not persist", zap.Error(err))
+	}
 	todo.Initialize(todo.Options{})
 	cron.Initialize(cron.Options{
 		StoragePath: filepath.Join(confdir.Dir(appCwd), "scheduled_tasks.json"),

--- a/internal/app/input/on_mcp.go
+++ b/internal/app/input/on_mcp.go
@@ -8,9 +8,11 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
+	"go.uber.org/zap"
 
 	"github.com/genai-io/san/internal/app/kit"
 	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/log"
 	coremcp "github.com/genai-io/san/internal/mcp"
 )
 
@@ -372,7 +374,9 @@ func (s *MCPSelector) HandleReconnect(name string) {
 func (s *MCPSelector) HandleRemove(name string) {
 	if s.registry != nil {
 		s.registry.SetDisabled(name, false)
-		s.registry.RemoveServer(name)
+		if err := s.registry.RemoveServer(name); err != nil {
+			log.Logger().Warn("failed to remove MCP server", zap.String("server", name), zap.Error(err))
+		}
 	}
 	s.refreshServers()
 	s.goBack()

--- a/internal/app/input/on_plugin.go
+++ b/internal/app/input/on_plugin.go
@@ -132,7 +132,7 @@ func (s *PluginSelector) getMaxIndex() int {
 }
 
 func (s *PluginSelector) ensureVisible() {
-	visible := s.maxVisible
+	var visible int
 	switch s.level {
 	case pluginLevelBrowsePlugins:
 		visible = max(4, s.height-14)

--- a/internal/app/model_session.go
+++ b/internal/app/model_session.go
@@ -141,7 +141,7 @@ func (m *model) loadSessionByID(id string) error {
 	// read-before-modify gate in this one.
 	m.ResetAgentSession()
 	fs.ResetFileViews()
-	m.services.Tracker.SetStorageDir("")
+	m.setTrackerStorageDir("")
 	m.restoreSessionData(sess)
 
 	if len(sess.Tasks) == 0 {
@@ -198,8 +198,8 @@ func (m *model) initTaskStorage(sessionID string) {
 	taskListID := setting.Getenv("TASK_LIST_ID")
 	if taskListID != "" {
 		dir := filepath.Join(confdir.Dir(homeDir), "tasks", taskListID)
-		m.services.Tracker.SetStorageDir(dir)
-		_ = m.services.Task.SetOutputDir(filepath.Join(dir, "outputs"))
+		m.setTrackerStorageDir(dir)
+		m.setTaskOutputDir(dir)
 		return
 	}
 
@@ -207,8 +207,29 @@ func (m *model) initTaskStorage(sessionID string) {
 		return
 	}
 	dir := filepath.Join(confdir.Dir(homeDir), "tasks", sessionID)
-	m.services.Tracker.SetStorageDir(dir)
-	_ = m.services.Task.SetOutputDir(filepath.Join(dir, "outputs"))
+	m.setTrackerStorageDir(dir)
+	m.setTaskOutputDir(dir)
+}
+
+// setTrackerStorageDir points the task tracker at dir. A failure leaves the
+// tracker working in memory but no longer persisting, which is worth a line in
+// the log — there is nothing the user can do about it mid-session, and failing
+// the session load over it would be worse than losing the task file.
+func (m *model) setTrackerStorageDir(dir string) {
+	if err := m.services.Tracker.SetStorageDir(dir); err != nil {
+		log.Logger().Warn("task tracker storage unavailable",
+			zap.String("dir", dir), zap.Error(err))
+	}
+}
+
+// setTaskOutputDir points background-task output at dir/outputs, with the same
+// degrade-and-log answer as setTrackerStorageDir.
+func (m *model) setTaskOutputDir(dir string) {
+	outputs := filepath.Join(dir, "outputs")
+	if err := m.services.Task.SetOutputDir(outputs); err != nil {
+		log.Logger().Warn("task output directory unavailable",
+			zap.String("dir", outputs), zap.Error(err))
+	}
 }
 
 func (m *model) forkSession() (string, error) {
@@ -233,7 +254,7 @@ func (m *model) forkSession() (string, error) {
 	// ensureAgentSession rebuilds with a Recorder bound to the new id, since
 	// NewRecorder invalidates its cache on exactly that mismatch.
 	m.StopAgentSession()
-	m.services.Tracker.SetStorageDir("")
+	m.setTrackerStorageDir("")
 	return originalID, nil
 }
 

--- a/internal/cron/loop.go
+++ b/internal/cron/loop.go
@@ -172,7 +172,7 @@ func loopIntervalToCadence(interval string, now time.Time) (loopCadence, error) 
 	}
 
 	requestedMinutes := intervalSpecToMinutes(spec)
-	effectiveMinutes := requestedMinutes
+	var effectiveMinutes int
 	switch {
 	case requestedMinutes < 60:
 		effectiveMinutes = nearestAllowed(requestedMinutes, []int{1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60})

--- a/internal/task/service.go
+++ b/internal/task/service.go
@@ -7,13 +7,18 @@ type Options struct {
 	OutputDir string
 }
 
-// Initialize creates the package-level *Manager and configures it.
-func Initialize(opts Options) {
+// Initialize creates the package-level *Manager and configures it. It returns
+// the error from configuring the output directory: the manager is installed
+// either way, so a caller that cannot use the directory still gets a working
+// in-memory manager and can decide what to say about the lost persistence.
+func Initialize(opts Options) error {
 	m := NewManager()
+	var err error
 	if opts.OutputDir != "" {
-		m.SetOutputDir(opts.OutputDir)
+		err = m.SetOutputDir(opts.OutputDir)
 	}
 	defaultManager = m
+	return err
 }
 
 // Default returns the package-level *Manager.

--- a/internal/todo/store.go
+++ b/internal/todo/store.go
@@ -76,7 +76,9 @@ func (s *Store) SetStorageDir(dir string) error {
 	// Create lock file
 	lockPath := filepath.Join(dir, ".lock")
 	if _, err := os.Stat(lockPath); os.IsNotExist(err) {
-		os.WriteFile(lockPath, nil, 0o644)
+		if err := os.WriteFile(lockPath, nil, 0o644); err != nil {
+			return fmt.Errorf("failed to create item storage lock file: %w", err)
+		}
 	}
 
 	// Load existing items from disk, then reconcile: this is the moment a

--- a/internal/tool/tasktools/trackercreate.go
+++ b/internal/tool/tasktools/trackercreate.go
@@ -33,13 +33,16 @@ func (t *TrackerCreateTool) Execute(ctx context.Context, params map[string]any, 
 	task := todo.Default().Create(subject, description, activeForm, metadata)
 
 	// Set dependencies if provided
+	note := ""
 	if ids := parseStringSlice(params["addBlockedBy"]); len(ids) > 0 {
-		todo.Default().Update(task.ID, todo.WithAddBlockedBy(ids))
+		if err := todo.Default().Update(task.ID, todo.WithAddBlockedBy(ids)); err != nil {
+			note = fmt.Sprintf(" (blockers not set: %v)", err)
+		}
 	}
 
 	return toolresult.ToolResult{
 		Success: true,
-		Output:  fmt.Sprintf("Task #%s created: %s", task.ID, task.Subject),
+		Output:  fmt.Sprintf("Task #%s created: %s%s", task.ID, task.Subject, note),
 		Metadata: toolresult.ResultMetadata{
 			Title:    t.Name(),
 			Icon:     t.Icon(),


### PR DESCRIPTION
> Stacked on #480 — review the second commit. The base collapses once #480 merges.

## Why

`make lint` is `go vet` + a format check + `layercheck`. None of them look at discarded errors.

That is how the bug in #480 got in. Two of its six sites were bare calls:

```go
if data, err := os.ReadFile(settingsPath); err == nil {
    json.Unmarshal(data, &settings)   // ← errcheck flags this on sight
}
```

## What this adds

`.golangci.yml` with **errcheck** and **ineffassign**, wired into `make lint` (so CI picks it up through the step it already runs) and documented in `docs/operations/development.md`.

The set is deliberately narrow. Both linters report *defects*, not style — style is already settled by gofmt + goimports — so a finding is always worth acting on and the gate never becomes noise a contributor learns to ignore. Adding a linter later means fixing its findings in the same change; the config says so at the top.

I ran a wider set while choosing (`staticcheck`, `unused`, `nilerr`, `bodyclose`) and left them out on purpose: most of their findings here are false positives for this codebase (`nilerr` fires on the slash-command handlers that deliberately return an error *message* as their output; `bodyclose` fires on synthetic responses in `llmerr`'s tests). They would have needed per-case suppressions on day one.

**The tree is at 0 findings** — nothing is grandfathered.

## What errcheck found

Beyond the two `json.Unmarshal` sites already fixed by #480:

| site | consequence |
| --- | --- |
| `tasktools/trackercreate.go` | `TaskCreate` returned `Success: true` and `"Task #N created"` even when attaching `addBlockedBy` failed — the agent believed a dependency existed that did not |
| `app/model_session.go` ×4, `app/init.go` | tracker storage / task output directories wired up with the error dropped; the task panel would quietly stop persisting |
| `todo/store.go` | the storage lock file was written unchecked, in the directory whose `MkdirAll` two lines above is a hard error |
| `app/input/on_mcp.go` | a failed MCP server removal still refreshed the list as if it had worked |
| `cmd/san/main.go` | `san version --json` exited 0 after a failed encode |

For the tracker/task directories the honest answer is degrade-and-log, not fail: there is nothing the user can do about it mid-session, and failing a session load over a missing task file would be worse than losing the file. `setTrackerStorageDir` / `setTaskOutputDir` now say which directory failed. `task.Initialize` returns the error so its one non-test caller can log it.

`ineffassign` found two dead initializers (`on_plugin.go`, `cron/loop.go`) where every branch of the following switch assigns.

## Exclusions

Cleanup calls whose failure the caller genuinely cannot act on are excluded **by name in the config**, not silenced with `_ =` at each call site — so the exclusion is visible in one place and reviewable:

- deferred `Close` on files, listeners, `http.Server`, gzip/zip readers
- `os.Remove` / `os.RemoveAll`
- `fmt.Fprint*` / `io.WriteString` (a failed write to a dying terminal has nowhere to be reported)
- `os.Setenv` / `os.Unsetenv` — these only fail on a name containing `=` or NUL, and every name here is a fixed provider env var

Test files are excluded from errcheck: a failed helper surfaces as the test failing.

## Verification

`make lint` → `0 issues.` · `go test ./...` passes.
