### PR TITLE
fix(tui): three scrollback rendering defects found verifying #495

### DIFF
--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -165,7 +165,7 @@ func renderNestedToolBody(content string) string {
 
 	var sb strings.Builder
 	for line := range strings.SplitSeq(content, "\n") {
-		line = afterLastCarriageReturn(line)
+		line = visibleLine(line)
 		if strings.TrimSpace(line) == "" {
 			sb.WriteString(strings.Repeat(" ", lipgloss.Width(nestedBodyPrefix)) + "\n")
 			continue
@@ -175,17 +175,11 @@ func renderNestedToolBody(content string) string {
 	return sb.String()
 }
 
-// afterLastCarriageReturn keeps only what a terminal would have left on screen.
-//
-// A tool that draws progress in place — git's "Rebasing (1/3)", a download
-// meter — ends each update with a carriage return and writes the next over it,
-// so everything before the final one was overwritten and never read. Passing
-// the whole line through puts that carriage return inside San's own gutter and
-// the terminal obeys it: the row restarts at column 0 and the "┊" connector is
-// gone, which is the stray unindented line in a rebase's output.
-//
-// A trailing one is CRLF, not an overwrite, so it goes first.
-func afterLastCarriageReturn(line string) string {
+// visibleLine drops the progress a tool drew in place and then wrote over —
+// git's "Rebasing (1/3)\r…". Left in, the carriage return lands inside the "┊"
+// gutter and the terminal restarts the row at column 0, connector and all. A
+// trailing one is CRLF, not an overwrite.
+func visibleLine(line string) string {
 	line = strings.TrimSuffix(line, "\r")
 	if i := strings.LastIndexByte(line, '\r'); i >= 0 {
 		return line[i+1:]
@@ -194,7 +188,7 @@ func afterLastCarriageReturn(line string) string {
 }
 
 func renderNestedToolBodyLine(line string) string {
-	return toolResultStyle.Render(nestedBodyPrefix+afterLastCarriageReturn(line)) + "\n"
+	return toolResultStyle.Render(nestedBodyPrefix+visibleLine(line)) + "\n"
 }
 
 func renderNestedToolBodyContinuous(content string) string {

--- a/internal/app/conv/tool_render.go
+++ b/internal/app/conv/tool_render.go
@@ -165,6 +165,7 @@ func renderNestedToolBody(content string) string {
 
 	var sb strings.Builder
 	for line := range strings.SplitSeq(content, "\n") {
+		line = afterLastCarriageReturn(line)
 		if strings.TrimSpace(line) == "" {
 			sb.WriteString(strings.Repeat(" ", lipgloss.Width(nestedBodyPrefix)) + "\n")
 			continue
@@ -174,8 +175,26 @@ func renderNestedToolBody(content string) string {
 	return sb.String()
 }
 
+// afterLastCarriageReturn keeps only what a terminal would have left on screen.
+//
+// A tool that draws progress in place — git's "Rebasing (1/3)", a download
+// meter — ends each update with a carriage return and writes the next over it,
+// so everything before the final one was overwritten and never read. Passing
+// the whole line through puts that carriage return inside San's own gutter and
+// the terminal obeys it: the row restarts at column 0 and the "┊" connector is
+// gone, which is the stray unindented line in a rebase's output.
+//
+// A trailing one is CRLF, not an overwrite, so it goes first.
+func afterLastCarriageReturn(line string) string {
+	line = strings.TrimSuffix(line, "\r")
+	if i := strings.LastIndexByte(line, '\r'); i >= 0 {
+		return line[i+1:]
+	}
+	return line
+}
+
 func renderNestedToolBodyLine(line string) string {
-	return toolResultStyle.Render(nestedBodyPrefix+line) + "\n"
+	return toolResultStyle.Render(nestedBodyPrefix+afterLastCarriageReturn(line)) + "\n"
 }
 
 func renderNestedToolBodyContinuous(content string) string {

--- a/internal/app/conv/tool_render_test.go
+++ b/internal/app/conv/tool_render_test.go
@@ -1,0 +1,43 @@
+package conv
+
+import (
+	"strings"
+	"testing"
+
+	xansi "github.com/charmbracelet/x/ansi"
+)
+
+// A tool that draws progress in place ends each update with a carriage return.
+// Rendering the whole line puts that carriage return inside the "┊" gutter and
+// the terminal obeys it — the row restarts at column 0 and the connector is
+// gone. git rebase is the one people see: "Rebasing (1/3)\rAuto-merging f.go".
+func TestNestedToolBodyDropsOverwrittenProgress(t *testing.T) {
+	body := renderNestedToolBody("Rebasing (1/1)\rAuto-merging f.txt\nCONFLICT (content): Merge conflict")
+
+	if strings.Contains(body, "\r") {
+		t.Fatalf("a carriage return reached the frame: %q", body)
+	}
+	if strings.Contains(body, "Rebasing (1/1)") {
+		t.Errorf("overwritten progress was rendered: %q", body)
+	}
+	for _, line := range strings.Split(strings.TrimRight(body, "\n"), "\n") {
+		if !strings.HasPrefix(xansi.Strip(line), "  ┊ ") && strings.TrimSpace(xansi.Strip(line)) != "" {
+			t.Errorf("line escaped the gutter: %q", line)
+		}
+	}
+	for _, want := range []string{"Auto-merging f.txt", "CONFLICT (content): Merge conflict"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body lost %q: %q", want, body)
+		}
+	}
+}
+
+// CRLF is a line ending, not an overwrite: the text before it is what was shown.
+func TestNestedToolBodyKeepsCRLFContent(t *testing.T) {
+	body := renderNestedToolBody("first line\r\nsecond line\r")
+	for _, want := range []string{"first line", "second line"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body lost %q: %q", want, body)
+		}
+	}
+}

--- a/internal/app/conv/tool_render_test.go
+++ b/internal/app/conv/tool_render_test.go
@@ -7,10 +7,8 @@ import (
 	xansi "github.com/charmbracelet/x/ansi"
 )
 
-// A tool that draws progress in place ends each update with a carriage return.
-// Rendering the whole line puts that carriage return inside the "┊" gutter and
-// the terminal obeys it — the row restarts at column 0 and the connector is
-// gone. git rebase is the one people see: "Rebasing (1/3)\rAuto-merging f.go".
+// A carriage return left in the line lands inside the "┊" gutter, and the
+// terminal restarts the row at column 0. git rebase is where people see it.
 func TestNestedToolBodyDropsOverwrittenProgress(t *testing.T) {
 	body := renderNestedToolBody("Rebasing (1/1)\rAuto-merging f.txt\nCONFLICT (content): Merge conflict")
 

--- a/internal/app/model_scrollback.go
+++ b/internal/app/model_scrollback.go
@@ -4,12 +4,9 @@
 // terminal's native scrollback above.
 //
 // The frame rule everything here obeys: insertAbove prints above the managed
-// frame and Bubble Tea's inline renderer only ever redraws the frame's current
-// extent, so whatever the frame holds at that moment stays on screen and any
-// row it stops holding is left behind. Both are permanent — native scrollback
-// cannot be rewritten. Hence a chunk no taller than the room above the frame,
-// a queue that waits for a panel to close, and a handoff copy that keeps the
-// frame from shrinking mid-print.
+// frame, and the inline renderer only redraws the frame's current extent — so
+// what the frame holds then stays on screen, and any row it stops holding is
+// left behind. Both are permanent; scrollback cannot be rewritten.
 package app
 
 import (
@@ -31,14 +28,8 @@ type pendingScrollbackPrint struct {
 	id        uint64
 	remaining string
 	current   string
-	// frameRows is how tall the chat section stood while the live tail still
-	// held what this print carries. The handoff copy is padded to it, so
-	// committing cannot shorten the frame — see pendingScrollbackView.
-	frameRows int
-	// started marks the first chunk having been prepared, after which part of
-	// the payload is already in scrollback and only the chunk in flight may be
-	// drawn — see pendingScrollbackView.
-	started bool
+	frameRows int  // chat rows this print's content occupied in the live tail
+	started   bool // first chunk prepared; the rest is no longer the frame's job
 }
 
 func printScrollback(id uint64) tea.Cmd {
@@ -223,8 +214,7 @@ func (m *model) handleFlushResult(msg flushResultMsg) tea.Cmd {
 
 	var cmds []tea.Cmd
 	if msg.printed != "" {
-		// No row budget: a streamed block leaves the live tail as its rendered
-		// self, so the copy already stands the same height as what it replaced.
+		// No budget: a streamed block leaves the tail as its rendered self.
 		cmds = append(cmds, m.queueScrollbackPrint(msg.printed, 0))
 	}
 	// Catch a block that completed while this one rendered — Stream.Active means
@@ -257,10 +247,8 @@ func (m *model) renderAndCommit(checkReady bool) []tea.Cmd {
 	var parts []string
 	lastIdx := len(m.conv.Messages) - 1
 	params := m.messageRenderParams()
-	// Measured before the loop below empties the live tail: the rows the handoff
-	// copy has to stand in for. The composer and status bar are left out because
-	// a commit does not touch them, and counting them would overshoot.
-	preCommitRows := viewRows(conv.RenderActiveContent(params))
+	// What the loop below is about to take out of the frame.
+	preCommitRows := rowCount(conv.RenderActiveContent(params))
 
 	for i := m.conv.CommittedCount; i < len(m.conv.Messages); i++ {
 		msg := m.conv.Messages[i]
@@ -421,15 +409,11 @@ func (m *model) useMinimalScrollbackFrame() {
 	m.flush.minimizeForPrint = true
 }
 
-// trimTrailingBlanks drops the empty cells a full-width buffer leaves at the end
-// of a row.
-//
-// They cost nothing at the width they were printed at, and native scrollback is
-// immutable, so they are still there when the window narrows — where the
-// terminal rewraps a row of visible text plus padding into two, the second all
-// spaces. That is the blank line a resize inserts between committed blocks.
-// Styled trailing cells are kept: a background color is content, not padding.
-func trimTrailingBlanks(line uv.Line) uv.Line {
+// trimPadding drops the padding a full-width buffer leaves on a row.
+// Free at the width it was printed at, but scrollback is immutable: narrow the
+// window and text-plus-padding rewraps into two rows, the second all spaces.
+// Styled cells stay — a background colour is content.
+func trimPadding(line uv.Line) uv.Line {
 	end := len(line)
 	for end > 0 && (line[end-1].IsZero() || line[end-1].Equal(&uv.EmptyCell)) {
 		end--
@@ -472,11 +456,10 @@ func renderScrollbackLines(lines []uv.Line) string {
 	if len(lines) == 0 {
 		return ""
 	}
-	trimmed := make(uv.Lines, len(lines))
 	for i, line := range lines {
-		trimmed[i] = trimTrailingBlanks(line)
+		lines[i] = trimPadding(line)
 	}
-	if rendered := trimmed.Render(); rendered != "" {
+	if rendered := uv.Lines(lines).Render(); rendered != "" {
 		return rendered
 	}
 	// insertAbove ignores an empty string. A reset sequence represents one
@@ -508,9 +491,7 @@ func (m model) welcomeBannerText() string {
 }
 
 // pendingScrollbackView is the handoff copy: the queued chunk stays drawn in the
-// managed view until its Println has been processed, so committing — which
-// empties the live tail first — cannot shrink the frame mid-print and leave the
-// plain streaming tail on screen for insertAbove to print underneath.
+// frame until its Println lands, so committing cannot shrink the frame mid-print.
 //
 // Restored from e02ed422, which 74ac1647 dropped as redundant beside the FIFO
 // and the renderer's flush barrier. It is not: the barrier fixes *when*
@@ -519,13 +500,10 @@ func (m model) pendingScrollbackView() string {
 	if len(m.flush.pendingPrints) == 0 {
 		return ""
 	}
+	// Until the first chunk goes out the whole payload stands in for the tail;
+	// after it, only the chunk in flight. Holding the remainder would swell the
+	// frame, and the next chunk's insertAbove welds that into its own output.
 	head := m.flush.pendingPrints[0]
-	// Before the first chunk the whole payload stands in for the tail that
-	// committing just emptied. After it, part is already in scrollback and only
-	// the chunk in flight may be drawn: a payload too tall for the room above
-	// the frame is printed in several, and holding the remainder here would put
-	// it in the frame for the next chunk's insertAbove to weld into the middle
-	// of the output it belongs to.
 	handoff := head.current
 	if !head.started {
 		handoff = head.remaining
@@ -533,16 +511,13 @@ func (m model) pendingScrollbackView() string {
 	if handoff == "" {
 		return ""
 	}
-	// The rendered block is usually shorter than the plain wrapped tail it
-	// replaces, and every row of that difference is one the frame would vacate.
-	for rows := viewRows(handoff); rows < head.frameRows; rows++ {
-		handoff += "\n"
-	}
-	return handoff
+	// The rendered block is shorter than the plain tail it replaces, and every
+	// row of the difference is one the frame would vacate.
+	return handoff + strings.Repeat("\n", max(head.frameRows-rowCount(handoff), 0))
 }
 
-// viewRows counts the rows a rendered section occupies.
-func viewRows(s string) int {
+// rowCount is how many terminal rows a rendered section occupies.
+func rowCount(s string) int {
 	if s == "" {
 		return 0
 	}

--- a/internal/app/model_scrollback.go
+++ b/internal/app/model_scrollback.go
@@ -415,13 +415,24 @@ func (m *model) useMinimalScrollbackFrame() {
 // trimPadding drops the padding a full-width buffer leaves on a row.
 // Free at the width it was printed at, but scrollback is immutable: narrow the
 // window and text-plus-padding rewraps into two rows, the second all spaces.
-// Styled cells stay — a background colour is content.
+//
+// A trailing space counts as padding whatever foreground or bold it inherited —
+// none of that shows on a space. Only a background or an underline does, and
+// those are content.
 func trimPadding(line uv.Line) uv.Line {
 	end := len(line)
-	for end > 0 && (line[end-1].IsZero() || line[end-1].Equal(&uv.EmptyCell)) {
+	for end > 0 && isPadding(&line[end-1]) {
 		end--
 	}
 	return line[:end]
+}
+
+func isPadding(c *uv.Cell) bool {
+	if c.IsZero() || c.Equal(&uv.EmptyCell) {
+		return true
+	}
+	return c.Content == " " && c.Link.IsZero() &&
+		c.Style.Bg == nil && c.Style.UnderlineColor == nil && c.Style.Underline == uv.UnderlineNone
 }
 
 // scrollbackPhysicalLines decomposes content exactly as Bubble Tea's

--- a/internal/app/model_scrollback.go
+++ b/internal/app/model_scrollback.go
@@ -31,6 +31,14 @@ type pendingScrollbackPrint struct {
 	id        uint64
 	remaining string
 	current   string
+	// frameRows is how tall the chat section stood while the live tail still
+	// held what this print carries. The handoff copy is padded to it, so
+	// committing cannot shorten the frame — see pendingScrollbackView.
+	frameRows int
+	// started marks the first chunk having been prepared, after which part of
+	// the payload is already in scrollback and only the chunk in flight may be
+	// drawn — see pendingScrollbackView.
+	started bool
 }
 
 func printScrollback(id uint64) tea.Cmd {
@@ -78,13 +86,10 @@ type flushSnapshot struct {
 // conversation block (thinking, content) off the UI goroutine and commits the
 // result to scrollback. See FlushStreamingBlocks and model_scrollback.go.
 type flushState struct {
-	rendering   bool             // one render in flight at a time, so Printlns stay ordered
-	renderer    *conv.MDRenderer // background renderer, off the live-view MDRenderer's mutex
-	width       int              // width the renderer was built for; rebuild when it changes
-	nextPrintID uint64           // monotonic identity for queued scrollback prints
-	// handoffRows is how tall the chat section stood while the live tail still
-	// held the blocks the queued print carries; the copy is padded to it.
-	handoffRows      int
+	rendering        bool                     // one render in flight at a time, so Printlns stay ordered
+	renderer         *conv.MDRenderer         // background renderer, off the live-view MDRenderer's mutex
+	width            int                      // width the renderer was built for; rebuild when it changes
+	nextPrintID      uint64                   // monotonic identity for queued scrollback prints
 	pendingPrints    []pendingScrollbackPrint // FIFO queue; only the head may be in flight
 	minimizeForPrint bool                     // temporarily shrink a full-height frame before insertAbove
 	frameForPrint    *tea.View                // freeze insertAbove geometry until the print completes
@@ -218,7 +223,9 @@ func (m *model) handleFlushResult(msg flushResultMsg) tea.Cmd {
 
 	var cmds []tea.Cmd
 	if msg.printed != "" {
-		cmds = append(cmds, m.queueScrollbackPrint(msg.printed))
+		// No row budget: a streamed block leaves the live tail as its rendered
+		// self, so the copy already stands the same height as what it replaced.
+		cmds = append(cmds, m.queueScrollbackPrint(msg.printed, 0))
 	}
 	// Catch a block that completed while this one rendered — Stream.Active means
 	// the row is still uncommitted, so it's safe.
@@ -280,8 +287,7 @@ func (m *model) renderAndCommit(checkReady bool) []tea.Cmd {
 	if banner := m.takeWelcomeBanner(); banner != "" {
 		parts = append([]string{banner}, parts...)
 	}
-	m.flush.handoffRows = preCommitRows
-	return []tea.Cmd{m.queueScrollbackPrint(strings.Join(parts, "\n"))}
+	return []tea.Cmd{m.queueScrollbackPrint(strings.Join(parts, "\n"), preCommitRows)}
 }
 
 // queueScrollbackPrint appends content to a single-flight FIFO. Only an empty
@@ -289,8 +295,8 @@ func (m *model) renderAndCommit(checkReady bool) []tea.Cmd {
 // Tea has processed the current Println. Each chunk is no taller than the rows
 // above the managed frame, so insertAbove cannot scroll live UI rows into native
 // history.
-func (m *model) queueScrollbackPrint(content string) tea.Cmd {
-	return m.flush.queueScrollbackPrint(content)
+func (m *model) queueScrollbackPrint(content string, frameRows int) tea.Cmd {
+	return m.flush.queueScrollbackPrint(content, frameRows)
 }
 
 // resumeDeferredScrollbackPrint restarts the queue once no panel owns the frame.
@@ -307,7 +313,7 @@ func (m *model) resumeDeferredScrollbackPrint() tea.Cmd {
 	return printScrollback(m.flush.pendingPrints[0].id)
 }
 
-func (f *flushState) queueScrollbackPrint(content string) tea.Cmd {
+func (f *flushState) queueScrollbackPrint(content string, frameRows int) tea.Cmd {
 	if content == "" {
 		return nil
 	}
@@ -315,6 +321,7 @@ func (f *flushState) queueScrollbackPrint(content string) tea.Cmd {
 	pending := pendingScrollbackPrint{
 		id:        f.nextPrintID,
 		remaining: content,
+		frameRows: frameRows,
 	}
 	f.pendingPrints = append(f.pendingPrints, pending)
 	if len(f.pendingPrints) > 1 {
@@ -381,6 +388,7 @@ func (f *flushState) prepareScrollbackPrint(id uint64, width, height, frameHeigh
 	if len(lines) == 0 {
 		return "", false
 	}
+	f.pendingPrints[0].started = true
 
 	capacity := len(lines)
 	f.minimizeForPrint = false
@@ -492,13 +500,22 @@ func (m model) pendingScrollbackView() string {
 		return ""
 	}
 	head := m.flush.pendingPrints[0]
+	// Before the first chunk the whole payload stands in for the tail that
+	// committing just emptied. After it, part is already in scrollback and only
+	// the chunk in flight may be drawn: a payload too tall for the room above
+	// the frame is printed in several, and holding the remainder here would put
+	// it in the frame for the next chunk's insertAbove to weld into the middle
+	// of the output it belongs to.
 	handoff := head.current
-	if handoff == "" {
+	if !head.started {
 		handoff = head.remaining
+	}
+	if handoff == "" {
+		return ""
 	}
 	// The rendered block is usually shorter than the plain wrapped tail it
 	// replaces, and every row of that difference is one the frame would vacate.
-	for rows := viewRows(handoff); rows < m.flush.handoffRows; rows++ {
+	for rows := viewRows(handoff); rows < head.frameRows; rows++ {
 		handoff += "\n"
 	}
 	return handoff

--- a/internal/app/model_scrollback.go
+++ b/internal/app/model_scrollback.go
@@ -421,6 +421,22 @@ func (m *model) useMinimalScrollbackFrame() {
 	m.flush.minimizeForPrint = true
 }
 
+// trimTrailingBlanks drops the empty cells a full-width buffer leaves at the end
+// of a row.
+//
+// They cost nothing at the width they were printed at, and native scrollback is
+// immutable, so they are still there when the window narrows — where the
+// terminal rewraps a row of visible text plus padding into two, the second all
+// spaces. That is the blank line a resize inserts between committed blocks.
+// Styled trailing cells are kept: a background color is content, not padding.
+func trimTrailingBlanks(line uv.Line) uv.Line {
+	end := len(line)
+	for end > 0 && (line[end-1].IsZero() || line[end-1].Equal(&uv.EmptyCell)) {
+		end--
+	}
+	return line[:end]
+}
+
 // scrollbackPhysicalLines decomposes content exactly as Bubble Tea's
 // insertAbove accounts for it: ANSI escapes are zero-width, grapheme clusters
 // retain their terminal width, soft wraps consume rows, and a trailing newline
@@ -456,7 +472,11 @@ func renderScrollbackLines(lines []uv.Line) string {
 	if len(lines) == 0 {
 		return ""
 	}
-	if rendered := uv.Lines(lines).Render(); rendered != "" {
+	trimmed := make(uv.Lines, len(lines))
+	for i, line := range lines {
+		trimmed[i] = trimTrailingBlanks(line)
+	}
+	if rendered := trimmed.Render(); rendered != "" {
 		return rendered
 	}
 	// insertAbove ignores an empty string. A reset sequence represents one

--- a/internal/app/model_scrollback.go
+++ b/internal/app/model_scrollback.go
@@ -77,13 +77,12 @@ type flushSnapshot struct {
 // conversation block (thinking, content) off the UI goroutine and commits the
 // result to scrollback. See FlushStreamingBlocks and model_scrollback.go.
 type flushState struct {
-	rendering        bool                     // one render in flight at a time, so Printlns stay ordered
-	renderer         *conv.MDRenderer         // background renderer, off the live-view MDRenderer's mutex
-	width            int                      // width the renderer was built for; rebuild when it changes
-	nextPrintID      uint64                   // monotonic identity for queued scrollback prints
-	pendingPrints    []pendingScrollbackPrint // FIFO queue; only the head may be in flight
-	minimizeForPrint bool                     // temporarily shrink a full-height frame before insertAbove
-	frameForPrint    *tea.View                // freeze insertAbove geometry until the print completes
+	rendering     bool                     // one render in flight at a time, so Printlns stay ordered
+	renderer      *conv.MDRenderer         // background renderer, off the live-view MDRenderer's mutex
+	width         int                      // width the renderer was built for; rebuild when it changes
+	nextPrintID   uint64                   // monotonic identity for queued scrollback prints
+	pendingPrints []pendingScrollbackPrint // FIFO queue; only the head may be in flight
+	frameForPrint *tea.View                // freeze insertAbove geometry until the print completes
 }
 
 // flushResultMsg is the result of rendering a flushSnapshot off-thread, carrying
@@ -333,7 +332,6 @@ func (f *flushState) finishScrollbackPrint(id uint64) tea.Cmd {
 	if len(f.pendingPrints) == 0 || f.pendingPrints[0].id != id {
 		return nil
 	}
-	f.minimizeForPrint = false
 	f.frameForPrint = nil
 	f.pendingPrints[0].current = ""
 	if f.pendingPrints[0].remaining != "" {
@@ -361,11 +359,19 @@ func (m *model) prepareScrollbackPrint(id uint64) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	if m.flush.minimizeForPrint {
+	if frameFillsScreen(frameHeight, m.env.Height) {
 		frame = tea.NewView("")
 	}
 	m.flush.frameForPrint = &frame
 	return content, true
+}
+
+// frameFillsScreen reports that the frame leaves no room above it. The print
+// then has nowhere to insert, so it shrinks the frame to nothing for the
+// duration — both halves of prepareScrollbackPrint read the answer here rather
+// than one telling the other.
+func frameFillsScreen(frameHeight, height int) bool {
+	return height > 0 && frameHeight >= height
 }
 
 func (f *flushState) prepareScrollbackPrint(id uint64, width, height, frameHeight int) (string, bool) {
@@ -379,11 +385,9 @@ func (f *flushState) prepareScrollbackPrint(id uint64, width, height, frameHeigh
 	f.pendingPrints[0].started = true
 
 	capacity := len(lines)
-	f.minimizeForPrint = false
 	if height > 0 {
 		capacity = height - min(max(frameHeight, 0), height)
-		if capacity < 1 {
-			f.minimizeForPrint = true
+		if frameFillsScreen(frameHeight, height) {
 			capacity = height
 		}
 	}
@@ -406,7 +410,6 @@ func (m *model) useMinimalScrollbackFrame() {
 	}
 	frame := tea.NewView("")
 	m.flush.frameForPrint = &frame
-	m.flush.minimizeForPrint = true
 }
 
 // trimPadding drops the padding a full-width buffer leaves on a row.

--- a/internal/app/model_scrollback_renderer_test.go
+++ b/internal/app/model_scrollback_renderer_test.go
@@ -219,7 +219,7 @@ func (m *nativeHistoryModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if !ok {
 			return m, nil
 		}
-		if m.flush.minimizeForPrint {
+		if frameFillsScreen(nativeFrameHeight, nativeHistoryHeight) {
 			frame = tea.NewView("")
 		}
 		m.flush.frameForPrint = &frame

--- a/internal/app/model_scrollback_renderer_test.go
+++ b/internal/app/model_scrollback_renderer_test.go
@@ -205,8 +205,8 @@ func (m *nativeHistoryModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			nativeBash + "6",
 			nativeBash + "7",
 			nativeBash + "8",
-		}, "\n"))
-		m.queueScrollbackPrint(nativeEdit)
+		}, "\n"), 0)
+		m.queueScrollbackPrint(nativeEdit, 0)
 		return m, first
 	case scrollbackPrintReadyMsg:
 		frame := m.View()
@@ -262,8 +262,8 @@ func (m *nativeHistoryModel) View() tea.View {
 	}, "\n"))
 }
 
-func (m *nativeHistoryModel) queueScrollbackPrint(content string) tea.Cmd {
-	return m.flush.queueScrollbackPrint(content)
+func (m *nativeHistoryModel) queueScrollbackPrint(content string, frameRows int) tea.Cmd {
+	return m.flush.queueScrollbackPrint(content, frameRows)
 }
 
 func (m *nativeHistoryModel) finishScrollbackPrint(id uint64) tea.Cmd {

--- a/internal/app/model_scrollback_test.go
+++ b/internal/app/model_scrollback_test.go
@@ -516,12 +516,10 @@ func TestHandleFlushResultDiscardsReplacedRow(t *testing.T) {
 	}
 }
 
-// A fullscreen picker holds the queue exactly like a docked prompt does, and
-// closing it has to restart the queue. Nothing in the picker's own dismissal
-// says "approval answered", so a resume wired to the three prompt replies never
-// fired: the head stalled, every block queued behind it, and renderAndCommit
-// had already advanced CommittedCount — so the live tail had stopped drawing
-// what the queue was still holding. The output was on neither.
+// A picker holds the queue like a docked prompt, and closing it has to restart
+// the queue. Wired to the three prompt replies, the resume never fired for one:
+// the head stalled, everything queued behind it, and CommittedCount had already
+// advanced — so the output was in neither the tail nor scrollback.
 func TestScrollbackPrintResumesWhenAnyOverlayCloses(t *testing.T) {
 	m := dockedModalModel(t, "about to inspect the repository")
 	m.userInput.Approval.Hide()
@@ -570,74 +568,20 @@ func TestScrollbackFrameHeightCountsWrappedRows(t *testing.T) {
 	}
 }
 
-// The handoff copy keeps a committed block drawn in the managed view until its
-// Println has landed. Without it the frame shrinks the moment CommittedCount
-// advances, and Bubble Tea's inline renderer leaves the vacated rows on screen —
-// a plain copy of the streaming tail welded into native scrollback, with the
-// rendered version printed underneath it.
-func TestCommittedBlockStaysInTheFrameUntilItsPrintLands(t *testing.T) {
-	m := flushTestModel(core.ChatMessage{})
-	cmd := m.queueScrollbackPrint("RENDERED_BLOCK", 0)
-	if cmd == nil {
-		t.Fatal("the first queued print must start")
-	}
-	if view := m.pendingScrollbackView(); !strings.Contains(view, "RENDERED_BLOCK") {
-		t.Fatalf("handoff copy = %q, want the queued block", view)
-	}
-
-	ready := cmd().(scrollbackPrintReadyMsg)
-	if _, ok := m.flush.prepareScrollbackPrint(ready.id, m.env.Width, m.env.Height, 0); !ok {
-		t.Fatal("the print did not prepare")
-	}
-	if view := m.pendingScrollbackView(); !strings.Contains(view, "RENDERED_BLOCK") {
-		t.Fatalf("handoff copy during the print = %q, want the block still drawn", view)
-	}
-
-	m.finishScrollbackPrint(ready.id)
-	if view := m.pendingScrollbackView(); view != "" {
-		t.Fatalf("handoff copy after the print = %q, want it dropped", view)
-	}
-}
-
-// The rendered block is shorter than the plain wrapped tail it replaces, and
-// every row of that difference is a row the frame vacates — so the copy is
-// padded to what the live tail occupied.
-func TestHandoffCopyKeepsTheFrameAtItsPreCommitHeight(t *testing.T) {
-	m := flushTestModel(core.ChatMessage{})
-	m.queueScrollbackPrint("ONE\nTWO", 6)
-	cmd := printScrollback(m.flush.pendingPrints[0].id)
-	ready := cmd().(scrollbackPrintReadyMsg)
-	m.flush.prepareScrollbackPrint(ready.id, m.env.Width, m.env.Height, 0)
-
-	if rows := viewRows(m.pendingScrollbackView()); rows != 6 {
-		t.Fatalf("handoff rows = %d, want the pre-commit height 6", rows)
-	}
-
-	// Never trimmed: a copy taller than the tail it replaces is the frame
-	// growing, which the renderer handles.
-	m.flush.pendingPrints[0].frameRows = 1
-	if rows := viewRows(m.pendingScrollbackView()); rows != 2 {
-		t.Fatalf("handoff rows = %d, want the block's own 2", rows)
-	}
-}
-
-// A payload taller than the room above the frame is printed in several chunks.
-// The handoff copy stands in for the tail only until the first chunk goes out;
-// after that part of the payload is already in scrollback, and holding the rest
-// in the frame is what the next chunk's insertAbove welds into the middle of
-// the output it belongs to.
-func TestHandoffCopyDropsTheRemainderOncePrintingStarts(t *testing.T) {
+// The handoff copy tracks one print's life: the whole payload stands in for the
+// tail a commit emptied, then only the chunk in flight once printing starts, and
+// nothing between chunks. Without it the frame shrinks the moment CommittedCount
+// advances and the renderer leaves the vacated rows on screen; holding the
+// remainder instead swells it for the next chunk's insertAbove to weld in.
+func TestHandoffCopyTracksThePrintInFlight(t *testing.T) {
 	m := flushTestModel(core.ChatMessage{})
 	m.env.Height = 6
-	tall := strings.Join([]string{"L1", "L2", "L3", "L4", "L5", "L6", "L7", "L8"}, "\n")
-	cmd := m.queueScrollbackPrint(tall, 0)
+	cmd := m.queueScrollbackPrint(strings.Join([]string{"L1", "L2", "L3", "L4", "L5", "L6", "L7", "L8"}, "\n"), 0)
 	if cmd == nil {
 		t.Fatal("the first queued print must start")
 	}
-
-	// Before the first chunk: the whole payload stands in for the emptied tail.
 	if view := m.pendingScrollbackView(); !strings.Contains(view, "L8") {
-		t.Fatalf("handoff copy before printing = %q, want the whole payload", view)
+		t.Fatalf("before printing = %q, want the whole payload", view)
 	}
 
 	ready := cmd().(scrollbackPrintReadyMsg)
@@ -648,24 +592,36 @@ func TestHandoffCopyDropsTheRemainderOncePrintingStarts(t *testing.T) {
 	if m.flush.pendingPrints[0].remaining == "" {
 		t.Fatal("the payload fit in one chunk; this test needs it split")
 	}
-
-	// Once printing has started, only the chunk in flight.
-	view := m.pendingScrollbackView()
-	if view != chunk {
-		t.Fatalf("handoff copy = %q, want only the chunk in flight %q", view, chunk)
+	if view := m.pendingScrollbackView(); view != chunk {
+		t.Fatalf("in flight = %q, want the chunk %q", view, chunk)
 	}
 
-	// And nothing at all between chunks.
 	m.finishScrollbackPrint(ready.id)
 	if view := m.pendingScrollbackView(); view != "" {
-		t.Fatalf("handoff copy between chunks = %q, want none", view)
+		t.Fatalf("between chunks = %q, want none", view)
 	}
 }
 
-// Committed rows must carry no trailing padding. Native scrollback is
-// immutable, so a row of text padded out to the terminal's width is still that
-// wide when the window narrows — where the terminal rewraps it into two, the
-// second all spaces. That is the blank line a resize inserts between blocks.
+// The rendered block is shorter than the plain tail it replaces, so the copy is
+// padded to what the commit removed — and never trimmed, since a taller copy is
+// the frame growing, which the renderer handles.
+func TestHandoffCopyKeepsTheFrameAtItsPreCommitHeight(t *testing.T) {
+	m := flushTestModel(core.ChatMessage{})
+	m.queueScrollbackPrint("ONE\nTWO", 6)
+	ready := printScrollback(m.flush.pendingPrints[0].id)().(scrollbackPrintReadyMsg)
+	m.flush.prepareScrollbackPrint(ready.id, m.env.Width, m.env.Height, 0)
+
+	if rows := rowCount(m.pendingScrollbackView()); rows != 6 {
+		t.Fatalf("handoff rows = %d, want the pre-commit height 6", rows)
+	}
+	m.flush.pendingPrints[0].frameRows = 1
+	if rows := rowCount(m.pendingScrollbackView()); rows != 2 {
+		t.Fatalf("handoff rows = %d, want the block's own 2", rows)
+	}
+}
+
+// Committed rows carry no trailing padding: scrollback is immutable, so a
+// padded row rewraps into two when the window narrows — the second all spaces.
 func TestScrollbackLinesCarryNoTrailingPadding(t *testing.T) {
 	rendered := renderScrollbackLines(scrollbackPhysicalLines("short\nalso short\n", 40))
 

--- a/internal/app/model_scrollback_test.go
+++ b/internal/app/model_scrollback_test.go
@@ -155,7 +155,7 @@ func TestScrollbackPhysicalLinesMatchBubbleTeaAccounting(t *testing.T) {
 func TestScrollbackChunkingPreservesStyledWrappedContent(t *testing.T) {
 	var flush flushState
 	content := "\x1b[31mabcdefghij\x1b[0m\nlast\n"
-	cmd := flush.queueScrollbackPrint(content)
+	cmd := flush.queueScrollbackPrint(content, 0)
 	if cmd == nil {
 		t.Fatal("the first chunk must start immediately")
 	}
@@ -183,7 +183,7 @@ func TestScrollbackChunkingPreservesStyledWrappedContent(t *testing.T) {
 func TestScrollbackFullHeightFrameMinimizesAndRestores(t *testing.T) {
 	m := flushTestModel(core.ChatMessage{})
 	m.env.Height = 1
-	cmd := m.queueScrollbackPrint("A")
+	cmd := m.queueScrollbackPrint("A", 0)
 	if cmd == nil {
 		t.Fatal("the first chunk must start immediately")
 	}
@@ -207,7 +207,7 @@ func TestScrollbackFullHeightFrameMinimizesAndRestores(t *testing.T) {
 // terminal history together with the actual conversation output.
 func TestScrollbackPrintWaitsForApprovalModalToClose(t *testing.T) {
 	m := dockedModalModel(t, "about to inspect the repository")
-	cmd := m.queueScrollbackPrint("COMMITTED_MARKDOWN_BLOCK")
+	cmd := m.queueScrollbackPrint("COMMITTED_MARKDOWN_BLOCK", 0)
 	if cmd == nil {
 		t.Fatal("the first queued print must start immediately")
 	}
@@ -248,7 +248,7 @@ func TestDeferredApprovalWaitsForScrollbackHandoff(t *testing.T) {
 		ToolName: "Bash",
 		BashMeta: &perm.BashMetadata{Command: "git status"},
 	}
-	cmd := m.queueScrollbackPrint("COMMITTED_BEFORE_APPROVAL")
+	cmd := m.queueScrollbackPrint("COMMITTED_BEFORE_APPROVAL", 0)
 	if cmd == nil {
 		t.Fatal("the queued print must start")
 	}
@@ -269,11 +269,11 @@ func TestDeferredApprovalWaitsForScrollbackHandoff(t *testing.T) {
 
 func TestScrollbackPrintQueueIsSingleFlightFIFO(t *testing.T) {
 	m := flushTestModel(core.ChatMessage{})
-	firstCmd := m.queueScrollbackPrint("A")
+	firstCmd := m.queueScrollbackPrint("A", 0)
 	if firstCmd == nil {
 		t.Fatal("the first queued print must start immediately")
 	}
-	if secondCmd := m.queueScrollbackPrint("B"); secondCmd != nil {
+	if secondCmd := m.queueScrollbackPrint("B", 0); secondCmd != nil {
 		t.Fatal("a second print must wait until the in-flight head completes")
 	}
 
@@ -530,7 +530,7 @@ func TestScrollbackPrintResumesWhenAnyOverlayCloses(t *testing.T) {
 		t.Fatal("the config picker did not become the active overlay")
 	}
 
-	cmd := m.queueScrollbackPrint("COMMITTED_MARKDOWN_BLOCK")
+	cmd := m.queueScrollbackPrint("COMMITTED_MARKDOWN_BLOCK", 0)
 	if cmd == nil {
 		t.Fatal("the first queued print must start immediately")
 	}
@@ -577,7 +577,7 @@ func TestScrollbackFrameHeightCountsWrappedRows(t *testing.T) {
 // rendered version printed underneath it.
 func TestCommittedBlockStaysInTheFrameUntilItsPrintLands(t *testing.T) {
 	m := flushTestModel(core.ChatMessage{})
-	cmd := m.queueScrollbackPrint("RENDERED_BLOCK")
+	cmd := m.queueScrollbackPrint("RENDERED_BLOCK", 0)
 	if cmd == nil {
 		t.Fatal("the first queued print must start")
 	}
@@ -604,8 +604,10 @@ func TestCommittedBlockStaysInTheFrameUntilItsPrintLands(t *testing.T) {
 // padded to what the live tail occupied.
 func TestHandoffCopyKeepsTheFrameAtItsPreCommitHeight(t *testing.T) {
 	m := flushTestModel(core.ChatMessage{})
-	m.queueScrollbackPrint("ONE\nTWO")
-	m.flush.handoffRows = 6
+	m.queueScrollbackPrint("ONE\nTWO", 6)
+	cmd := printScrollback(m.flush.pendingPrints[0].id)
+	ready := cmd().(scrollbackPrintReadyMsg)
+	m.flush.prepareScrollbackPrint(ready.id, m.env.Width, m.env.Height, 0)
 
 	if rows := viewRows(m.pendingScrollbackView()); rows != 6 {
 		t.Fatalf("handoff rows = %d, want the pre-commit height 6", rows)
@@ -613,8 +615,49 @@ func TestHandoffCopyKeepsTheFrameAtItsPreCommitHeight(t *testing.T) {
 
 	// Never trimmed: a copy taller than the tail it replaces is the frame
 	// growing, which the renderer handles.
-	m.flush.handoffRows = 1
+	m.flush.pendingPrints[0].frameRows = 1
 	if rows := viewRows(m.pendingScrollbackView()); rows != 2 {
 		t.Fatalf("handoff rows = %d, want the block's own 2", rows)
+	}
+}
+
+// A payload taller than the room above the frame is printed in several chunks.
+// The handoff copy stands in for the tail only until the first chunk goes out;
+// after that part of the payload is already in scrollback, and holding the rest
+// in the frame is what the next chunk's insertAbove welds into the middle of
+// the output it belongs to.
+func TestHandoffCopyDropsTheRemainderOncePrintingStarts(t *testing.T) {
+	m := flushTestModel(core.ChatMessage{})
+	m.env.Height = 6
+	tall := strings.Join([]string{"L1", "L2", "L3", "L4", "L5", "L6", "L7", "L8"}, "\n")
+	cmd := m.queueScrollbackPrint(tall, 0)
+	if cmd == nil {
+		t.Fatal("the first queued print must start")
+	}
+
+	// Before the first chunk: the whole payload stands in for the emptied tail.
+	if view := m.pendingScrollbackView(); !strings.Contains(view, "L8") {
+		t.Fatalf("handoff copy before printing = %q, want the whole payload", view)
+	}
+
+	ready := cmd().(scrollbackPrintReadyMsg)
+	chunk, ok := m.flush.prepareScrollbackPrint(ready.id, m.env.Width, m.env.Height, 2)
+	if !ok {
+		t.Fatal("the print did not prepare")
+	}
+	if m.flush.pendingPrints[0].remaining == "" {
+		t.Fatal("the payload fit in one chunk; this test needs it split")
+	}
+
+	// Once printing has started, only the chunk in flight.
+	view := m.pendingScrollbackView()
+	if view != chunk {
+		t.Fatalf("handoff copy = %q, want only the chunk in flight %q", view, chunk)
+	}
+
+	// And nothing at all between chunks.
+	m.finishScrollbackPrint(ready.id)
+	if view := m.pendingScrollbackView(); view != "" {
+		t.Fatalf("handoff copy between chunks = %q, want none", view)
 	}
 }

--- a/internal/app/model_scrollback_test.go
+++ b/internal/app/model_scrollback_test.go
@@ -661,3 +661,22 @@ func TestHandoffCopyDropsTheRemainderOncePrintingStarts(t *testing.T) {
 		t.Fatalf("handoff copy between chunks = %q, want none", view)
 	}
 }
+
+// Committed rows must carry no trailing padding. Native scrollback is
+// immutable, so a row of text padded out to the terminal's width is still that
+// wide when the window narrows — where the terminal rewraps it into two, the
+// second all spaces. That is the blank line a resize inserts between blocks.
+func TestScrollbackLinesCarryNoTrailingPadding(t *testing.T) {
+	rendered := renderScrollbackLines(scrollbackPhysicalLines("short\nalso short\n", 40))
+
+	for _, line := range strings.Split(rendered, "\n") {
+		if plain := ansi.Strip(line); plain != strings.TrimRight(plain, " ") {
+			t.Errorf("line padded to the buffer width: %q", plain)
+		}
+	}
+	for _, want := range []string{"short", "also short"} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("rendered lost %q: %q", want, rendered)
+		}
+	}
+}

--- a/internal/app/model_scrollback_test.go
+++ b/internal/app/model_scrollback_test.go
@@ -188,8 +188,8 @@ func TestScrollbackFullHeightFrameMinimizesAndRestores(t *testing.T) {
 		t.Fatal("the first chunk must start immediately")
 	}
 	ready := cmd().(scrollbackPrintReadyMsg)
-	if _, ok := m.prepareScrollbackPrint(ready.id); !ok || !m.flush.minimizeForPrint {
-		t.Fatal("a full-height frame must be minimized before printing")
+	if _, ok := m.prepareScrollbackPrint(ready.id); !ok {
+		t.Fatal("a full-height frame must still prepare a print")
 	}
 	if frame, ok := m.scrollbackFrameForPrint(); !ok || frame.Content != "" {
 		t.Fatalf("frame during print = %#v, ok=%v, want an empty frozen frame", frame, ok)
@@ -197,7 +197,7 @@ func TestScrollbackFullHeightFrameMinimizesAndRestores(t *testing.T) {
 	if next := m.finishScrollbackPrint(ready.id); next != nil {
 		t.Fatal("the one-row payload should finish in one minimized print")
 	}
-	if m.flush.minimizeForPrint || m.flush.frameForPrint != nil {
+	if m.flush.frameForPrint != nil {
 		t.Fatal("the managed frame must be restored after the print completes")
 	}
 }

--- a/internal/app/model_scrollback_test.go
+++ b/internal/app/model_scrollback_test.go
@@ -623,7 +623,11 @@ func TestHandoffCopyKeepsTheFrameAtItsPreCommitHeight(t *testing.T) {
 // Committed rows carry no trailing padding: scrollback is immutable, so a
 // padded row rewraps into two when the window narrows — the second all spaces.
 func TestScrollbackLinesCarryNoTrailingPadding(t *testing.T) {
-	rendered := renderScrollbackLines(scrollbackPhysicalLines("short\nalso short\n", 40))
+	// Real trailing spaces under an open foreground colour — how the markdown
+	// renderer pads a block. They are cells, not gaps, so "is it empty" misses
+	// them; nothing of a foreground shows on a space, only a background would.
+	styled := "\x1b[38;2;24;24;27mshort" + strings.Repeat(" ", 30) + "\nalso short\n"
+	rendered := renderScrollbackLines(scrollbackPhysicalLines(styled, 40))
 
 	for _, line := range strings.Split(rendered, "\n") {
 		if plain := ansi.Strip(line); plain != strings.TrimRight(plain, " ") {


### PR DESCRIPTION
Three scrollback defects found while verifying #495, each reproduced and checked in tmux against a scripted endpoint.

- **A carriage return broke the output gutter.** git draws progress in place — `Rebasing (1/3)\r…` — so one line can carry a carriage return mid-way. The terminal obeyed it inside `  ┊ `, restarting the row at column 0: the stray unindented `error: could not apply …` in a rebase's output. Lines now render as the terminal would leave them.
- **A split print welded the input strip into its own output.** A payload taller than the room above the frame prints in chunks, and the handoff copy drew the whole remainder between them — swelling the frame for the next `insertAbove` to weld in behind it. It now stands in for the emptied live tail only until the first chunk goes out.
- **A narrowing window opened a blank row between blocks.** Committed rows were padded to the terminal's width, and scrollback is immutable: narrowing rewrapped text-plus-padding into two rows, the second all spaces. Rows now end where their content does.

Still open: a narrowing terminal rewraps committed rows knowing nothing of San's indentation, so a bullet's continuation lands in the left margin. Only rows San has not printed yet can be laid out for a new width, and those already are.
