### PR TITLE
chore: modernize Go idioms with the modernize analyzer

### DIFF
--- a/cmd/san/update.go
+++ b/cmd/san/update.go
@@ -268,10 +268,7 @@ func (pw *progressWriter) spin() {
 
 func (pw *progressWriter) printBar(width int) {
 	pct := float64(pw.written) / float64(pw.total)
-	filled := int(pct * float64(width))
-	if filled > width {
-		filled = width
-	}
+	filled := min(int(pct*float64(width)), width)
 	bar := strings.Repeat("█", filled) + strings.Repeat("░", width-filled)
 	fmt.Fprintf(os.Stderr, "\r  downloading [%s] %3.0f%%", bar, pct*100)
 }

--- a/internal/app/conv/agent_activity.go
+++ b/internal/app/conv/agent_activity.go
@@ -2,6 +2,7 @@ package conv
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -98,8 +99,8 @@ func agentSummary(input string, activity []string, stats AgentStats) string {
 }
 
 func agentModel(activity []string, fallback string) string {
-	for i := len(activity) - 1; i >= 0; i-- {
-		if model, ok := strings.CutPrefix(strings.TrimSpace(activity[i]), "Model: "); ok {
+	for _, a := range slices.Backward(activity) {
+		if model, ok := strings.CutPrefix(strings.TrimSpace(a), "Model: "); ok {
 			return strings.TrimSpace(model)
 		}
 	}
@@ -127,8 +128,8 @@ func tokenSummary(inputTokens, outputTokens int) string {
 }
 
 func agentTokens(activity []string, stats AgentStats) string {
-	for i := len(activity) - 1; i >= 0; i-- {
-		inputTokens, outputTokens, ok := parseUsageActivity(activity[i])
+	for _, a := range slices.Backward(activity) {
+		inputTokens, outputTokens, ok := parseUsageActivity(a)
 		if ok {
 			return tokenSummary(inputTokens, outputTokens)
 		}
@@ -143,7 +144,7 @@ func parseUsageActivity(line string) (int, int, bool) {
 		return 0, 0, false
 	}
 	var inputTokens, outputTokens int
-	for _, field := range strings.Fields(rest) {
+	for field := range strings.FieldsSeq(rest) {
 		key, value, ok := strings.Cut(field, "=")
 		if !ok {
 			continue
@@ -163,8 +164,8 @@ func parseUsageActivity(line string) (int, int, bool) {
 }
 
 func agentStatus(activity []string) string {
-	for i := len(activity) - 1; i >= 0; i-- {
-		line := strings.TrimSpace(activity[i])
+	for _, a := range slices.Backward(activity) {
+		line := strings.TrimSpace(a)
 		if line == "" || isAgentToolLine(line) || strings.HasPrefix(line, "Mode: ") || strings.HasPrefix(line, "Model: ") || strings.HasPrefix(line, "Usage: ") {
 			continue
 		}

--- a/internal/app/conv/cjk_wrap_test.go
+++ b/internal/app/conv/cjk_wrap_test.go
@@ -16,7 +16,7 @@ import (
 
 func nonEmptyLines(out string) []string {
 	var lines []string
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		if strings.TrimSpace(xansi.Strip(line)) != "" {
 			lines = append(lines, line)
 		}
@@ -58,7 +58,7 @@ func TestBlockquoteCJKPreservesContent(t *testing.T) {
 		t.Fatalf("render: %v", err)
 	}
 	var got strings.Builder
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		plain := strings.TrimRight(xansi.Strip(line), " ")
 		plain = strings.TrimPrefix(plain, "│ ")
 		got.WriteString(plain)

--- a/internal/app/conv/markdown.go
+++ b/internal/app/conv/markdown.go
@@ -507,7 +507,7 @@ type listLevel struct {
 func parseListItems(content string) []listItem {
 	var items []listItem
 	var stack []listLevel // one entry per active nesting level, outermost first
-	for _, line := range strings.Split(content, "\n") {
+	for line := range strings.SplitSeq(content, "\n") {
 		indent, ordered, number, text, ok := parseListMarker(line)
 		if !ok {
 			mergeContinuation(items, line)

--- a/internal/app/conv/markdown_test.go
+++ b/internal/app/conv/markdown_test.go
@@ -203,7 +203,7 @@ func TestMDRenderer_TableInListNotFolded(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Render error: %v", err)
 	}
-	for _, line := range strings.Split(stripANSI(out), "\n") {
+	for line := range strings.SplitSeq(stripANSI(out), "\n") {
 		if strings.Contains(line, "kube-apiserver") && strings.Contains(line, "etcd") {
 			t.Errorf("table rows were folded onto one line:\n%s", stripANSI(out))
 		}
@@ -227,7 +227,7 @@ func TestMDRenderer_ListContinuation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Render error: %v", err)
 	}
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		plain := strings.TrimRight(stripANSI(line), " ")
 		if plain == "" {
 			continue

--- a/internal/app/conv/message_test.go
+++ b/internal/app/conv/message_test.go
@@ -485,7 +485,7 @@ func Test_renderBashToolCallKeepsFullCommandWhenRunningDetailNeedsSpace(t *testi
 	if strings.Contains(rendered, "...") || strings.Contains(rendered, "…") {
 		t.Fatalf("running command must not be abbreviated, got %q", rendered)
 	}
-	for _, line := range strings.Split(strings.TrimSuffix(rendered, "\n"), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSuffix(rendered, "\n"), "\n") {
 		if w := lipgloss.Width(line); w > width {
 			t.Fatalf("running command line width %d exceeds terminal width %d: %q", w, width, line)
 		}
@@ -619,7 +619,7 @@ func TestRenderToolCallsPutsTimerOnBashHeaderForMultilineCommand(t *testing.T) {
 	}
 
 	rendered := stripANSI(RenderToolCalls(params))
-	header := strings.SplitN(rendered, "\n", 2)[0]
+	header, _, _ := strings.Cut(rendered, "\n")
 	if !strings.Contains(header, "· 1m 30s") {
 		t.Fatalf("RenderToolCalls() header = %q, want the timer on the Bash header line", header)
 	}

--- a/internal/app/conv/question.go
+++ b/internal/app/conv/question.go
@@ -375,10 +375,7 @@ func (p *QuestionPrompt) Render() string {
 	}
 
 	var sb strings.Builder
-	contentWidth := p.width - 2
-	if contentWidth < 40 {
-		contentWidth = 40
-	}
+	contentWidth := max(p.width-2, 40)
 
 	currentQ := p.request.Questions[p.currentQuestion]
 

--- a/internal/app/conv/status_bar.go
+++ b/internal/app/conv/status_bar.go
@@ -94,10 +94,9 @@ func RenderContextBar(used, limit int) string {
 	if pct > 100 {
 		pct = 100
 	}
-	filled := int((pct/100)*float64(contextBarWidth) + 0.5) // round to nearest cell
-	if filled > contextBarWidth {
-		filled = contextBarWidth
-	}
+	filled := min(
+		// round to nearest cell
+		int((pct/100)*float64(contextBarWidth)+0.5), contextBarWidth)
 	bar := strings.Repeat("█", filled) + strings.Repeat("░", contextBarWidth-filled)
 	style := classifyContextTier(pct).style()
 	return style.Render(fmt.Sprintf("[%s] %d%%", bar, int(pct+0.5)))

--- a/internal/app/conv/tool.go
+++ b/internal/app/conv/tool.go
@@ -245,8 +245,8 @@ func ExecuteApproved(ctx context.Context, agentUI *AgentToUI, toolCalls []core.T
 		prepared, err := coretool.PrepareToolCall(tc, executor)
 		if err != nil {
 			errMsg := "Error parsing tool input: " + err.Error()
-			if strings.HasPrefix(err.Error(), "unknown tool: ") {
-				errMsg = "Unknown tool: " + strings.TrimPrefix(err.Error(), "unknown tool: ")
+			if after, ok := strings.CutPrefix(err.Error(), "unknown tool: "); ok {
+				errMsg = "Unknown tool: " + after
 			}
 			return newExecResult(tc, idx, errMsg, true)
 		}

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -71,8 +71,8 @@ func RenderToolResult(result toolresult.ToolResult, width int) string {
 		}
 	case "WebFetch":
 		if result.Output != "" {
-			lines := strings.Split(result.Output, "\n")
-			for _, line := range lines {
+			lines := strings.SplitSeq(result.Output, "\n")
+			for line := range lines {
 				sb.WriteString("  ")
 				sb.WriteString(line)
 				sb.WriteString("\n")
@@ -585,10 +585,7 @@ func renderLines(lines []toolresult.ContentLine) string {
 			maxLineNo = line.LineNo
 		}
 	}
-	lineNoWidth := len(fmt.Sprintf("%d", maxLineNo))
-	if lineNoWidth < 4 {
-		lineNoWidth = 4
-	}
+	lineNoWidth := max(len(fmt.Sprintf("%d", maxLineNo)), 4)
 
 	for _, line := range lines {
 		switch line.Type {
@@ -1318,10 +1315,7 @@ func maxToolLabelWidth(width int) int {
 	if width <= 0 {
 		return 80
 	}
-	maxWidth := width * 80 / 100
-	if maxWidth < 50 {
-		maxWidth = 50
-	}
+	maxWidth := max(width*80/100, 50)
 	labelWidth := maxWidth - lipgloss.Width("● ")
 	if labelWidth < 20 {
 		return 20

--- a/internal/app/input/on_approval.go
+++ b/internal/app/input/on_approval.go
@@ -250,10 +250,7 @@ func (p *ApprovalModel) renderInline() string {
 	}
 
 	var sb strings.Builder
-	contentWidth := p.width - 2
-	if contentWidth < 40 {
-		contentWidth = 40
-	}
+	contentWidth := max(p.width-2, 40)
 
 	title := p.getTitle()
 	sb.WriteString(" ")

--- a/internal/app/input/on_approval_bash.go
+++ b/internal/app/input/on_approval_bash.go
@@ -67,10 +67,7 @@ func (b *approvalBashPreview) render(width int) string {
 	}
 
 	const indent = 3
-	contentWidth := width - indent
-	if contentWidth < 8 {
-		contentWidth = 8
-	}
+	contentWidth := max(width-indent, 8)
 
 	for i := 0; i < showCount; i++ {
 		sb.WriteString("   ")

--- a/internal/app/input/on_memory.go
+++ b/internal/app/input/on_memory.go
@@ -404,7 +404,7 @@ func memoryAddToGitignore(cwd, entry string) {
 
 	content := string(data)
 	// Check line-by-line to avoid substring false positives
-	for _, line := range strings.Split(content, "\n") {
+	for line := range strings.SplitSeq(content, "\n") {
 		if strings.TrimSpace(line) == entry {
 			return
 		}

--- a/internal/app/input/on_persona_test.go
+++ b/internal/app/input/on_persona_test.go
@@ -161,7 +161,7 @@ func TestPersonaSelector_RenderKeepsRowsWithinPanel(t *testing.T) {
 	rendered := s.Render()
 	plain := xansi.Strip(rendered)
 	row := ""
-	for _, line := range strings.Split(plain, "\n") {
+	for line := range strings.SplitSeq(plain, "\n") {
 		if strings.Contains(line, "software-engineer") {
 			row = strings.TrimSpace(line)
 			break

--- a/internal/app/input/on_plugin.go
+++ b/internal/app/input/on_plugin.go
@@ -723,8 +723,8 @@ func (s *PluginSelector) addMarketplace() tea.Cmd {
 		}
 		id = filepath.Base(absPath)
 		err = s.marketplaceManager.AddDirectory(id, absPath)
-	} else if strings.HasPrefix(source, "https://github.com/") {
-		repo := strings.TrimPrefix(source, "https://github.com/")
+	} else if after, ok := strings.CutPrefix(source, "https://github.com/"); ok {
+		repo := after
 		repo = strings.TrimSuffix(repo, ".git")
 		repo = strings.TrimSuffix(repo, "/")
 		parts := strings.Split(repo, "/")

--- a/internal/app/input/on_plugin_command.go
+++ b/internal/app/input/on_plugin_command.go
@@ -453,8 +453,8 @@ func pluginParseMarketplaceSource(source, explicitID string) (id, normalizedSour
 		}, nil
 	}
 
-	if strings.HasPrefix(source, "https://github.com/") {
-		repo := strings.TrimPrefix(source, "https://github.com/")
+	if after, ok := strings.CutPrefix(source, "https://github.com/"); ok {
+		repo := after
 		repo = strings.TrimSuffix(repo, ".git")
 		repo = strings.TrimSuffix(repo, "/")
 		return pluginParseGitHubMarketplace(repo, explicitID)

--- a/internal/app/input/on_queue_test.go
+++ b/internal/app/input/on_queue_test.go
@@ -41,7 +41,7 @@ func TestQueueDequeueIsFIFO(t *testing.T) {
 
 func TestQueueMaxSize(t *testing.T) {
 	var q Queue
-	for i := 0; i < maxQueueSize; i++ {
+	for range maxQueueSize {
 		q.Enqueue("item", nil)
 	}
 	if q.Enqueue("overflow", nil) != -1 {

--- a/internal/app/input/on_secret.go
+++ b/internal/app/input/on_secret.go
@@ -88,10 +88,7 @@ func (p *SecretPromptModel) Render() string {
 		return ""
 	}
 
-	contentWidth := p.width - 2
-	if contentWidth < 40 {
-		contentWidth = 40
-	}
+	contentWidth := max(p.width-2, 40)
 	p.input.SetWidth(inputWidth(contentWidth))
 
 	var sb strings.Builder

--- a/internal/app/input/on_session.go
+++ b/internal/app/input/on_session.go
@@ -4,6 +4,7 @@ package input
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -189,8 +190,8 @@ func (s *SessionSelector) getLastMessage(sess *session.SessionMetadata) string {
 		return ""
 	}
 
-	for i := len(fullSession.Messages) - 1; i >= 0; i-- {
-		msg := fullSession.Messages[i]
+	for _, msg := range slices.Backward(fullSession.Messages) {
+
 		if msg.Role != core.RoleUser && msg.Role != core.RoleAssistant {
 			continue
 		}

--- a/internal/app/input/on_skill_test.go
+++ b/internal/app/input/on_skill_test.go
@@ -28,7 +28,7 @@ func TestSkillRowDoesNotWrapWithCJKDescription(t *testing.T) {
 	s.renderItemList(&sb, panel)
 
 	var lines []string
-	for _, l := range strings.Split(sb.String(), "\n") {
+	for l := range strings.SplitSeq(sb.String(), "\n") {
 		if strings.TrimSpace(l) != "" {
 			lines = append(lines, l)
 		}

--- a/internal/app/input/on_textarea.go
+++ b/internal/app/input/on_textarea.go
@@ -234,11 +234,11 @@ func indexRunes(haystack []rune, needle string, start int) int {
 		// Convert byte position back to rune offset
 		return start + len([]rune(s[byteStart:byteStart+idx]))
 	}
-	idx := strings.Index(s, needle)
-	if idx < 0 {
+	before, _, ok := strings.Cut(s, needle)
+	if !ok {
 		return -1
 	}
-	return len([]rune(s[:idx]))
+	return len([]rune(before))
 }
 
 // HistoryUp navigates to the previous history entry.

--- a/internal/app/kit/listnav.go
+++ b/internal/app/kit/listnav.go
@@ -58,10 +58,7 @@ func (n *ListNav) Reset() {
 // VisibleRange returns the start (inclusive) and end (exclusive) indices
 // for the currently visible window of items.
 func (n *ListNav) VisibleRange() (start, end int) {
-	end = n.Scroll + n.MaxVisible
-	if end > n.Total {
-		end = n.Total
-	}
+	end = min(n.Scroll+n.MaxVisible, n.Total)
 	return n.Scroll, end
 }
 

--- a/internal/app/kit/suggest/suggest.go
+++ b/internal/app/kit/suggest/suggest.go
@@ -297,7 +297,7 @@ func loadGitignore(dir string) *gitignore {
 		return nil
 	}
 	gi := &gitignore{}
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue

--- a/internal/app/kit/util.go
+++ b/internal/app/kit/util.go
@@ -99,8 +99,8 @@ func ShortenPath(path string) string {
 }
 
 func ShortenPathForProject(path, cwd string) string {
-	if strings.HasPrefix(path, cwd) {
-		rel := strings.TrimPrefix(path, cwd)
+	if after, ok := strings.CutPrefix(path, cwd); ok {
+		rel := after
 		rel = strings.TrimPrefix(rel, "/")
 		if rel != "" {
 			return rel
@@ -137,10 +137,9 @@ const AlignedRowMinGap = 2
 // FormatAlignedRow formats "icon  name<padding>info" with name padded to
 // colWidth and always separated from info by at least AlignedRowMinGap spaces.
 func FormatAlignedRow(icon, name string, colWidth int, info string) string {
-	gap := colWidth - lipgloss.Width(name) // display width, ANSI/Unicode safe
-	if gap < AlignedRowMinGap {
-		gap = AlignedRowMinGap
-	}
+	gap := max(
+		// display width, ANSI/Unicode safe
+		colWidth-lipgloss.Width(name), AlignedRowMinGap)
 	return fmt.Sprintf("%s  %s%s%s", icon, name, strings.Repeat(" ", gap), info)
 }
 

--- a/internal/app/selflearn_recent.go
+++ b/internal/app/selflearn_recent.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -48,8 +49,8 @@ func (l *RecentLearnLog) recent() []RecentLearnEvent {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	out := make([]RecentLearnEvent, 0, len(l.events))
-	for i := len(l.events) - 1; i >= 0; i-- {
-		out = append(out, l.events[i])
+	for _, v := range slices.Backward(l.events) {
+		out = append(out, v)
 	}
 	return out
 }

--- a/internal/app/trigger/file_watcher.go
+++ b/internal/app/trigger/file_watcher.go
@@ -2,6 +2,7 @@ package trigger
 
 import (
 	"context"
+	"maps"
 	"os"
 	"path/filepath"
 	"sync"
@@ -134,9 +135,7 @@ func (w *FileWatcher) poll() {
 
 	w.mu.Lock()
 	paths := make(map[string]fileSnapshot, len(w.paths))
-	for path, snap := range w.paths {
-		paths[path] = snap
-	}
+	maps.Copy(paths, w.paths)
 	w.mu.Unlock()
 
 	var changes []change

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -77,16 +77,14 @@ func TestConcurrentWritesLeaveIntactContent(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for _, payload := range []string{a, b} {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range 50 {
 				if err := Write(path, []byte(payload), 0o644); err != nil {
 					t.Errorf("Write: %v", err)
 					return
 				}
 			}
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/internal/core/message.go
+++ b/internal/core/message.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -415,9 +416,9 @@ func writeConversationText(w io.Writer, msgs []Message, stripReminders bool) {
 
 // LastAssistantChatContent returns the most recent non-empty assistant content from chat messages.
 func LastAssistantChatContent(msgs []ChatMessage) string {
-	for i := len(msgs) - 1; i >= 0; i-- {
-		if msgs[i].Role == RoleAssistant && msgs[i].Content != "" {
-			return msgs[i].Content
+	for _, msg := range slices.Backward(msgs) {
+		if msg.Role == RoleAssistant && msg.Content != "" {
+			return msg.Content
 		}
 	}
 	return ""

--- a/internal/cron/cron.go
+++ b/internal/cron/cron.go
@@ -69,7 +69,7 @@ func parse(expr string) (*expression, error) {
 func parseField(raw string, spec fieldSpec) (field, error) {
 	f := field{values: make(map[int]bool)}
 
-	for _, part := range strings.Split(raw, ",") {
+	for part := range strings.SplitSeq(raw, ",") {
 		if err := parsePart(part, spec, f.values); err != nil {
 			return f, err
 		}

--- a/internal/cron/cron_test.go
+++ b/internal/cron/cron_test.go
@@ -126,7 +126,7 @@ func TestStoreTick(t *testing.T) {
 
 func TestStore_maxJobs(t *testing.T) {
 	store := NewScheduler()
-	for i := 0; i < maxJobs; i++ {
+	for i := range maxJobs {
 		_, err := store.Create("*/5 * * * *", "job", true, false)
 		if err != nil {
 			t.Fatalf("Create %d failed: %v", i, err)

--- a/internal/cron/loop.go
+++ b/internal/cron/loop.go
@@ -199,10 +199,7 @@ func loopIntervalToCadence(interval string, now time.Time) (loopCadence, error) 
 func intervalSpecToMinutes(spec loopIntervalSpec) int {
 	switch spec.Unit {
 	case "s":
-		minutes := (spec.Value + 59) / 60
-		if minutes < 1 {
-			minutes = 1
-		}
+		minutes := max((spec.Value+59)/60, 1)
 		return minutes
 	case "m":
 		return spec.Value

--- a/internal/cron/store.go
+++ b/internal/cron/store.go
@@ -413,10 +413,7 @@ func computeRecurringJitter(expr *expression, base time.Time, jobID string) time
 		return 0
 	}
 
-	maxJitter := period / 10
-	if maxJitter > maxRecurringJitter {
-		maxJitter = maxRecurringJitter
-	}
+	maxJitter := min(period/10, maxRecurringJitter)
 	if maxJitter <= 0 {
 		return 0
 	}

--- a/internal/hook/engine.go
+++ b/internal/hook/engine.go
@@ -177,11 +177,9 @@ func (e *Engine) Execute(ctx context.Context, event EventType, input HookInput) 
 	for _, hook := range hooks {
 		if hook.Command != nil && (hook.Command.Async || hook.Command.AsyncRewake) {
 			hookCopy, inputCopy := hook, input
-			e.detachedWg.Add(1)
-			go func() {
-				defer e.detachedWg.Done()
+			e.detachedWg.Go(func() {
 				e.executeDetachedHook(context.Background(), hookCopy, inputCopy)
-			}()
+			})
 			// Emit at launch; the detached goroutine re-emits with the real
 			// outcome when it finishes. Two records make the lifecycle visible.
 			e.audit(HookFiredAudit{
@@ -264,11 +262,9 @@ func (e *Engine) ExecuteAsync(event EventType, input HookInput) {
 	hooks := e.getMatchingHooks(event, &input)
 	for _, hook := range hooks {
 		hookCopy, inputCopy := hook, input
-		e.detachedWg.Add(1)
-		go func() {
-			defer e.detachedWg.Done()
+		e.detachedWg.Go(func() {
 			e.executeDetachedHook(context.Background(), hookCopy, inputCopy)
-		}()
+		})
 	}
 }
 

--- a/internal/inspector/replay.go
+++ b/internal/inspector/replay.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"os"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 
@@ -293,8 +294,8 @@ func (b *replayBuilder) activeMessages() []replayMessage {
 	}
 
 	var leafID string
-	for i := len(b.order) - 1; i >= 0; i-- {
-		id := b.order[i]
+	for _, id := range slices.Backward(b.order) {
+
 		if !hasChild[id] {
 			leafID = id
 			break
@@ -324,8 +325,8 @@ func (b *replayBuilder) activeMessages() []replayMessage {
 	}
 
 	out := make([]replayMessage, 0, len(reversed))
-	for i := len(reversed) - 1; i >= 0; i-- {
-		out = append(out, reversed[i])
+	for _, r := range slices.Backward(reversed) {
+		out = append(out, r)
 	}
 	return out
 }

--- a/internal/inspector/server.go
+++ b/internal/inspector/server.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -340,8 +341,8 @@ func readFromOffset(path string, offset int64) ([]byte, int64, error) {
 }
 
 func lastNewline(b []byte) int {
-	for i := len(b) - 1; i >= 0; i-- {
-		if b[i] == '\n' {
+	for i, v := range slices.Backward(b) {
+		if v == '\n' {
 			return i
 		}
 	}

--- a/internal/log/response.go
+++ b/internal/log/response.go
@@ -54,7 +54,7 @@ func logResponse(prefix, providerName string, resp any) {
 
 	if content := rl.LogContent(); content != "" {
 		sb.WriteString("    Content:\n")
-		for _, line := range strings.Split(content, "\n") {
+		for line := range strings.SplitSeq(content, "\n") {
 			fmt.Fprintf(&sb, "        %s\n", line)
 		}
 	}

--- a/internal/mcp/adopt_clients_test.go
+++ b/internal/mcp/adopt_clients_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"maps"
 	"sync"
 	"testing"
 	"time"
@@ -55,9 +56,7 @@ func connectedClient(t *testing.T, cfg ServerConfig, tr transport.Transport) *Cl
 
 func registryWith(configs map[string]ServerConfig, clients map[string]*Client) *Registry {
 	r := newEmptyRegistry()
-	for name, cfg := range configs {
-		r.configs[name] = cfg
-	}
+	maps.Copy(r.configs, configs)
 	for name, c := range clients {
 		r.clients[name] = c
 		r.getOrCreateConnectionState(name).retainWithoutLeases = true

--- a/internal/mcp/caller_test.go
+++ b/internal/mcp/caller_test.go
@@ -67,14 +67,12 @@ func TestConcurrentLeaseAcquisitionSharesOneConnectionUntilFinalRelease(t *testi
 	errors := make(chan []error, 2)
 	var wg sync.WaitGroup
 	for range 2 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
 			cleanup, errs := AcquireServerConnectionLeases(context.Background(), registry, []string{"shared"})
 			cleanups <- cleanup
 			errors <- errs
-		}()
+		})
 	}
 	close(start)
 	wg.Wait()

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -21,11 +21,11 @@ const (
 	ClientVersion = "1.0.0"
 )
 
-var requestIDCounter uint64
+var requestIDCounter atomic.Uint64
 
 // nextRequestID generates a unique request ID
 func nextRequestID() uint64 {
-	return atomic.AddUint64(&requestIDCounter, 1)
+	return requestIDCounter.Add(1)
 }
 
 // Client is an MCP client that connects to a single MCP server

--- a/internal/mcp/transport/stdio_test.go
+++ b/internal/mcp/transport/stdio_test.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"os"
+	"slices"
 	"testing"
 )
 
@@ -114,13 +115,7 @@ func Test_buildEnv(t *testing.T) {
 	env := buildEnv(configEnv)
 
 	// Check that MY_VAR is in the result
-	found := false
-	for _, e := range env {
-		if e == "MY_VAR=my_value" {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(env, "MY_VAR=my_value")
 
 	if !found {
 		t.Error("MY_VAR=my_value not found in result")

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -179,8 +179,8 @@ const (
 type Server struct {
 	Config       ServerConfig       `json:"config"`
 	Status       ServerStatus       `json:"status"`
-	Capabilities ServerCapabilities `json:"capabilities,omitempty"`
-	ServerInfo   ServerInfo         `json:"serverInfo,omitempty"`
+	Capabilities ServerCapabilities `json:"capabilities"`
+	ServerInfo   ServerInfo         `json:"serverInfo"`
 	Error        string             `json:"error,omitempty"`
 	Tools        []MCPTool          `json:"tools,omitempty"`
 	Resources    []MCPResource      `json:"resources,omitempty"`

--- a/internal/plugin/compat.go
+++ b/internal/plugin/compat.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"encoding/json"
+	"maps"
 	"os"
 	"path/filepath"
 
@@ -56,9 +57,7 @@ func (r *Registry) LoadClaudePlugins(ctx context.Context) error {
 	}
 
 	r.mu.Lock()
-	for key, p := range collected {
-		r.plugins[key] = p
-	}
+	maps.Copy(r.plugins, collected)
 	r.mu.Unlock()
 
 	return nil

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -123,9 +124,7 @@ func (r *Registry) loadEnabledPlugins(cwd string) (map[string]bool, error) {
 		if err := json.Unmarshal(data, &settings); err != nil {
 			continue
 		}
-		for k, v := range settings.EnabledPlugins {
-			result[k] = v
-		}
+		maps.Copy(result, settings.EnabledPlugins)
 	}
 
 	return result, nil
@@ -395,9 +394,7 @@ func (r *Registry) GetAllLSPServers() map[string]LSPServerConfig {
 		if !p.Enabled || p.Components.LSP == nil {
 			continue
 		}
-		for name, config := range p.Components.LSP {
-			result[name] = config
-		}
+		maps.Copy(result, p.Components.LSP)
 	}
 	return result
 }

--- a/internal/reminder/reminder_test.go
+++ b/internal/reminder/reminder_test.go
@@ -270,7 +270,7 @@ func TestServiceConcurrentAccess(t *testing.T) {
 	s := NewService()
 
 	var wg sync.WaitGroup
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()

--- a/internal/selflearn/skillpatch.go
+++ b/internal/selflearn/skillpatch.go
@@ -3,6 +3,7 @@ package selflearn
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -83,7 +84,7 @@ func lineWindowReplace(content, oldText, newText string, replaceAll bool, norm f
 	var starts []int
 	for i := 0; i+w <= len(contentLines); {
 		match := true
-		for j := 0; j < w; j++ {
+		for j := range w {
 			if normContent[i+j] != normOld[j] {
 				match = false
 				break
@@ -111,8 +112,8 @@ func lineWindowReplace(content, oldText, newText string, replaceAll bool, norm f
 	newLines := strings.Split(newText, "\n")
 	// Replace from the last match backward so earlier indices stay valid.
 	out := contentLines
-	for i := len(starts) - 1; i >= 0; i-- {
-		s := starts[i]
+	for _, s := range slices.Backward(starts) {
+
 		out = append(out[:s], append(append([]string{}, newLines...), out[s+w:]...)...)
 	}
 	return strings.Join(out, "\n"), true, nil

--- a/internal/session/message_convert.go
+++ b/internal/session/message_convert.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -200,8 +201,8 @@ func toolResultToBlocks(tr *core.ToolResult) []ContentBlock {
 }
 
 func ExtractLastUserText(msgs []core.Message) string {
-	for i := len(msgs) - 1; i >= 0; i-- {
-		if text, ok := extractUserText(msgs[i]); ok {
+	for _, msg := range slices.Backward(msgs) {
+		if text, ok := extractUserText(msg); ok {
 			return text
 		}
 	}

--- a/internal/session/transcript/fs_store.go
+++ b/internal/session/transcript/fs_store.go
@@ -514,8 +514,8 @@ func (s *FileStore) Fork(ctx context.Context, cmd ForkCommand) error {
 
 func rewriteRecordSessionID(id, oldSessionID, newSessionID string) string {
 	prefix := oldSessionID + ":"
-	if strings.HasPrefix(id, prefix) {
-		return newSessionID + ":" + strings.TrimPrefix(id, prefix)
+	if after, ok := strings.CutPrefix(id, prefix); ok {
+		return newSessionID + ":" + after
 	}
 	return id
 }
@@ -1076,11 +1076,11 @@ func firstUserText(messages []Node) string {
 }
 
 func lastUserText(messages []Node) string {
-	for i := len(messages) - 1; i >= 0; i-- {
-		if messages[i].Role != "user" {
+	for _, message := range slices.Backward(messages) {
+		if message.Role != "user" {
 			continue
 		}
-		if text := firstTextBlock(messages[i].Content); text != "" {
+		if text := firstTextBlock(message.Content); text != "" {
 			return text
 		}
 	}
@@ -1100,9 +1100,9 @@ func firstTextBlock(content []ContentBlock) string {
 }
 
 func lastGitBranch(messages []Node) string {
-	for i := len(messages) - 1; i >= 0; i-- {
-		if messages[i].GitBranch != "" {
-			return messages[i].GitBranch
+	for _, message := range slices.Backward(messages) {
+		if message.GitBranch != "" {
+			return message.GitBranch
 		}
 	}
 	return ""

--- a/internal/session/transcript/index_recovery_test.go
+++ b/internal/session/transcript/index_recovery_test.go
@@ -3,6 +3,7 @@ package transcript
 import (
 	"context"
 	"os"
+	"slices"
 	"testing"
 	"time"
 )
@@ -119,10 +120,5 @@ func TestStartOnAnEmptyStoreStillWorks(t *testing.T) {
 }
 
 func contains(haystack []string, needle string) bool {
-	for _, s := range haystack {
-		if s == needle {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(haystack, needle)
 }

--- a/internal/session/transcript/projector.go
+++ b/internal/session/transcript/projector.go
@@ -3,6 +3,7 @@ package transcript
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/genai-io/san/internal/todo"
 )
@@ -190,8 +191,8 @@ func materializeActiveChain(messageMap map[string]Node, order []string, boundary
 	}
 
 	var leafID string
-	for i := len(order) - 1; i >= 0; i-- {
-		id := order[i]
+	for _, id := range slices.Backward(order) {
+
 		if !hasChild[id] {
 			leafID = id
 			break
@@ -225,8 +226,8 @@ func materializeActiveChain(messageMap map[string]Node, order []string, boundary
 	}
 
 	out := make([]Node, 0, len(reversed))
-	for i := len(reversed) - 1; i >= 0; i-- {
-		out = append(out, reversed[i])
+	for _, r := range slices.Backward(reversed) {
+		out = append(out, r)
 	}
 	return out
 }

--- a/internal/session/transcript/tool_result.go
+++ b/internal/session/transcript/tool_result.go
@@ -33,14 +33,14 @@ func hydrateToolResultBlocks(blocks []ContentBlock, marker string, load func(too
 }
 
 func persistedToolResultID(text, marker string) (string, bool) {
-	idx := strings.Index(text, marker)
-	if idx < 0 {
+	_, after, ok := strings.Cut(text, marker)
+	if !ok {
 		return "", false
 	}
-	suffix := text[idx+len(marker):]
-	end := strings.Index(suffix, "]")
-	if end < 0 {
+	suffix := after
+	before0, _, ok0 := strings.Cut(suffix, "]")
+	if !ok0 {
 		return "", false
 	}
-	return suffix[:end], true
+	return before0, true
 }

--- a/internal/session/transcript/types_test.go
+++ b/internal/session/transcript/types_test.go
@@ -47,10 +47,10 @@ func TestTranscriptTypesCarryProjectedState(t *testing.T) {
 
 func TestProjectedTypesDoNotExposeJSONTags(t *testing.T) {
 	fields := []reflect.StructField{
-		reflect.TypeOf(Transcript{}).Field(0),
-		reflect.TypeOf(Node{}).Field(0),
-		reflect.TypeOf(State{}).Field(0),
-		reflect.TypeOf(ListItem{}).Field(0),
+		reflect.TypeFor[Transcript]().Field(0),
+		reflect.TypeFor[Node]().Field(0),
+		reflect.TypeFor[State]().Field(0),
+		reflect.TypeFor[ListItem]().Field(0),
 	}
 
 	for _, field := range fields {

--- a/internal/setting/loader.go
+++ b/internal/setting/loader.go
@@ -417,9 +417,7 @@ func IsDefaultDisabledTool(name string) bool {
 // keys fall back to the default.
 func WithDefaultDisabledTools(explicit map[string]bool) map[string]bool {
 	result := make(map[string]bool, len(explicit)+len(defaultDisabledTools))
-	for name, disabled := range defaultDisabledTools {
-		result[name] = disabled
-	}
+	maps.Copy(result, defaultDisabledTools)
 	maps.Copy(result, explicit)
 	for name, disabled := range result {
 		if !disabled {

--- a/internal/setting/security.go
+++ b/internal/setting/security.go
@@ -108,7 +108,7 @@ func isRootOrHomeRemoval(cmd string) bool {
 // letting an unparseable root/home removal through.
 func crudeRootOrHomeRemovalScan(cmd string) bool {
 	hasRM, recursive, rootHome := false, false, false
-	for _, f := range strings.Fields(cmd) {
+	for f := range strings.FieldsSeq(cmd) {
 		switch {
 		case f == "rm" || strings.HasSuffix(f, "/rm"):
 			hasRM = true
@@ -498,7 +498,7 @@ func hasZshDangerousCommand(cmd string) bool {
 	segments := extractBashCommands(cmd)
 	var expanded []string
 	for _, seg := range segments {
-		for _, pipePart := range strings.Split(seg, "|") {
+		for pipePart := range strings.SplitSeq(seg, "|") {
 			if s := strings.TrimSpace(pipePart); s != "" {
 				expanded = append(expanded, s)
 			}

--- a/internal/setting/settings.go
+++ b/internal/setting/settings.go
@@ -25,7 +25,7 @@ import (
 
 // Data represents the complete San configuration.
 type Data struct {
-	Permissions    PermissionSettings `json:"permissions,omitempty"`
+	Permissions    PermissionSettings `json:"permissions"`
 	Model          string             `json:"model,omitempty"`
 	Hooks          map[string][]Hook  `json:"hooks,omitempty"`
 	Env            map[string]string  `json:"env,omitempty"`
@@ -61,11 +61,11 @@ type Data struct {
 	Persona string `json:"persona,omitempty"`
 	// SelfLearn toggles + tunes the self-learning loop (per-turn background
 	// review of memory and skills). Both arms are off by default (opt-in).
-	SelfLearn SelfLearnSettings `json:"selfLearn,omitempty"`
+	SelfLearn SelfLearnSettings `json:"selfLearn"`
 	// AutoPilot configures the autopilot copilot: which lifecycle points it
 	// steers, how it drives (model + system prompt), and the mission it steers
 	// toward (JSON key "autoPilot").
-	AutoPilot AutoPilotSettings `json:"autoPilot,omitempty"`
+	AutoPilot AutoPilotSettings `json:"autoPilot"`
 	// LastOperationMode is the user-wide mode restored when starting a new session.
 	LastOperationMode string `json:"lastOperationMode,omitempty"`
 }
@@ -94,7 +94,7 @@ type AutoPilotSettings struct {
 	// briefing composed in the /autopilot Mission dialog.
 	Mission string `json:"mission,omitempty"`
 	// Steers selects which lifecycle points the copilot takes the helm at.
-	Steers SteerSettings `json:"steers,omitempty"`
+	Steers SteerSettings `json:"steers"`
 	// MaxContinuations caps how many times the TurnEnd steer may auto-continue
 	// a finished turn before yielding to the human. 0 = the default cap,
 	// negative = no cap (see AutoPilotUnlimitedContinuations).
@@ -229,8 +229,8 @@ func (a AutoPilotSettings) Equal(b AutoPilotSettings) bool {
 // by the model (the Evolve tool); the per-arm fields are permission / store
 // settings only. See notes/active/l1-background-review.md §3.1.
 type SelfLearnSettings struct {
-	Memory SelfLearnMemory `json:"memory,omitempty"`
-	Skills SelfLearnSkills `json:"skills,omitempty"`
+	Memory SelfLearnMemory `json:"memory"`
+	Skills SelfLearnSkills `json:"skills"`
 
 	// Strategy, when non-empty, replaces the built-in learning strategy in the
 	// reviewer prompt (edited via the /evolve Strategy entry) — it steers both
@@ -569,10 +569,8 @@ func (sp *SessionPermissions) AddWorkingDirectory(dir string) {
 // edit allowances together).
 func (sp *SessionPermissions) addWorkingDirectoryLocked(dir string) {
 	// Avoid duplicates
-	for _, d := range sp.WorkingDirectories {
-		if d == dir {
-			return
-		}
+	if slices.Contains(sp.WorkingDirectories, dir) {
+		return
 	}
 	sp.WorkingDirectories = append(sp.WorkingDirectories, dir)
 }
@@ -759,15 +757,9 @@ func (s *Data) Clone() *Data {
 		v := *s.ContextBar
 		dst.ContextBar = &v
 	}
-	for k, v := range s.Env {
-		dst.Env[k] = v
-	}
-	for k, v := range s.EnabledPlugins {
-		dst.EnabledPlugins[k] = v
-	}
-	for k, v := range s.DisabledTools {
-		dst.DisabledTools[k] = v
-	}
+	maps.Copy(dst.Env, s.Env)
+	maps.Copy(dst.EnabledPlugins, s.EnabledPlugins)
+	maps.Copy(dst.DisabledTools, s.DisabledTools)
 	for event, hooks := range s.Hooks {
 		clonedHooks := make([]Hook, len(hooks))
 		for i, hook := range hooks {

--- a/internal/skill/registry.go
+++ b/internal/skill/registry.go
@@ -3,6 +3,7 @@ package skill
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -275,9 +276,7 @@ func (r *Registry) GetStatesAt(userLevel bool) map[string]SkillState {
 		src = r.projectStore.states
 	}
 	result := make(map[string]SkillState, len(src))
-	for k, v := range src {
-		result[k] = v
-	}
+	maps.Copy(result, src)
 	return result
 }
 

--- a/internal/subagent/executor.go
+++ b/internal/subagent/executor.go
@@ -355,10 +355,7 @@ func (e *Executor) prepareRunConfig(ctx context.Context, req tool.AgentExecReque
 
 	permMode := e.requestPermissionMode(config, req)
 
-	maxSteps := defaultMaxSteps
-	if config.MaxSteps > maxSteps {
-		maxSteps = config.MaxSteps
-	}
+	maxSteps := max(config.MaxSteps, defaultMaxSteps)
 	if req.MaxSteps > maxSteps {
 		maxSteps = req.MaxSteps
 	}
@@ -526,12 +523,7 @@ func canEditWorkspace(mode PermissionMode, allow ToolList) bool {
 	case setting.ModeAutoAccept, setting.ModeBypassPermissions:
 		return true
 	}
-	for _, name := range allow.Names() {
-		if perm.IsEditTool(name) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(allow.Names(), perm.IsEditTool)
 }
 
 func interpretStopReason(result *core.Result, maxSteps int) (success bool, errMsg string) {

--- a/internal/subagent/loader.go
+++ b/internal/subagent/loader.go
@@ -3,6 +3,7 @@ package subagent
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 
@@ -72,8 +73,8 @@ func LoadAgents(cwd string) {
 	priorityOrdered = append(priorityOrdered, additionalAgentPaths...)
 	additionalAgentPathsMu.Unlock()
 
-	for i := len(priorityOrdered) - 1; i >= 0; i-- {
-		sp := priorityOrdered[i]
+	for _, sp := range slices.Backward(priorityOrdered) {
+
 		loadAgentsFromDirWithNamespace(sp.path, sp.namespace)
 	}
 }

--- a/internal/task/bash_task_test.go
+++ b/internal/task/bash_task_test.go
@@ -149,7 +149,7 @@ func TestBashTask_ConcurrentAccess(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Multiple goroutines reading and writing
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wg.Add(3)
 
 		go func() {

--- a/internal/task/manager_test.go
+++ b/internal/task/manager_test.go
@@ -46,7 +46,7 @@ func TestManager_List(t *testing.T) {
 	defer cancel()
 
 	// Create multiple tasks
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		cmd := exec.CommandContext(ctx, "echo", "test")
 		cmd.Start()
 		m.CreateBashTask(cmd, "echo test", "Test task", cancel)
@@ -66,7 +66,7 @@ func TestManager_ListRunning(t *testing.T) {
 
 	// Create 3 tasks
 	var tasks []*BashTask
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		cmd := exec.CommandContext(ctx, "echo", "test")
 		cmd.Start()
 		task := m.CreateBashTask(cmd, "echo test", "Test task", cancel)
@@ -110,7 +110,7 @@ func TestManager_GenerateUniqueIDs(t *testing.T) {
 
 	ids := make(map[string]bool)
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		cmd := exec.CommandContext(ctx, "echo", "test")
 		cmd.Start()
 		task := m.CreateBashTask(cmd, "echo test", "Test task", cancel)

--- a/internal/tool/skill/skill.go
+++ b/internal/tool/skill/skill.go
@@ -3,6 +3,7 @@ package skill
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -213,8 +214,8 @@ func alreadyInlined(ctx context.Context, fullName string) bool {
 	}
 	msgs := getter()
 	tag := "<command-name>" + fullName + "</command-name>"
-	for i := len(msgs) - 1; i >= 0; i-- {
-		m := msgs[i]
+	for _, m := range slices.Backward(msgs) {
+
 		// Want the most recent user-typed turn; a tool result is also RoleUser
 		// (it carries a ToolResult), so skip those to avoid stopping on one.
 		if m.Role != core.RoleUser || m.ToolResult != nil {

--- a/tests/integration/cli/startup_test.go
+++ b/tests/integration/cli/startup_test.go
@@ -286,8 +286,8 @@ func filteredEnv(removeKeys ...string) []string {
 	var env []string
 	for _, kv := range os.Environ() {
 		key := kv
-		if idx := strings.Index(kv, "="); idx >= 0 {
-			key = kv[:idx]
+		if before, _, ok := strings.Cut(kv, "="); ok {
+			key = before
 		}
 		if !remove[key] {
 			env = append(env, kv)

--- a/tests/integration/persona/persona_test.go
+++ b/tests/integration/persona/persona_test.go
@@ -475,8 +475,8 @@ func filteredEnv(removeKeys ...string) []string {
 	var env []string
 	for _, kv := range os.Environ() {
 		key := kv
-		if idx := strings.Index(kv, "="); idx >= 0 {
-			key = kv[:idx]
+		if before, _, ok := strings.Cut(kv, "="); ok {
+			key = before
 		}
 		if !remove[key] {
 			env = append(env, kv)

--- a/tests/integration/session/session_test.go
+++ b/tests/integration/session/session_test.go
@@ -414,7 +414,7 @@ func TestSession_JSONL_Integrity(t *testing.T) {
 		if line == "" {
 			continue // trailing newline is expected
 		}
-		var obj map[string]interface{}
+		var obj map[string]any
 		if err := json.Unmarshal([]byte(line), &obj); err != nil {
 			t.Errorf("line %d is not valid JSON: %v\ncontent: %s", i+1, err, line)
 		} else {
@@ -532,7 +532,7 @@ func TestSession_SaveTwice_NoDuplication(t *testing.T) {
 		t.Fatalf("ReadFile: %v", err)
 	}
 	count := 0
-	for _, line := range strings.Split(string(raw), "\n") {
+	for line := range strings.SplitSeq(string(raw), "\n") {
 		if strings.Contains(line, `"type":"message.appended"`) ||
 			strings.Contains(line, `"type":"transcript.message.appended"`) {
 			count++

--- a/tools/layercheck/main.go
+++ b/tools/layercheck/main.go
@@ -65,8 +65,8 @@ func main() {
 		for _, imp := range p.Imports {
 			toRel, toLayer, ok := lookupLayer(layerOf, imp)
 			if !ok {
-				if strings.HasPrefix(imp, repoModule+"/") {
-					unknown[strings.TrimPrefix(imp, repoModule+"/")] = true
+				if after, ok0 := strings.CutPrefix(imp, repoModule+"/"); ok0 {
+					unknown[after] = true
 				}
 				continue
 			}
@@ -127,7 +127,7 @@ func loadLayerMap(path string) (map[string]string, error) {
 
 func parseLayerMap(markdown string) (map[string]string, error) {
 	layerOf := map[string]string{}
-	for _, line := range strings.Split(markdown, "\n") {
+	for line := range strings.SplitSeq(markdown, "\n") {
 		cells := markdownTableCells(line)
 		if len(cells) < 2 {
 			continue


### PR DESCRIPTION
## What

Ran the x/tools `modernize` analyzer suite over the whole tree and applied every fix it offers.

```
go run golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize@latest -fix ./...
```

**100 diagnostics → 0, across 64 files, net −63 lines.**

This is the same suite `go fix` ships with since Go 1.26. Every rewrite is behavior-preserving by construction — the analyzer only emits a fix when it can prove the replacement is equivalent, and the fixes are explicitly designed to be applied en masse.

## Breakdown

| Count | Rewrite |
|---:|---|
| 17 | `slices.Backward` for reverse index loops |
| 16 | `strings.SplitSeq` instead of `Split` + range |
| 10 | `maps.Copy` for `m[k]=v` copy loops |
| 9 | built-in `max` |
| 8 | dropped ineffective `omitempty` tags (see below) |
| 8 | range-over-int |
| 6 | `strings.CutPrefix` replacing `HasPrefix` + `TrimPrefix` |
| 5 | `strings.Cut` replacing `strings.Index` slicing |
| 4 | `reflect.TypeFor` |
| 4 | built-in `min` |
| 4 | `sync.WaitGroup.Go` |
| 3 | `slices.Contains` |
| 2 | `strings.FieldsSeq` |
| 1 each | `slices.ContainsFunc`, `strings.Cut` for `SplitN`, `atomic.Uint64`, `interface{}` → `any` |

The 18 `SplitSeq` / `FieldsSeq` conversions are the only ones with a runtime effect: iterating the sequence avoids materialising the intermediate slice.

## The `omitempty` tags are worth a second look

`encoding/json` ignores `omitempty` on non-pointer nested struct fields, so these eight tags never suppressed anything. Removing them changes no serialized output — it just stops the tag from claiming otherwise:

- `setting.Data.Permissions` / `.SelfLearn` / `.AutoPilot`
- `setting.SelfLearnSettings.Memory` / `.Skills`
- `setting.AutoPilotSettings.Steers`
- `mcp.Server.Capabilities` / `.ServerInfo`

**The original intent behind them is still unmet.** `internal/setting/loader.go` marshals `Data` straight back to the user's `settings.json`, which means every save writes out full `"permissions"`, `"selfLearn"` and `"autoPilot"` blocks even for users who never configured them.

Restoring the intent means switching to `omitzero` (Go 1.24), which **is** a behavior change — the analyzer flags it as an alternative fix and deliberately declines to apply it. Left out of this PR on purpose; happy to follow up separately if that is the behavior we want.

## Verification

- `go build ./...` — clean
- `make lint` — `go vet` clean, `layercheck: no layer violations`
- `go test ./...` — all green

## Unrelated flake spotted while verifying

`TestHooks_BidirectionalPrompt_MultiRound` / `_SingleRound` / `_UserDeclines` fail roughly half the time under a full parallel `go test ./...`, and pass 100% when the package runs alone. **This reproduces identically on unmodified `main`** — it is not introduced here.

Root cause looks like the 500 ms race in `internal/hook/executors_command.go`:

```go
// Interactive hooks (prompt-response) produce output before needing
// more stdin, so the timer is cancelled in time.
stdinTimer := time.AfterFunc(500*time.Millisecond, func() {
	stdinPipe.Close()
})
```

Under load a hook script's interpreter startup easily exceeds 500 ms, stdin gets closed before the first prompt round, and the exchange breaks. That affects real interactive hooks, not just the tests — filing separately.
