### PR TITLE
fix(mcp): a server's tools reach the agent that is running

### DIFF
--- a/internal/app/agent.go
+++ b/internal/app/agent.go
@@ -114,6 +114,39 @@ func (m *model) promptParams() agent.BuildParams {
 	}
 }
 
+// syncMCPTools replaces the mcp__* tools in the running agent's registry with
+// what the servers now advertise. A server that loads tools lazily, or gates
+// them behind a login, changes its list while connected, and the registry is
+// what the loop reads at every step — so the next step sees the change without
+// the agent being rebuilt.
+//
+// It runs on the MCP session's own goroutine, which is why it touches only
+// services: core.Tools locks, and so do Session.Tools and DisabledTools.
+func (m *model) syncMCPTools() {
+	tools := m.services.Agent.Tools()
+	if tools == nil {
+		return // no agent yet — whatever it is built with will be current
+	}
+	disabled := m.services.Setting.DisabledTools()
+
+	live := make(map[string]bool)
+	for _, t := range mcp.AsCoreTools(m.services.MCP.GetToolSchemas(), mcp.NewCaller(m.services.MCP)) {
+		name := t.Schema().Name
+		// The /tool panel's disable applies to MCP tools here for the same
+		// reason agent.BuildParams applies it when the agent is built.
+		if disabled[name] {
+			continue
+		}
+		live[name] = true
+		tools.Add(t, "mcp:"+name)
+	}
+	for _, schema := range tools.Schemas() {
+		if mcp.IsMCPTool(schema.Name) && !live[schema.Name] {
+			tools.Remove(schema.Name, "mcp:"+schema.Name)
+		}
+	}
+}
+
 func (m *model) buildAgentParams() agent.BuildParams {
 	params := m.promptParams()
 

--- a/internal/app/init.go
+++ b/internal/app/init.go
@@ -144,6 +144,7 @@ func (m *model) reloadProjectServices(cwd string) {
 		log.Logger().Warn("Failed to initialize mcp", zap.Error(err))
 	}
 	m.services.MCP = mcp.DefaultRegistry()
+	m.services.MCP.SetOnToolsChanged(m.syncMCPTools)
 
 	persona.Initialize(cwd)
 	m.services.Persona = persona.Default()

--- a/internal/app/mcp_tools_sync_test.go
+++ b/internal/app/mcp_tools_sync_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	sdkagent "github.com/genai-io/sdk-go/pkg/agent"
-	"github.com/genai-io/sdk-go/pkg/ai"
 
 	"github.com/genai-io/san/internal/agent"
 	"github.com/genai-io/san/internal/core"
@@ -15,11 +14,10 @@ import (
 	"github.com/genai-io/san/tests/integration/testutil"
 )
 
-type stubTool struct{ name string }
-
-func (s stubTool) Schema() core.ToolSchema { return core.ToolSchema{Name: s.name} }
-func (s stubTool) Run(context.Context, ai.ToolCall) (sdkagent.Result, error) {
-	return sdkagent.TextResult("ok"), nil
+func namedTool(name string) core.Tool {
+	return sdkagent.ToolFunc(name, "", func(context.Context, struct{}) (sdkagent.Result, error) {
+		return sdkagent.TextResult("ok"), nil
+	})
 }
 
 // A server whose tools changed has to reach the agent that is running, not just
@@ -38,8 +36,8 @@ func TestSyncMCPToolsReachesTheRunningAgent(t *testing.T) {
 	if tools == nil {
 		t.Fatal("a started session has no toolset")
 	}
-	tools.Add(stubTool{name: "mcp__gone__read"}, "mcp:test")
-	tools.Add(stubTool{name: "Read"}, "builtin:test")
+	tools.Add(namedTool("mcp__gone__read"), "mcp:test")
+	tools.Add(namedTool("Read"), "builtin:test")
 
 	m := &model{services: services{
 		Agent:   sess,
@@ -60,7 +58,10 @@ func TestSyncMCPToolsReachesTheRunningAgent(t *testing.T) {
 	}
 }
 
-// No agent yet is not an error: whatever it is built with will be current.
+// MCP connects in Init and the agent starts on the first submit, so a server
+// that announces a change in between finds no toolset at all. Without the nil
+// guard that is a panic on the MCP session's goroutine, which takes San with
+// it — the ordinary startup path, not an edge.
 func TestSyncMCPToolsBeforeAnAgentExists(t *testing.T) {
 	m := &model{services: services{
 		Agent:   &agent.Session{},

--- a/internal/app/mcp_tools_sync_test.go
+++ b/internal/app/mcp_tools_sync_test.go
@@ -1,0 +1,71 @@
+package app
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	sdkagent "github.com/genai-io/sdk-go/pkg/agent"
+	"github.com/genai-io/sdk-go/pkg/ai"
+
+	"github.com/genai-io/san/internal/agent"
+	"github.com/genai-io/san/internal/core"
+	"github.com/genai-io/san/internal/mcp"
+	"github.com/genai-io/san/internal/setting"
+	"github.com/genai-io/san/tests/integration/testutil"
+)
+
+type stubTool struct{ name string }
+
+func (s stubTool) Schema() core.ToolSchema { return core.ToolSchema{Name: s.name} }
+func (s stubTool) Run(context.Context, ai.ToolCall) (sdkagent.Result, error) {
+	return sdkagent.TextResult("ok"), nil
+}
+
+// A server whose tools changed has to reach the agent that is running, not just
+// the /mcp listing. The registry is what the loop reads at every step, so
+// reconciling it is what lets the next step see the change — and until this was
+// wired, Registry.SetOnToolsChanged had no caller outside a test, so the whole
+// notification chain ended in a nil callback.
+func TestSyncMCPToolsReachesTheRunningAgent(t *testing.T) {
+	sess := &agent.Session{}
+	if err := sess.Start(agent.BuildParams{Provider: &testutil.FakeProvider{}, ModelID: "m"}, nil); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer sess.Stop()
+
+	tools := sess.Tools()
+	if tools == nil {
+		t.Fatal("a started session has no toolset")
+	}
+	tools.Add(stubTool{name: "mcp__gone__read"}, "mcp:test")
+	tools.Add(stubTool{name: "Read"}, "builtin:test")
+
+	m := &model{services: services{
+		Agent:   sess,
+		MCP:     mcp.NewRegistryForTest(nil),
+		Setting: setting.Default(),
+	}}
+	m.syncMCPTools()
+
+	var names []string
+	for _, s := range tools.Schemas() {
+		names = append(names, s.Name)
+	}
+	if slices.Contains(names, "mcp__gone__read") {
+		t.Errorf("a tool no server advertises any more is still in the agent's registry: %v", names)
+	}
+	if !slices.Contains(names, "Read") {
+		t.Errorf("reconciling the MCP tools took a built-in with it: %v", names)
+	}
+}
+
+// No agent yet is not an error: whatever it is built with will be current.
+func TestSyncMCPToolsBeforeAnAgentExists(t *testing.T) {
+	m := &model{services: services{
+		Agent:   &agent.Session{},
+		MCP:     mcp.NewRegistryForTest(nil),
+		Setting: setting.Default(),
+	}}
+	m.syncMCPTools()
+}


### PR DESCRIPTION
`Registry.SetOnToolsChanged` had no caller outside a test. The chain a
tools-changed notification travels — MCP session → `Client.notifyToolsChanged`
→ `Registry.notifyToolsChanged` → `r.onToolsChanged` — ended in a nil callback.

So a server that loads its tools lazily, or gates them behind a login, would
show the new set in `/mcp` and the running agent would go on being offered the
old one until it was rebuilt.

Found while auditing what was left in the SDK after #507. It predates that PR —
`main` has the same shape — which is why it is here on its own rather than
folded into an MCP swap.

### The reconcile belongs in the app

That is where the three things meet: what the servers now advertise, what
`/tool` has disabled, and the toolset the running agent reads. `core.Tools` is
already a runtime registry with `Add`/`Remove`, so nothing is rebuilt — the
next step sees the change.

It runs on the MCP session's goroutine, so it touches only services:
`core.Tools` locks, and so do `Session.Tools` and `Settings.DisabledTools`.

### The test is the point

Nothing anywhere asserted the callback was reachable, which is how it sat
disconnected. The new test fails without the fix — checked by stubbing
`syncMCPTools` out and watching it go red — and covers both halves: a tool no
server advertises any more is removed, and a built-in beside it is not.

`make lint`, `layercheck`, `make format-check` and `go test -race ./...` pass.