### PR TITLE
feat(memory): adopt the AGENTS.md standard for project instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,6 @@ coverage.out
 .mcp.json
 CLAUDE.md
 CLAUDE.local.md
+AGENTS.local.md
 .autodev/
 /layercheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,12 @@ This file is the short navigation map for agents and contributors. Keep durable
 knowledge in `docs/`; keep this file focused on where to look and what rules to
 follow before changing code.
 
-`AGENTS.md` is a static navigation aid for whoever opens the repository.
-`SAN.md` and `CLAUDE.md` at the project root are loaded into the running
-agent's system prompt at startup — they belong to runtime context, not to
-this file. Do not mix the two.
+San follows the [AGENTS.md](https://agents.md) standard, so this file is both
+the navigation aid for whoever opens the repository and the project
+instructions loaded into the running agent's context at session start. Keep it
+short: pointers and rules only. Uncommitted personal notes belong in
+`AGENTS.local.md` (git-ignored); a subdirectory with its own conventions can
+carry its own `AGENTS.md`, and the file nearest the working directory wins.
 
 ## Start Here
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Subcommands: `inspector` · `agent` · `plugin` · `mcp` — run `san <command> 
 <details>
 <summary><b>Config files &amp; layout</b></summary>
 
-Settings load from `~/.san/` and `<project>/.san/`, with project settings overriding user settings. Project instructions are read from `.san/SAN.md`, `SAN.md`, `.claude/CLAUDE.md`, or `CLAUDE.md`, in that order.
+Settings load from `~/.san/` and `<project>/.san/`, with project settings overriding user settings. Project instructions follow the [AGENTS.md](https://agents.md) standard: `~/.san/AGENTS.md`, every `AGENTS.md` from the repository root down to the working directory (the nearest one wins), and a git-ignored `AGENTS.local.md` at the root.
 
 User-level (`~/.san/`):
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -164,7 +164,7 @@ san --resume                 # 选择历史会话恢复
 <details>
 <summary><b>配置文件与目录结构</b></summary>
 
-配置从 `~/.san/`（用户级）与 `<项目>/.san/`（项目级）加载，项目级覆盖用户级。项目指令依次读取 `.san/SAN.md`、`SAN.md`、`.claude/CLAUDE.md`、`CLAUDE.md`。
+配置从 `~/.san/`（用户级）与 `<项目>/.san/`（项目级）加载，项目级覆盖用户级。项目指令遵循 [AGENTS.md](https://agents.md) 行业标准：`~/.san/AGENTS.md`，从仓库根目录到当前工作目录沿途每一层的 `AGENTS.md`（越近的越优先），以及根目录下不入库的 `AGENTS.local.md`。
 
 用户级（`~/.san/`）：
 

--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -166,7 +166,7 @@ reconstructed chain matches what the live agent actually sent.
 Reminder providers render from cached instructions
 (`env.CachedUserInstructions` / `CachedProjectInstructions`). On PostCompact the
 harness calls `refreshMemoryContext` to **re-read the memory files from disk
-before** re-emitting, so a `SAN.md`/`CLAUDE.md` edited mid-session re-injects
+before** re-emitting, so an `AGENTS.md` edited mid-session re-injects
 its *latest* content rather than a stale cached copy. This is the key asymmetry
 with the system prompt: the prompt is reused from cache (it cannot have
 changed), but reminders are deliberately rebuilt.

--- a/docs/concepts/harness-channels.md
+++ b/docs/concepts/harness-channels.md
@@ -6,7 +6,7 @@ each with different cache, lifecycle, and stability properties:
 | Channel | What lives there | Cache-friendly? | Mutable mid-session? |
 |---|---|---|---|
 | **System prompt** | Identity, output style, engineering defaults, policy, guidelines, environment footer. Slot-sectioned. | Yes — invariant per session unless a section mutates. | Yes (Use/Drop), but expensive (cache miss). |
-| **`<system-reminder>` blocks** | Session-level / project-level dynamic content: **active-skills directory**, SAN.md/CLAUDE.md memory, one-time notices. Attached below the next user message. | Yes — once attached, the user message is immutable. | No (re-emitted as new attachments, never mutated). |
+| **`<system-reminder>` blocks** | Session-level / project-level dynamic content: **active-skills directory**, AGENTS.md memory, one-time notices. Attached below the next user message. | Yes — once attached, the user message is immutable. | No (re-emitted as new attachments, never mutated). |
 | **User messages** | The actual prompt the user typed. | Yes — already cached. | No. |
 
 > The active-skills list (what skills the model is currently aware of) used
@@ -77,8 +77,8 @@ harness has standard providers:
 | Provider ID | Source | Re-emit triggers |
 |---|---|---|
 | `skills-directory` | active skills (and the "use Skill tool to invoke" preamble) | session start, PostCompact, skill enable/disable/activate |
-| `memory-user` | `~/.san/SAN.md` and `~/.claude/CLAUDE.md` | session start, PostCompact, file change |
-| `memory-project` | `<project>/SAN.md` and `<project>/CLAUDE.md` | session start, PostCompact, file change, cwd change |
+| `memory-user` | `~/.san/AGENTS.md` and `~/.san/rules/*.md` | session start, PostCompact, file change |
+| `memory-project` | every `AGENTS.md` from the repository root down to the cwd, `<cwd>/.san/rules/*.md`, and `<root>/AGENTS.local.md` | session start, PostCompact, file change, cwd change |
 
 Each provider has a stable ID; re-emitting from the same ID **drops the
 previous queued entry**, so toggling a skill three times in a row
@@ -105,16 +105,18 @@ tags back to the user.
 
 Implementation: [`packages/reminder.md`](../packages/2-feature/reminder.md).
 
-## Memory: SAN.md / CLAUDE.md
+## Memory: AGENTS.md
 
-Two memory tiers:
+San follows the [AGENTS.md](https://agents.md) standard. Two memory tiers:
 
-- **User memory**: `~/.san/SAN.md` (San) and `~/.claude/CLAUDE.md`
-  (Claude Code compat). Loaded once per session, attached as
-  `memory-user` reminder.
-- **Project memory**: `<project>/SAN.md`, `<project>/CLAUDE.md`, plus
-  recursively-loaded `<dir>/SAN.md` upwards from the start path.
-  Attached as `memory-project` reminder.
+- **User memory**: `~/.san/AGENTS.md`, plus `~/.san/rules/*.md`. Loaded
+  once per session, attached as the `memory-user` reminder.
+- **Project memory**: every `AGENTS.md` from the repository root down to
+  the working directory, then `<cwd>/.san/rules/*.md`, then the
+  git-ignored `<root>/AGENTS.local.md`. Files nearer the working
+  directory are injected last, so the closest instructions win — the
+  precedence Codex and Cursor use. The combined body is capped at 32 KB.
+  Attached as the `memory-project` reminder.
 
 Memory is **never** in the system prompt — that would invalidate the
 prompt cache every time the user edited their memory file.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -103,7 +103,8 @@ san --continue                       # resume the last session
 | User | `~/.san/skills/` `~/.san/agents/` `~/.san/commands/` `~/.san/plugins/` | Your personal extensions |
 | Project | `<project>/.san/settings.json` | Per-project overrides |
 | Project | `<project>/.san/{skills,agents,commands}/` | Project-scoped extensions |
-| Project | `<project>/SAN.md` or `CLAUDE.md` | Auto-loaded into the system prompt |
+| Project | `<project>/AGENTS.md` (and one per subdirectory) | Auto-loaded as project instructions |
+| Project | `<project>/AGENTS.local.md` | Same, but git-ignored |
 
 See [`reference/configuration.md`](../reference/configuration.md) for the
 full schema.

--- a/docs/guides/inspector.md
+++ b/docs/guides/inspector.md
@@ -68,7 +68,7 @@ hidden fields.
 At any record, you can open the **System Prompt overlay** to see the
 full system prompt that was active at that moment. This includes all
 sections injected by the harness: personas, skills, project memory
-(`SAN.md` / `CLAUDE.md`), and MCP server prompts. (Tool schemas are not
+(`AGENTS.md`), and MCP server prompts. (Tool schemas are not
 part of the system prompt — see Replay State below for those.)
 
 ### Replay State

--- a/docs/operations/benchmark.md
+++ b/docs/operations/benchmark.md
@@ -112,7 +112,7 @@ Requires a Bash tool call + counting + response.
 
 Measured separately from the runs above, on **San v1.22.0** and **Claude Code v2.1.220** (2026-07-26). This is the fixed cost the harness itself imposes on every conversation: the system prompt plus the tool schemas, sent before the user's first message.
 
-Both were measured in an empty directory with no project instructions (`CLAUDE.md` / `SAN.md`), no MCP servers, and no plugins, so the numbers reflect the harness alone.
+Both were measured in an empty directory with no project instructions (`AGENTS.md`), no MCP servers, and no plugins, so the numbers reflect the harness alone.
 
 | Component | San | Claude Code |
 |-----------|-----|-------------|

--- a/docs/reference/slash-commands.md
+++ b/docs/reference/slash-commands.md
@@ -19,7 +19,7 @@ Slash commands are typed directly in the TUI input box. They trigger local UI ac
 | `/tokenlimit` | View / set token budget |
 | `/context` | Show what is filling the context window, by category |
 | `/compact` | Compress conversation history |
-| `/init` | Create SAN.md and config files |
+| `/init` | Create AGENTS.md and config files |
 | `/memory` | View / edit memory files |
 | `/mcp` | Manage MCP servers |
 | `/plugin` | Manage plugins |
@@ -50,8 +50,8 @@ TestBuiltinCommandsUseModelsAndExcludeRemovedCommands
                                          — /models is registered; /model and /glob are absent
 TestExecuteCommandExit                    — /exit returns quit command
 TestExecuteCommandUnknown                 — unknown commands show error message
-TestHandleInitCommand                     — /init creates .san/SAN.md file
-TestHandleInitCommand (local)             — /init local creates .san/SAN.local.md
+TestHandleInitCommand                     — /init creates AGENTS.md at the project root
+TestHandleInitCommand (local)             — /init local creates AGENTS.local.md
 TestHandleInitCommand (rules)             — /init rules creates .san/rules directory
 TestHandleMemoryList                      — /memory list formats output with sections
 TestExecuteCommandLoopSchedulesRecurringPrompt
@@ -158,8 +158,8 @@ tmux send-keys -t t_cmds 'mkdir -p /tmp/init_test && cd /tmp/init_test && san' E
 sleep 2
 tmux send-keys -t t_cmds '/init' Enter
 sleep 3
-ls /tmp/init_test/.san/
-# Expected: SAN.md created under .san/
+ls /tmp/init_test/
+# Expected: AGENTS.md created at the project root
 
 # Test 8: Command suggestion dropdown
 tmux send-keys -t t_cmds C-c

--- a/internal/app/input/on_memory.go
+++ b/internal/app/input/on_memory.go
@@ -79,22 +79,25 @@ func (m *MemorySelector) EnterSelect(cwd string, width, height int) {
 
 	paths := system.GetAllMemoryPaths(cwd)
 	m.items = []memoryItem{
-		m.buildMemoryItem("Global", "global", paths.Global, cwd,
-			fmt.Sprintf("Saved in %s", kit.ShortenPath(paths.Global[0])),
+		m.buildMemoryItem("Global", "global", []string{paths.Global}, cwd,
+			fmt.Sprintf("Saved in %s", kit.ShortenPath(paths.Global)),
 			"Will be created on edit"),
 
 		m.buildMemoryItem("Project", "project", paths.Project, cwd,
-			"Checked in at .san/SAN.md",
+			"Checked in at AGENTS.md",
 			"Use /init to create"),
 
-		m.buildMemoryItem("Local", "local", paths.Local, cwd,
+		m.buildMemoryItem("Local", "local", []string{paths.Local}, cwd,
 			"Not committed (git-ignored)",
 			"Use /init local to create"),
 	}
 }
 
+// buildMemoryItem describes one memory level. searchPaths is a root-first
+// chain, so the nearest existing file is the one the agent actually obeys;
+// when none exists the first path is where the file would be created.
 func (m *MemorySelector) buildMemoryItem(label, level string, searchPaths []string, cwd, defaultDesc, createHint string) memoryItem {
-	foundPath := system.FindMemoryFile(searchPaths)
+	foundPath := system.FindNearestMemoryFile(searchPaths)
 	exists := foundPath != ""
 
 	path := foundPath
@@ -307,8 +310,6 @@ func HandleInitCommand(cwd, args string) (string, error) {
 	args = strings.TrimSpace(args)
 	parts := strings.Fields(args)
 
-	isClaude := strings.Contains(args, "--claude")
-
 	subCmd := ""
 	if len(parts) > 0 && !strings.HasPrefix(parts[0], "--") {
 		subCmd = strings.ToLower(parts[0])
@@ -318,31 +319,21 @@ func HandleInitCommand(cwd, args string) (string, error) {
 	case "local":
 		return handleInitLocal(cwd)
 	case "rules":
-		return handleInitRules(cwd, isClaude)
+		return handleInitRules(cwd)
 	default:
-		return handleInitProject(cwd, isClaude)
+		return handleInitProject(cwd)
 	}
 }
 
-func handleInitProject(cwd string, isClaude bool) (string, error) {
-	var targetDir, fileName string
-	if isClaude {
-		targetDir = filepath.Join(cwd, ".claude")
-		fileName = "CLAUDE.md"
-	} else {
-		targetDir = confdir.Dir(cwd)
-		fileName = "SAN.md"
-	}
-	filePath := filepath.Join(targetDir, fileName)
+func handleInitProject(cwd string) (string, error) {
+	root := system.ProjectRoot(cwd)
+	filePath := filepath.Join(root, system.InstructionFile)
 
 	if _, err := os.Stat(filePath); err == nil {
 		return fmt.Sprintf("File already exists: %s\nUse /memory edit to modify it.", filePath), nil
 	}
 
-	if err := os.MkdirAll(targetDir, 0o755); err != nil {
-		return "", fmt.Errorf("failed to create directory %s: %w", targetDir, err)
-	}
-	if err := os.WriteFile(filePath, []byte(getMemoryProjectTemplate(cwd)), 0o644); err != nil {
+	if err := os.WriteFile(filePath, []byte(getMemoryProjectTemplate(root)), 0o644); err != nil {
 		return "", fmt.Errorf("failed to write file %s: %w", filePath, err)
 	}
 
@@ -350,32 +341,24 @@ func handleInitProject(cwd string, isClaude bool) (string, error) {
 }
 
 func handleInitLocal(cwd string) (string, error) {
-	targetDir := confdir.Dir(cwd)
-	filePath := filepath.Join(targetDir, "SAN.local.md")
+	root := system.ProjectRoot(cwd)
+	filePath := filepath.Join(root, system.LocalInstructionFile)
 
 	if _, err := os.Stat(filePath); err == nil {
 		return fmt.Sprintf("File already exists: %s\nUse /memory edit local to modify it.", filePath), nil
 	}
 
-	if err := os.MkdirAll(targetDir, 0o755); err != nil {
-		return "", fmt.Errorf("failed to create directory %s: %w", targetDir, err)
-	}
 	if err := os.WriteFile(filePath, []byte(getMemoryLocalTemplate()), 0o644); err != nil {
 		return "", fmt.Errorf("failed to write file %s: %w", filePath, err)
 	}
 
-	memoryAddToGitignore(cwd, "SAN.local.md")
+	memoryAddToGitignore(root, system.LocalInstructionFile)
 
 	return fmt.Sprintf("Created %s (added to .gitignore)\n\nEdit with: /memory edit local", filePath), nil
 }
 
-func handleInitRules(cwd string, isClaude bool) (string, error) {
-	var rulesDir string
-	if isClaude {
-		rulesDir = filepath.Join(cwd, ".claude", "rules")
-	} else {
-		rulesDir = filepath.Join(confdir.Dir(cwd), "rules")
-	}
+func handleInitRules(cwd string) (string, error) {
+	rulesDir := filepath.Join(confdir.Dir(cwd), "rules")
 
 	if _, err := os.Stat(rulesDir); err == nil {
 		return fmt.Sprintf("Directory already exists: %s", rulesDir), nil
@@ -479,7 +462,7 @@ func handleMemoryList(cwd string) (string, error) {
 	sb.WriteString("╭─ Memory Files ─────────────────────────────────────╮\n")
 	sb.WriteString(memoryFormatBoxLine(""))
 
-	state.writeMemorySection(&sb, "Global", paths.Global, paths.GlobalRules, paths.Global[0], false)
+	state.writeMemorySection(&sb, "Global", []string{paths.Global}, paths.GlobalRules, paths.Global, false)
 	state.writeMemorySection(&sb, "Project", paths.Project, paths.ProjectRules, "/init", true)
 	state.writeMemoryLocalSection(&sb, paths.Local)
 
@@ -497,13 +480,13 @@ func handleMemoryList(cwd string) (string, error) {
 }
 
 func (s *memoryListState) writeMemorySection(sb *strings.Builder, label string, mainPaths []string, rulesDir, createHint string, isProject bool) {
-	mainFound := system.FindMemoryFile(mainPaths)
+	mainFound := system.ExistingMemoryFiles(mainPaths)
 	rulesFiles := system.ListRulesFiles(rulesDir)
 
-	if mainFound != "" || len(rulesFiles) > 0 {
+	if len(mainFound) > 0 || len(rulesFiles) > 0 {
 		sb.WriteString(memoryFormatBoxLine(fmt.Sprintf(" ● %s", label)))
-		if mainFound != "" {
-			s.writeMemoryFileLine(sb, mainFound, isProject)
+		for _, mf := range mainFound {
+			s.writeMemoryFileLine(sb, mf, isProject)
 		}
 		for _, rf := range rulesFiles {
 			s.writeMemoryFileLine(sb, rf, isProject)
@@ -515,11 +498,10 @@ func (s *memoryListState) writeMemorySection(sb *strings.Builder, label string, 
 	sb.WriteString(memoryFormatBoxLine(""))
 }
 
-func (s *memoryListState) writeMemoryLocalSection(sb *strings.Builder, localPaths []string) {
-	localFound := system.FindMemoryFile(localPaths)
-	if localFound != "" {
+func (s *memoryListState) writeMemoryLocalSection(sb *strings.Builder, localPath string) {
+	if _, err := os.Stat(localPath); err == nil {
 		sb.WriteString(memoryFormatBoxLine(" ● Local (git-ignored)"))
-		s.writeMemoryFileLine(sb, localFound, true)
+		s.writeMemoryFileLine(sb, localPath, true)
 	} else {
 		sb.WriteString(memoryFormatBoxLine(" ○ Local (not found)"))
 		sb.WriteString(memoryFormatBoxLine("   Create: /init local"))
@@ -622,11 +604,11 @@ func handleMemoryEdit(cwd, scope string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		memoryAddToGitignore(cwd, "SAN.local.md")
+		memoryAddToGitignore(system.ProjectRoot(cwd), system.LocalInstructionFile)
 		return filePath, nil
 
 	default:
-		filePath := system.FindMemoryFile(paths.Project)
+		filePath := system.FindNearestMemoryFile(paths.Project)
 		if filePath == "" {
 			// Return empty path; caller should display the message.
 			return "", nil
@@ -635,14 +617,12 @@ func handleMemoryEdit(cwd, scope string) (string, error) {
 	}
 }
 
-// ensureMemoryFile finds or creates a memory file from the given search paths.
-func ensureMemoryFile(searchPaths []string, template string) (string, error) {
-	filePath := system.FindMemoryFile(searchPaths)
-	if filePath != "" {
+// ensureMemoryFile returns filePath, creating it from template when absent.
+func ensureMemoryFile(filePath, template string) (string, error) {
+	if _, err := os.Stat(filePath); err == nil {
 		return filePath, nil
 	}
 
-	filePath = searchPaths[0]
 	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
 		return "", fmt.Errorf("failed to create directory: %w", err)
 	}
@@ -652,11 +632,12 @@ func ensureMemoryFile(searchPaths []string, template string) (string, error) {
 	return filePath, nil
 }
 
-func getMemoryProjectTemplate(cwd string) string {
-	projectName := filepath.Base(cwd)
-	return fmt.Sprintf(`# SAN.md
+func getMemoryProjectTemplate(root string) string {
+	projectName := filepath.Base(root)
+	return fmt.Sprintf(`# AGENTS.md
 
-This file provides guidance to San when working with code in this repository.
+This file provides guidance to San and other coding agents working in this
+repository.
 
 ## Project Overview
 
@@ -679,7 +660,7 @@ This file provides guidance to San when working with code in this repository.
 }
 
 func getMemoryGlobalTemplate() string {
-	return `# SAN.md
+	return `# AGENTS.md
 
 Global instructions for San (applies to all projects).
 
@@ -694,7 +675,7 @@ Global instructions for San (applies to all projects).
 }
 
 func getMemoryLocalTemplate() string {
-	return `# SAN.local.md
+	return `# AGENTS.local.md
 
 Local instructions for this project (not committed to git).
 
@@ -730,11 +711,11 @@ This file defines specific rules for San to follow.
 // CreateMemoryFile creates a memory file if it doesn't exist.
 func CreateMemoryFile(filePath, level, cwd string) error {
 	template := getMemoryTemplateForLevel(level, cwd)
-	if _, err := ensureMemoryFile([]string{filePath}, template); err != nil {
+	if _, err := ensureMemoryFile(filePath, template); err != nil {
 		return err
 	}
 	if level == "local" {
-		memoryAddToGitignore(cwd, "SAN.local.md")
+		memoryAddToGitignore(system.ProjectRoot(cwd), system.LocalInstructionFile)
 	}
 	return nil
 }
@@ -745,7 +726,7 @@ func getMemoryTemplateForLevel(level, cwd string) string {
 	case "global":
 		return getMemoryGlobalTemplate()
 	case "project":
-		return getMemoryProjectTemplate(cwd)
+		return getMemoryProjectTemplate(system.ProjectRoot(cwd))
 	case "local":
 		return getMemoryLocalTemplate()
 	default:

--- a/internal/app/kit/token.go
+++ b/internal/app/kit/token.go
@@ -93,7 +93,7 @@ func runTokens(class runeClass, n int) int {
 // far more tokens per character — measuring those against a prose ratio
 // understates the two largest categories in the breakdown. The same reasoning
 // separates CJK, which sits near one token per character; a single ratio reads
-// a Chinese SAN.md as a quarter of its real size.
+// a Chinese AGENTS.md as a quarter of its real size.
 //
 // The result is an estimate and is always presented as one: only the provider
 // reports exact counts, and /context labels which numbers are which.

--- a/internal/app/kit/token_test.go
+++ b/internal/app/kit/token_test.go
@@ -128,7 +128,7 @@ func TestGetEffectiveInputLimitWithoutModelIsZero(t *testing.T) {
 	}
 }
 
-// A single ratio over the whole string is what makes a Chinese SAN.md read as
+// A single ratio over the whole string is what makes a Chinese AGENTS.md read as
 // a quarter of its real cost, so the two scripts are checked against each
 // other rather than against exact numbers a tokenizer would have to confirm.
 func TestEstimateTokensCountsCJKHeavierThanASCII(t *testing.T) {

--- a/internal/command/registry.go
+++ b/internal/command/registry.go
@@ -39,7 +39,7 @@ func builtinCommands() []Info {
 		{Name: "tokenlimit", Description: "View or set token limits for current model"},
 		{Name: "context", Description: "Show what is filling the context window, by category"},
 		{Name: "compact", Description: "Summarize conversation to reduce context size"},
-		{Name: "init", Description: "Initialize memory files (SAN.md, local, rules)"},
+		{Name: "init", Description: "Initialize instruction files (AGENTS.md, local, rules)"},
 		{Name: "memory", Description: "View and manage memory files (list/show/edit) with @import support"},
 		{Name: "mcp", Description: "Manage MCP servers (add/edit/remove/connect/list)"},
 		{Name: "plugin", Description: "Manage plugins (list/install/marketplace/enable/disable/info)"},

--- a/internal/core/section.go
+++ b/internal/core/section.go
@@ -21,7 +21,7 @@ type Source string
 
 const (
 	Predefined Source = "predefined" // embedded templates
-	FromFile   Source = "file"       // SAN.md, AGENT.md, skill defs
+	FromFile   Source = "file"       // AGENTS.md, agent definitions, skill defs
 	Injected   Source = "injected"   // passed by parent agent or app layer
 	Dynamic    Source = "dynamic"    // generated at runtime (env, hook context)
 )

--- a/internal/core/system/builder_test.go
+++ b/internal/core/system/builder_test.go
@@ -89,7 +89,7 @@ func TestBuildPromptCaching(t *testing.T) {
 }
 
 func TestBuildPromptOmitsMemory(t *testing.T) {
-	// Memory (CLAUDE.md / SAN.md) no longer lives in the system prompt — it
+	// Memory (AGENTS.md) no longer lives in the system prompt — it
 	// rides on user messages as a <system-reminder> block via the harness's
 	// reminder service so memory edits don't invalidate the cache prefix.
 	sys := Build(core.ScopeMain,

--- a/internal/core/system/memory.go
+++ b/internal/core/system/memory.go
@@ -17,6 +17,19 @@ import (
 const (
 	maxImportDepth = 5
 
+	// InstructionFile is the industry-standard agent instruction file
+	// (https://agents.md). San reads it at the user level and at every
+	// directory from the project root down to the working directory.
+	InstructionFile = "AGENTS.md"
+
+	// LocalInstructionFile holds project instructions that stay out of git.
+	LocalInstructionFile = "AGENTS.local.md"
+
+	// instructionsByteCap bounds the combined size of the instruction files
+	// injected at session start, matching Codex's 32 KiB project_doc_max_bytes
+	// so a deep directory chain cannot crowd out the conversation.
+	instructionsByteCap = 32 * 1024
+
 	// AutoMemoryIndexName is the index file of the agent-written auto-memory
 	// store. Topic files (loaded on demand by the agent) live beside it.
 	AutoMemoryIndexName = "MEMORY.md"
@@ -82,7 +95,7 @@ func ResolveAutoMemoryDir(cwd, override string) string {
 // resolve it with ResolveAutoMemoryDir so a user-configured memory path is
 // honored (the reviewer prompt and the main-agent memory reminder both do).
 // Capped at autoMemoryByteCap. It is a distinct source from LoadMemoryFiles:
-// agent-written memory and user-authored SAN.md/CLAUDE.md instructions are
+// agent-written memory and user-authored AGENTS.md instructions are
 // injected as separate blocks and never mixed. Returns ("", false) when the
 // store is empty or absent. When the index exceeds the cap it is truncated on
 // a line boundary with a marker — topic files are read on demand and never
@@ -139,107 +152,134 @@ func LoadInstructions(cwd string) (user, project string) {
 	return strings.Join(userParts, "\n\n"), strings.Join(projectParts, "\n\n")
 }
 
-// LoadMemoryFiles loads all memory files with metadata.
-// Returns files in order: global, global rules, project, project rules, local.
+// LoadMemoryFiles loads every instruction file that applies to cwd, in the
+// order they are injected: user-level AGENTS.md, user rules, the project chain
+// from the repository root down to cwd, project rules, then the git-ignored
+// local override. Files closer to cwd are injected last so their instructions
+// win, mirroring the AGENTS.md convention shared by Codex and Cursor.
 func LoadMemoryFiles(cwd string) []MemoryFile {
-	var files []MemoryFile
 	homeDir, _ := os.UserHomeDir()
-	seen := make(map[string]bool)
+	l := &loader{seen: make(map[string]bool), remaining: instructionsByteCap}
 
 	userDir := confdir.Dir(homeDir)
-	userSources := []string{
-		filepath.Join(userDir, "SAN.md"),
-		filepath.Join(homeDir, ".claude", "CLAUDE.md"),
-	}
-	if f := loadMemoryFile(userSources, "global", seen); f != nil {
-		files = append(files, *f)
-	}
+	l.add(filepath.Join(userDir, InstructionFile), "global")
+	l.addRulesDirectory(filepath.Join(userDir, "rules"), "global")
 
-	userRulesDir := filepath.Join(userDir, "rules")
-	files = append(files, loadRulesDirectory(userRulesDir, "global", seen)...)
-
-	projectDir := confdir.Dir(cwd)
-	projectSources := []string{
-		filepath.Join(projectDir, "SAN.md"),
-		filepath.Join(cwd, "SAN.md"),
-		filepath.Join(cwd, ".claude", "CLAUDE.md"),
-		filepath.Join(cwd, "CLAUDE.md"),
+	for _, path := range ProjectInstructionChain(cwd) {
+		l.add(path, "project")
 	}
-	if f := loadMemoryFile(projectSources, "project", seen); f != nil {
-		files = append(files, *f)
-	}
+	l.addRulesDirectory(filepath.Join(confdir.Dir(cwd), "rules"), "project")
 
-	projectRulesDir := filepath.Join(projectDir, "rules")
-	files = append(files, loadRulesDirectory(projectRulesDir, "project", seen)...)
+	l.add(filepath.Join(ProjectRoot(cwd), LocalInstructionFile), "local")
 
-	localSources := []string{
-		filepath.Join(projectDir, "SAN.local.md"),
-	}
-	if f := loadMemoryFile(localSources, "local", seen); f != nil {
-		files = append(files, *f)
-	}
-
-	return files
+	return l.files
 }
 
-func loadMemoryFile(sources []string, level string, seen map[string]bool) *MemoryFile {
-	for _, src := range sources {
-		info, err := os.Stat(src)
-		if err != nil {
-			continue
+// ProjectRoot returns the repository root at or above cwd, falling back to cwd
+// when cwd is not inside a repository. Instruction discovery starts here.
+func ProjectRoot(cwd string) string {
+	dir := cwd
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir
 		}
-		if seen[src] {
-			continue
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return cwd
 		}
-		data, err := os.ReadFile(src)
-		if err != nil {
-			continue
-		}
-		content := strings.TrimSpace(string(data))
-		if content == "" {
-			continue
-		}
-		seen[src] = true
-		content = resolveImports(content, filepath.Dir(src), 0, seen)
-
-		log.Logger().Info("Loaded memory file",
-			zap.String("path", src),
-			zap.Int64("bytes", info.Size()),
-			zap.String("level", level))
-
-		return &MemoryFile{
-			Path:    src,
-			Size:    info.Size(),
-			Content: fmt.Sprintf("<!-- Source: %s -->\n%s", src, content),
-			Level:   level,
-		}
+		dir = parent
 	}
-	return nil
 }
 
-func loadRulesDirectory(dir string, level string, seen map[string]bool) []MemoryFile {
-	var files []MemoryFile
+// ProjectInstructionChain returns the AGENTS.md path for every directory from
+// the project root down to cwd, root first. Every file in the chain is loaded;
+// the ones nearer cwd are injected last and therefore take precedence.
+func ProjectInstructionChain(cwd string) []string {
+	root := ProjectRoot(cwd)
+	paths := []string{filepath.Join(root, InstructionFile)}
+
+	rel, err := filepath.Rel(root, cwd)
+	if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
+		return paths
+	}
+	dir := root
+	for _, segment := range strings.Split(rel, string(filepath.Separator)) {
+		dir = filepath.Join(dir, segment)
+		paths = append(paths, filepath.Join(dir, InstructionFile))
+	}
+	return paths
+}
+
+// loader accumulates instruction files while enforcing the combined byte cap.
+type loader struct {
+	seen      map[string]bool
+	remaining int
+	files     []MemoryFile
+}
+
+// add loads one instruction file, resolves its @imports, and appends it unless
+// the file is missing, empty, already loaded, or the byte cap is exhausted.
+func (l *loader) add(path, level string) {
+	info, err := os.Stat(path)
+	if err != nil || l.seen[path] {
+		return
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	content := strings.TrimSpace(string(data))
+	if content == "" {
+		return
+	}
+	l.seen[path] = true
+	content = resolveImports(content, filepath.Dir(path), 0, l.seen)
+
+	if l.remaining <= 0 {
+		log.Logger().Warn("Skipped instruction file: byte cap reached",
+			zap.String("path", path),
+			zap.Int("cap", instructionsByteCap))
+		return
+	}
+	if len(content) > l.remaining {
+		log.Logger().Warn("Truncated instruction file: byte cap reached",
+			zap.String("path", path),
+			zap.Int("cap", instructionsByteCap))
+		content = truncateOnLineBoundary(content, l.remaining) +
+			"\n\n<!-- instructions truncated: combined 32KB cap reached -->"
+	}
+	l.remaining -= len(content)
+
+	log.Logger().Info("Loaded instruction file",
+		zap.String("path", path),
+		zap.Int64("bytes", info.Size()),
+		zap.String("level", level))
+
+	l.files = append(l.files, MemoryFile{
+		Path:    path,
+		Size:    info.Size(),
+		Content: fmt.Sprintf("<!-- Source: %s -->\n%s", path, content),
+		Level:   level,
+	})
+}
+
+// addRulesDirectory loads every .md file in dir, alphabetically.
+func (l *loader) addRulesDirectory(dir, level string) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return files
+		return
 	}
-	var mdFiles []string
+	var paths []string
 	for _, entry := range entries {
-		if entry.IsDir() {
+		if entry.IsDir() || !strings.HasSuffix(strings.ToLower(entry.Name()), ".md") {
 			continue
 		}
-		name := entry.Name()
-		if strings.HasSuffix(strings.ToLower(name), ".md") {
-			mdFiles = append(mdFiles, filepath.Join(dir, name))
-		}
+		paths = append(paths, filepath.Join(dir, entry.Name()))
 	}
-	sort.Strings(mdFiles)
-	for _, path := range mdFiles {
-		if f := loadMemoryFile([]string{path}, level, seen); f != nil {
-			files = append(files, *f)
-		}
+	sort.Strings(paths)
+	for _, path := range paths {
+		l.add(path, level)
 	}
-	return files
 }
 
 // importRe matches @import directives in memory files (e.g., @file.md).
@@ -292,45 +332,49 @@ func resolveImports(content string, basePath string, depth int, seen map[string]
 	})
 }
 
-// MemoryPaths holds categorized memory file paths.
+// MemoryPaths holds the instruction paths San consults, for display and edit.
 type MemoryPaths struct {
-	Global       []string
-	GlobalRules  string
-	Project      []string
-	ProjectRules string
-	Local        []string
+	Global       string   // ~/.san/AGENTS.md
+	GlobalRules  string   // ~/.san/rules/
+	Project      []string // <root>/AGENTS.md ... <cwd>/AGENTS.md, root first
+	ProjectRules string   // <cwd>/.san/rules/
+	Local        string   // <root>/AGENTS.local.md
 }
 
-// GetAllMemoryPaths returns all memory paths organized by category.
+// GetAllMemoryPaths returns all instruction paths organized by category.
 func GetAllMemoryPaths(cwd string) MemoryPaths {
 	homeDir, _ := os.UserHomeDir()
+	userDir := confdir.Dir(homeDir)
 	return MemoryPaths{
-		Global: []string{
-			filepath.Join(confdir.Dir(homeDir), "SAN.md"),
-			filepath.Join(homeDir, ".claude", "CLAUDE.md"),
-		},
-		GlobalRules: filepath.Join(confdir.Dir(homeDir), "rules"),
-		Project: []string{
-			filepath.Join(confdir.Dir(cwd), "SAN.md"),
-			filepath.Join(cwd, "SAN.md"),
-			filepath.Join(cwd, ".claude", "CLAUDE.md"),
-			filepath.Join(cwd, "CLAUDE.md"),
-		},
+		Global:       filepath.Join(userDir, InstructionFile),
+		GlobalRules:  filepath.Join(userDir, "rules"),
+		Project:      ProjectInstructionChain(cwd),
 		ProjectRules: filepath.Join(confdir.Dir(cwd), "rules"),
-		Local: []string{
-			filepath.Join(confdir.Dir(cwd), "SAN.local.md"),
-		},
+		Local:        filepath.Join(ProjectRoot(cwd), LocalInstructionFile),
 	}
 }
 
-// FindMemoryFile returns the first existing file path from the given list.
-func FindMemoryFile(paths []string) string {
-	for _, path := range paths {
-		if _, err := os.Stat(path); err == nil {
-			return path
+// FindNearestMemoryFile returns the existing path closest to the working
+// directory -- the last entry of a root-first chain -- since the instructions
+// nearest cwd are the ones that win.
+func FindNearestMemoryFile(paths []string) string {
+	for i := len(paths) - 1; i >= 0; i-- {
+		if _, err := os.Stat(paths[i]); err == nil {
+			return paths[i]
 		}
 	}
 	return ""
+}
+
+// ExistingMemoryFiles returns the paths that exist, preserving chain order.
+func ExistingMemoryFiles(paths []string) []string {
+	var found []string
+	for _, path := range paths {
+		if _, err := os.Stat(path); err == nil {
+			found = append(found, path)
+		}
+	}
+	return found
 }
 
 // ListRulesFiles returns all .md files in a rules directory.

--- a/internal/core/system/memory_test.go
+++ b/internal/core/system/memory_test.go
@@ -104,63 +104,199 @@ func TestResolveImportsMaxDepth(t *testing.T) {
 }
 
 func TestLoadRulesDirectory(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "san-test-rules")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
+	tmpDir := t.TempDir()
 	rulesDir := filepath.Join(tmpDir, "rules")
 	if err := os.MkdirAll(rulesDir, 0o755); err != nil {
 		t.Fatalf("Failed to create rules dir: %v", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(rulesDir, "coding.md"), []byte("# Coding Rules"), 0o644); err != nil {
-		t.Fatalf("Failed to write coding.md: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(rulesDir, "security.md"), []byte("# Security Rules"), 0o644); err != nil {
-		t.Fatalf("Failed to write security.md: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(rulesDir, "readme.txt"), []byte("Ignore me"), 0o644); err != nil {
-		t.Fatalf("Failed to write readme.txt: %v", err)
-	}
+	writeFile(t, filepath.Join(rulesDir, "coding.md"), "# Coding Rules")
+	writeFile(t, filepath.Join(rulesDir, "security.md"), "# Security Rules")
+	writeFile(t, filepath.Join(rulesDir, "readme.txt"), "Ignore me")
 
-	seen := make(map[string]bool)
-	files := loadRulesDirectory(rulesDir, "project", seen)
+	l := &loader{seen: make(map[string]bool), remaining: instructionsByteCap}
+	l.addRulesDirectory(rulesDir, "project")
 
-	if len(files) != 2 {
-		t.Errorf("Expected 2 rule files, got %d", len(files))
+	if len(l.files) != 2 {
+		t.Fatalf("Expected 2 rule files, got %d", len(l.files))
 	}
-
-	if len(files) > 0 && !strings.Contains(files[0].Path, "coding.md") {
-		t.Errorf("Expected coding.md first (alphabetical), got: %s", files[0].Path)
+	if !strings.Contains(l.files[0].Path, "coding.md") {
+		t.Errorf("Expected coding.md first (alphabetical), got: %s", l.files[0].Path)
 	}
-	if len(files) > 1 && !strings.Contains(files[1].Path, "security.md") {
-		t.Errorf("Expected security.md second, got: %s", files[1].Path)
+	if !strings.Contains(l.files[1].Path, "security.md") {
+		t.Errorf("Expected security.md second, got: %s", l.files[1].Path)
 	}
 }
 
 func TestGetAllMemoryPaths(t *testing.T) {
-	cwd := "/test/project"
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cwd := t.TempDir()
+
 	paths := GetAllMemoryPaths(cwd)
 
-	// SAN.md (+ root) and CLAUDE.md (+ .claude).
-	if len(paths.Project) != 4 {
-		t.Errorf("Expected 4 project paths, got %d", len(paths.Project))
+	if want := filepath.Join(home, ".san", InstructionFile); paths.Global != want {
+		t.Errorf("Global = %q, want %q", paths.Global, want)
 	}
-	if !strings.Contains(paths.Project[0], "SAN.md") {
-		t.Errorf("Expected SAN.md preferred first, got: %s", paths.Project[0])
+	if len(paths.Project) != 1 || paths.Project[0] != filepath.Join(cwd, InstructionFile) {
+		t.Errorf("Project = %v, want [%s]", paths.Project, filepath.Join(cwd, InstructionFile))
+	}
+	if want := filepath.Join(cwd, LocalInstructionFile); paths.Local != want {
+		t.Errorf("Local = %q, want %q", paths.Local, want)
+	}
+	if want := filepath.Join(cwd, ".san", "rules"); paths.ProjectRules != want {
+		t.Errorf("ProjectRules = %q, want %q", paths.ProjectRules, want)
+	}
+}
+
+func TestProjectRootAndInstructionChain(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, ".git"), "gitdir: elsewhere")
+	sub := filepath.Join(root, "packages", "api")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
 	}
 
-	if len(paths.Local) != 1 {
-		t.Errorf("Expected 1 local path, got %d", len(paths.Local))
-	}
-	if !strings.Contains(paths.Local[0], "SAN.local.md") {
-		t.Errorf("Expected SAN.local.md in local paths, got: %s", paths.Local[0])
+	if got := ProjectRoot(sub); got != root {
+		t.Errorf("ProjectRoot(%s) = %q, want %q", sub, got, root)
 	}
 
-	if !strings.Contains(paths.ProjectRules, "rules") {
-		t.Errorf("Expected rules in project rules path, got: %s", paths.ProjectRules)
+	chain := ProjectInstructionChain(sub)
+	want := []string{
+		filepath.Join(root, InstructionFile),
+		filepath.Join(root, "packages", InstructionFile),
+		filepath.Join(sub, InstructionFile),
+	}
+	if len(chain) != len(want) {
+		t.Fatalf("chain = %v, want %v", chain, want)
+	}
+	for i := range want {
+		if chain[i] != want[i] {
+			t.Errorf("chain[%d] = %q, want %q", i, chain[i], want[i])
+		}
+	}
+
+	loose := t.TempDir()
+	if got := ProjectInstructionChain(loose); len(got) != 1 || got[0] != filepath.Join(loose, InstructionFile) {
+		t.Errorf("outside a repository the chain should be the cwd file alone, got %v", got)
+	}
+}
+
+func TestLoadMemoryFiles_NestedChainNearestLast(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, ".git"), "gitdir: elsewhere")
+	writeFile(t, filepath.Join(root, InstructionFile), "root instructions")
+
+	sub := filepath.Join(root, "packages", "api")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	writeFile(t, filepath.Join(sub, InstructionFile), "package instructions")
+
+	files := LoadMemoryFiles(sub)
+	if len(files) != 2 {
+		t.Fatalf("expected the root and package files, got %d: %v", len(files), files)
+	}
+	if !strings.Contains(files[0].Content, "root instructions") {
+		t.Errorf("expected the root file first, got: %s", files[0].Path)
+	}
+	if !strings.Contains(files[1].Content, "package instructions") {
+		t.Errorf("expected the package file last so it wins, got: %s", files[1].Path)
+	}
+}
+
+func TestLoadMemoryFiles_SectionOrder(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(home, ".san", InstructionFile), "user instructions")
+	writeFile(t, filepath.Join(home, ".san", "rules", "01-global.md"), "global rule")
+	writeFile(t, filepath.Join(root, InstructionFile), "project instructions")
+	writeFile(t, filepath.Join(root, ".san", "rules", "01-project.md"), "project rule")
+	writeFile(t, filepath.Join(root, LocalInstructionFile), "local instructions")
+
+	files := LoadMemoryFiles(root)
+	if len(files) != 5 {
+		t.Fatalf("expected 5 instruction files, got %d", len(files))
+	}
+
+	wantLevels := []string{"global", "global", "project", "project", "local"}
+	wantPaths := []string{
+		filepath.Join(home, ".san", InstructionFile),
+		filepath.Join(home, ".san", "rules", "01-global.md"),
+		filepath.Join(root, InstructionFile),
+		filepath.Join(root, ".san", "rules", "01-project.md"),
+		filepath.Join(root, LocalInstructionFile),
+	}
+	for i := range wantPaths {
+		if files[i].Level != wantLevels[i] || files[i].Path != wantPaths[i] {
+			t.Errorf("files[%d] = (%s, %s), want (%s, %s)", i, files[i].Level, files[i].Path, wantLevels[i], wantPaths[i])
+		}
+	}
+}
+
+func TestLoadMemoryFiles_ByteCap(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, ".git"), "gitdir: elsewhere")
+	writeFile(t, filepath.Join(root, InstructionFile), strings.Repeat("root line\n", instructionsByteCap/5))
+
+	sub := filepath.Join(root, "packages")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	writeFile(t, filepath.Join(sub, InstructionFile), "package instructions")
+
+	files := LoadMemoryFiles(sub)
+	if len(files) != 1 {
+		t.Fatalf("expected the oversized root file to exhaust the cap, got %d files", len(files))
+	}
+	if !strings.Contains(files[0].Content, "instructions truncated") {
+		t.Error("expected a truncation marker in the capped file")
+	}
+	if len(files[0].Content) > instructionsByteCap+len(files[0].Path)+200 {
+		t.Errorf("capped content is %d bytes, want at most ~%d", len(files[0].Content), instructionsByteCap)
+	}
+}
+
+func TestFindNearestMemoryFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	root := filepath.Join(tmpDir, "root.md")
+	nested := filepath.Join(tmpDir, "nested.md")
+	writeFile(t, root, "root")
+	writeFile(t, nested, "nested")
+
+	tests := []struct {
+		name     string
+		paths    []string
+		expected string
+	}{
+		{"nearest wins", []string{root, filepath.Join(tmpDir, "gone.md"), nested}, nested},
+		{"falls back to the only existing file", []string{root, filepath.Join(tmpDir, "gone.md")}, root},
+		{"no files exist", []string{filepath.Join(tmpDir, "a.md")}, ""},
+		{"empty chain", nil, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := FindNearestMemoryFile(tc.paths); got != tc.expected {
+				t.Errorf("FindNearestMemoryFile() = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestExistingMemoryFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	first := filepath.Join(tmpDir, "first.md")
+	second := filepath.Join(tmpDir, "second.md")
+	writeFile(t, first, "first")
+	writeFile(t, second, "second")
+
+	got := ExistingMemoryFiles([]string{first, filepath.Join(tmpDir, "gone.md"), second})
+	if len(got) != 2 || got[0] != first || got[1] != second {
+		t.Errorf("ExistingMemoryFiles() = %v, want [%s %s]", got, first, second)
 	}
 }
 
@@ -269,44 +405,13 @@ Nested content here`
 }
 
 func TestLoadMemoryFilesWithImports(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "san-test-memory-imports")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
 
-	sanDir := filepath.Join(tmpDir, ".san")
-	if err := os.MkdirAll(sanDir, 0o755); err != nil {
-		t.Fatalf("Failed to create .san dir: %v", err)
-	}
+	writeFile(t, filepath.Join(root, InstructionFile), "# Project Memory\n@extra.md\nEnd of memory")
+	writeFile(t, filepath.Join(root, "extra.md"), "## Extra Content\nThis was imported")
 
-	sanMdContent := `# Project Memory
-@extra.md
-End of memory`
-
-	extraContent := `## Extra Content
-This was imported`
-
-	if err := os.WriteFile(filepath.Join(sanDir, "SAN.md"), []byte(sanMdContent), 0o644); err != nil {
-		t.Fatalf("Failed to write SAN.md: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(sanDir, "extra.md"), []byte(extraContent), 0o644); err != nil {
-		t.Fatalf("Failed to write extra.md: %v", err)
-	}
-
-	files := LoadMemoryFiles(tmpDir)
-
-	var projectFile *MemoryFile
-	for i := range files {
-		if files[i].Level == "project" && strings.Contains(files[i].Path, "SAN.md") {
-			projectFile = &files[i]
-			break
-		}
-	}
-
-	if projectFile == nil {
-		t.Fatal("Expected to find project SAN.md file")
-	}
+	projectFile := findProjectFile(t, LoadMemoryFiles(root))
 
 	if !strings.Contains(projectFile.Content, "<!-- Imported: extra.md -->") {
 		t.Errorf("Expected import comment in content, got: %s", projectFile.Content)
@@ -316,218 +421,82 @@ This was imported`
 	}
 }
 
-func TestFindMemoryFile(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "san-test-find")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	existingFile := filepath.Join(tmpDir, "exists.md")
-	if err := os.WriteFile(existingFile, []byte("content"), 0o644); err != nil {
-		t.Fatalf("Failed to write file: %v", err)
-	}
-
-	tests := []struct {
-		name     string
-		paths    []string
-		expected string
-	}{
-		{
-			name:     "first existing file wins",
-			paths:    []string{filepath.Join(tmpDir, "notexist.md"), existingFile},
-			expected: existingFile,
-		},
-		{
-			name:     "no files exist",
-			paths:    []string{filepath.Join(tmpDir, "a.md"), filepath.Join(tmpDir, "b.md")},
-			expected: "",
-		},
-		{
-			name:     "empty paths",
-			paths:    []string{},
-			expected: "",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			result := FindMemoryFile(tc.paths)
-			if result != tc.expected {
-				t.Errorf("FindMemoryFile() = %q, expected %q", result, tc.expected)
-			}
-		})
-	}
-}
-
 func TestLoadInstructions(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "san-test-instructions")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	root := t.TempDir()
 
-	sanDir := filepath.Join(tmpDir, ".san")
-	if err := os.MkdirAll(sanDir, 0o755); err != nil {
-		t.Fatalf("Failed to create .san dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(sanDir, "SAN.md"), []byte("Project instructions here"), 0o644); err != nil {
-		t.Fatalf("Failed to write SAN.md: %v", err)
-	}
+	writeFile(t, filepath.Join(home, ".san", InstructionFile), "User instructions here")
+	writeFile(t, filepath.Join(root, InstructionFile), "Project instructions here")
+	writeFile(t, filepath.Join(root, LocalInstructionFile), "Local instructions here")
 
-	if err := os.WriteFile(filepath.Join(sanDir, "SAN.local.md"), []byte("Local instructions here"), 0o644); err != nil {
-		t.Fatalf("Failed to write SAN.local.md: %v", err)
+	user, project := LoadInstructions(root)
+
+	if !strings.Contains(user, "User instructions here") {
+		t.Errorf("user instructions should contain the user AGENTS.md content, got: %s", user)
 	}
-
-	user, project := LoadInstructions(tmpDir)
-
 	if !strings.Contains(project, "Project instructions here") {
-		t.Errorf("project instructions should contain SAN.md content, got: %s", project)
+		t.Errorf("project instructions should contain the AGENTS.md content, got: %s", project)
 	}
 	if !strings.Contains(project, "Local instructions here") {
-		t.Errorf("project instructions should contain SAN.local.md content, got: %s", project)
-	}
-
-	_ = user
-}
-
-func TestLoadMemoryFiles_PrefersSanPathsAndPreservesSectionOrder(t *testing.T) {
-	tmpHome := t.TempDir()
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpHome)
-
-	userSanDir := filepath.Join(tmpHome, ".san")
-	userClaudeDir := filepath.Join(tmpHome, ".claude")
-	projectSanDir := filepath.Join(tmpDir, ".san")
-	projectClaudeDir := filepath.Join(tmpDir, ".claude")
-
-	for _, dir := range []string{userSanDir, userClaudeDir, projectSanDir, projectClaudeDir, filepath.Join(userSanDir, "rules"), filepath.Join(projectSanDir, "rules")} {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			t.Fatalf("MkdirAll(%s): %v", dir, err)
-		}
-	}
-
-	if err := os.WriteFile(filepath.Join(userSanDir, "SAN.md"), []byte("user san"), 0o644); err != nil {
-		t.Fatalf("WriteFile(user SAN): %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(userClaudeDir, "CLAUDE.md"), []byte("user claude fallback"), 0o644); err != nil {
-		t.Fatalf("WriteFile(user CLAUDE): %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(userSanDir, "rules", "01-global.md"), []byte("global rule"), 0o644); err != nil {
-		t.Fatalf("WriteFile(global rule): %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectSanDir, "SAN.md"), []byte("project san"), 0o644); err != nil {
-		t.Fatalf("WriteFile(project SAN): %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectClaudeDir, "CLAUDE.md"), []byte("project claude fallback"), 0o644); err != nil {
-		t.Fatalf("WriteFile(project CLAUDE): %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectSanDir, "rules", "01-project.md"), []byte("project rule"), 0o644); err != nil {
-		t.Fatalf("WriteFile(project rule): %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(projectSanDir, "SAN.local.md"), []byte("project local"), 0o644); err != nil {
-		t.Fatalf("WriteFile(local SAN): %v", err)
-	}
-
-	files := LoadMemoryFiles(tmpDir)
-	if len(files) != 5 {
-		t.Fatalf("expected 5 memory files, got %d", len(files))
-	}
-
-	if files[0].Level != "global" || !strings.Contains(files[0].Path, filepath.Join(".san", "SAN.md")) {
-		t.Fatalf("expected global SAN.md first, got level=%q path=%q", files[0].Level, files[0].Path)
-	}
-	if strings.Contains(files[0].Content, "user claude fallback") {
-		t.Fatal("expected user .san/SAN.md to take precedence over ~/.claude/CLAUDE.md")
-	}
-	if files[1].Level != "global" {
-		t.Fatalf("expected global rules second, got level=%q", files[1].Level)
-	}
-	if files[2].Level != "project" || !strings.Contains(files[2].Path, filepath.Join(".san", "SAN.md")) {
-		t.Fatalf("expected project SAN.md third, got level=%q path=%q", files[2].Level, files[2].Path)
-	}
-	if strings.Contains(files[2].Content, "project claude fallback") {
-		t.Fatal("expected project .san/SAN.md to take precedence over project CLAUDE.md")
-	}
-	if files[3].Level != "project" {
-		t.Fatalf("expected project rules fourth, got level=%q", files[3].Level)
-	}
-	if files[4].Level != "local" || !strings.Contains(files[4].Path, "SAN.local.md") {
-		t.Fatalf("expected local SAN.local.md last, got level=%q path=%q", files[4].Level, files[4].Path)
+		t.Errorf("project instructions should contain the AGENTS.local.md content, got: %s", project)
 	}
 }
 
 func TestMemory_ImportChain(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "san-test-import-chain")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
 
-	sanDir := filepath.Join(tmpDir, ".san")
-	if err := os.MkdirAll(sanDir, 0o755); err != nil {
-		t.Fatalf("Failed to create .san dir: %v", err)
-	}
+	writeFile(t, filepath.Join(root, InstructionFile), "# Root\n@a.md")
+	writeFile(t, filepath.Join(root, "a.md"), "## Level A\n@b.md")
+	writeFile(t, filepath.Join(root, "b.md"), "### Level B\nFinal content from B")
 
-	sanMdContent := "# Root\n@a.md"
-	aMdContent := "## Level A\n@b.md"
-	bMdContent := "### Level B\nFinal content from B"
+	projectFile := findProjectFile(t, LoadMemoryFiles(root))
 
-	if err := os.WriteFile(filepath.Join(sanDir, "SAN.md"), []byte(sanMdContent), 0o644); err != nil {
-		t.Fatalf("Failed to write SAN.md: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(sanDir, "a.md"), []byte(aMdContent), 0o644); err != nil {
-		t.Fatalf("Failed to write a.md: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(sanDir, "b.md"), []byte(bMdContent), 0o644); err != nil {
-		t.Fatalf("Failed to write b.md: %v", err)
-	}
-
-	files := LoadMemoryFiles(tmpDir)
-
-	var projectFile *MemoryFile
-	for i := range files {
-		if files[i].Level == "project" && strings.Contains(files[i].Path, "SAN.md") {
-			projectFile = &files[i]
-			break
+	for _, want := range []string{"Level A", "Final content from B", "<!-- Imported: a.md -->", "<!-- Imported: b.md -->"} {
+		if !strings.Contains(projectFile.Content, want) {
+			t.Errorf("Expected %q in resolved output; got: %s", want, projectFile.Content)
 		}
-	}
-
-	if projectFile == nil {
-		t.Fatal("Expected to find project SAN.md file")
-	}
-
-	if !strings.Contains(projectFile.Content, "Level A") {
-		t.Errorf("Expected 'Level A' content (from a.md) in resolved output; got: %s", projectFile.Content)
-	}
-	if !strings.Contains(projectFile.Content, "Final content from B") {
-		t.Errorf("Expected 'Final content from B' (from b.md) in resolved output; got: %s", projectFile.Content)
-	}
-	if !strings.Contains(projectFile.Content, "<!-- Imported: a.md -->") {
-		t.Errorf("Expected import comment for a.md; got: %s", projectFile.Content)
-	}
-	if !strings.Contains(projectFile.Content, "<!-- Imported: b.md -->") {
-		t.Errorf("Expected import comment for b.md; got: %s", projectFile.Content)
 	}
 }
 
 func TestMemory_MissingFile_NoError(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "san-test-missing-sanmd")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
 
-	files := LoadMemoryFiles(tmpDir)
-
+	files := LoadMemoryFiles(root)
 	for _, f := range files {
-		if f.Level == "project" && strings.Contains(f.Path, tmpDir) {
-			t.Errorf("Did not expect a project memory file when SAN.md is absent, got: %s", f.Path)
+		if f.Level == "project" && strings.Contains(f.Path, root) {
+			t.Errorf("Did not expect a project instruction file when AGENTS.md is absent, got: %s", f.Path)
 		}
 	}
 
-	_, project := LoadInstructions(tmpDir)
-	_ = project
+	if _, project := LoadInstructions(root); project != "" {
+		t.Errorf("Expected no project instructions, got: %s", project)
+	}
+}
+
+// writeFile writes content to path, creating parent directories as needed.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+// findProjectFile returns the single project-level instruction file.
+func findProjectFile(t *testing.T, files []MemoryFile) MemoryFile {
+	t.Helper()
+	for _, f := range files {
+		if f.Level == "project" {
+			return f
+		}
+	}
+	t.Fatal("Expected a project-level AGENTS.md in the loaded files")
+	return MemoryFile{}
 }
 
 func TestResolveAutoMemoryDir(t *testing.T) {

--- a/internal/hook/hooks_test.go
+++ b/internal/hook/hooks_test.go
@@ -76,7 +76,7 @@ func Test_getMatchValue(t *testing.T) {
 		{TaskCreated, HookInput{TaskSubject: "Explore"}, "Explore"},
 		{TaskCompleted, HookInput{TaskSubject: "Plan"}, "Plan"},
 		{ConfigChange, HookInput{Source: "user_settings"}, "user_settings"},
-		{InstructionsLoaded, HookInput{FilePath: "/tmp/SAN.md"}, "/tmp/SAN.md"},
+		{InstructionsLoaded, HookInput{FilePath: "/tmp/AGENTS.md"}, "/tmp/AGENTS.md"},
 		{CwdChanged, HookInput{NewCwd: "/tmp/worktree"}, "/tmp/worktree"},
 		{FileChanged, HookInput{FilePath: "/tmp/file.txt"}, "/tmp/file.txt"},
 		{PreCompact, HookInput{Trigger: "auto"}, "auto"},

--- a/internal/reminder/reminder.go
+++ b/internal/reminder/reminder.go
@@ -30,7 +30,7 @@ const (
 	ProviderMemoryProject   = "memory-project"
 	// ProviderMemoryAuto is the agent-written memory store maintained by the
 	// L1 reviewer (internal/selflearn). It is a distinct source from the
-	// user-authored SAN.md/CLAUDE.md so agent-written and user-authored
+	// user-authored AGENTS.md so agent-written and user-authored
 	// instructions are never mixed in the prompt. See
 	// notes/active/l1-background-review.md §4.5.
 	ProviderMemoryAuto = "memory-auto"

--- a/internal/subagent/executor.go
+++ b/internal/subagent/executor.go
@@ -45,7 +45,7 @@ type Executor struct {
 	hooks                      hook.Handler
 	sessionStore               SubagentSessionStore // Optional: when set, subagent sessions are persisted
 	parentSessionID            string               // Parent session ID for linking subagent sessions
-	projectInstructions        string               // project memory (CLAUDE.md/AGENTS.md) for edit-capable subagents
+	projectInstructions        string               // project memory (AGENTS.md) for edit-capable subagents
 	skillsPrompt               string               // available skills section for capable subagents
 	mcpTools                   mcp.Tools            // tool schemas + execution
 	mcpServers                 mcp.Servers          // connect/disconnect for per-subagent server sets
@@ -114,7 +114,7 @@ func (e *Executor) currentParentPermissionMode() PermissionMode {
 }
 
 // SetProjectInstructions provides the project's instruction memory
-// (CLAUDE.md/AGENTS.md). Edit-capable subagents receive it as a
+// (AGENTS.md). Edit-capable subagents receive it as a
 // <system-reminder> so their changes follow project conventions; read-only
 // agents do not carry it.
 func (e *Executor) SetProjectInstructions(instructions string) {


### PR DESCRIPTION
## What & why

Project instructions were read from `SAN.md` / `CLAUDE.md` at a handful of fixed
locations, first match wins. That is neither the convention the ecosystem
settled on nor enough for a monorepo, where a package needs instructions of its
own.

San now follows the [AGENTS.md](https://agents.md) standard, with the discovery
semantics Codex and Cursor share: the file nearest the working directory wins.

### What loads now

```
global   ~/.san/AGENTS.md            then ~/.san/rules/*.md
project  <git root>/AGENTS.md -> ... -> <cwd>/AGENTS.md   (all of them, root first)
         <cwd>/.san/rules/*.md
local    <git root>/AGENTS.local.md  (git-ignored)
cap      32KB combined, matching Codex's project_doc_max_bytes
```

Files nearer the working directory are injected last, so their instructions
take precedence. Everything past the cap is truncated on a line boundary with a
marker rather than silently dropped.

### Breaking change

`SAN.md`, `.san/SAN.md`, `SAN.local.md`, `CLAUDE.md`, `.claude/CLAUDE.md` and
`~/.claude/CLAUDE.md` are no longer read anywhere — no fallback, no shim. A
project that wants its instructions back renames the file to `AGENTS.md`; a
user-level file moves to `~/.san/AGENTS.md`.

`/init --claude` is gone with them.

### Command surface

- `/init` writes `<root>/AGENTS.md` (was `.san/SAN.md`)
- `/init local` writes `<root>/AGENTS.local.md` and adds it to `.gitignore`
- `/memory list` shows every file in the chain instead of only the first
- `/memory edit` opens the file nearest the working directory

### Implementation

Discovery moved into three helpers in `internal/core/system/memory.go` —
`ProjectRoot` (walks up for `.git`, handles worktrees, falls back to cwd),
`ProjectInstructionChain` (root-first path chain) and `FindNearestMemoryFile`
(chain-tail-first lookup). The old first-match-wins `loadMemoryFile` /
`loadRulesDirectory` pair is replaced by a `loader` that walks the chain while
keeping a byte budget, since the semantics changed from "take one" to "take all
in order, and account for size".

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [x] Other: breaking change — legacy instruction filenames are dropped outright

## Testing

```bash
go test ./...        # all packages pass
make lint            # golangci-lint: 0 issues; layercheck: no violations
```

New coverage in `internal/core/system/memory_test.go` for the root→cwd chain
(`TestProjectRootAndInstructionChain`, `TestLoadMemoryFiles_NestedChainNearestLast`),
section order (`TestLoadMemoryFiles_SectionOrder`), the byte cap
(`TestLoadMemoryFiles_ByteCap`) and nearest-wins lookup
(`TestFindNearestMemoryFile`).

Existing cases that called `LoadMemoryFiles` now pin `HOME` to a temp dir —
several of them were reading the developer's real `~/.san` and would have passed
regardless of the code.

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, …)
- [x] All commits signed off (`git commit -s`) — certifies the [DCO](https://developercertificate.org)
- [x] Tests pass locally
- [x] Docs updated (if behavior or config changed)
- [x] Read and follow the [Code of Conduct](CODE_OF_CONDUCT.md)
