### PR TITLE
refactor(mcp): a count is a count, and the queue is aitest's

### DIFF
--- a/internal/app/input/on_mcp_command.go
+++ b/internal/app/input/on_mcp_command.go
@@ -82,11 +82,11 @@ func handleMCPList(reg *coremcp.Registry) (string, error) {
 			if len(srv.Tools) > 0 {
 				fmt.Fprintf(&sb, "    Tools: %d\n", len(srv.Tools))
 			}
-			if len(srv.Resources) > 0 {
-				fmt.Fprintf(&sb, "    Resources: %d\n", len(srv.Resources))
+			if srv.ResourceCount > 0 {
+				fmt.Fprintf(&sb, "    Resources: %d\n", srv.ResourceCount)
 			}
-			if len(srv.Prompts) > 0 {
-				fmt.Fprintf(&sb, "    Prompts: %d\n", len(srv.Prompts))
+			if srv.PromptCount > 0 {
+				fmt.Fprintf(&sb, "    Prompts: %d\n", srv.PromptCount)
 			}
 		}
 

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -1,8 +1,6 @@
 package llm
 
 import (
-	"iter"
-
 	"github.com/genai-io/sdk-go/pkg/ai"
 	"github.com/genai-io/sdk-go/pkg/ai/aitest"
 
@@ -20,7 +18,6 @@ import (
 // model behind it is the SDK's test double.
 type mockLLMProvider struct {
 	responses []CompletionResponse
-	callIdx   int
 	models    []ModelInfo
 	listErr   error
 	listCalls int
@@ -30,18 +27,15 @@ type mockLLMProvider struct {
 
 func (m *mockLLMProvider) Client(string, map[string]string) (*ai.Client, error) {
 	if m.driver == nil {
-		m.driver = aitest.Always(func(ctx context.Context, req *ai.Request) iter.Seq2[ai.Delta, error] {
-			resp := CompletionResponse{Content: ai.TextContent("no more responses"), StopReason: ai.StopEndTurn}
-			if m.callIdx < len(m.responses) {
-				resp = m.responses[m.callIdx]
-				m.callIdx++
-			}
-			return aitest.Replies(ai.Response{
-				Content:    resp.Content,
-				StopReason: ai.StopEndTurn,
-				Usage:      ai.Usage{Input: resp.Usage.Input, Output: resp.Usage.Output},
-			})(ctx, req)
-		})
+		turns := make([]aitest.Turn, 0, len(m.responses))
+		for _, r := range m.responses {
+			turns = append(turns, aitest.Replies(ai.Response{
+				Content:    r.Content,
+				StopReason: r.StopReason,
+				Usage:      ai.Usage{Input: r.Usage.Input, Output: r.Usage.Output},
+			}))
+		}
+		m.driver = aitest.New(turns...)
 	}
 	return m.driver.Client(), nil
 }

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -37,11 +37,12 @@ type Client struct {
 	// dial opens the session. Tests replace it; see conn.
 	dial func(ctx context.Context, onToolsChanged func()) (conn, error)
 
-	mu        sync.RWMutex
-	session   conn
-	tools     []core.Tool
-	resources []MCPResource
-	prompts   []MCPPrompt
+	mu      sync.RWMutex
+	session conn
+	tools   []core.Tool
+	// Nothing reads a resource or a prompt here; /mcp says how many there are.
+	resourceCount int
+	promptCount   int
 
 	onToolsChanged func()
 }
@@ -65,17 +66,9 @@ func dialSDK(config ServerConfig) func(context.Context, func()) (conn, error) {
 			// San is full-screen, so this cannot go to the terminal.
 			Stderr: serverLog{name: config.Name},
 		}
-		var opts []sdkmcp.Option
-		if onToolsChanged != nil {
-			// The SDK hands the callback its own client; San's re-read goes
-			// through this one, which is the same session under San's cache.
-			opts = append(opts, sdkmcp.OnToolsChanged(func(*sdkmcp.Client) { onToolsChanged() }))
-		}
-		c, err := sdkmcp.Connect(ctx, server, opts...)
-		if err != nil {
-			return nil, err
-		}
-		return sdkSession{c}, nil
+		// The SDK hands the callback its own client; San's re-read goes through
+		// this one, which is the same session under San's cache.
+		return sdkmcp.Connect(ctx, server, sdkmcp.OnToolsChanged(func(*sdkmcp.Client) { onToolsChanged() }))
 	}
 }
 
@@ -87,13 +80,6 @@ func (l serverLog) Write(p []byte) (int, error) {
 		glog.Logger().Debug("mcp server output", zap.String("server", l.name), zap.String("line", line))
 	}
 	return len(p), nil
-}
-
-// sdkSession is the SDK's client under what this package asks.
-type sdkSession struct{ *sdkmcp.Client }
-
-func (s sdkSession) Tools(ctx context.Context) ([]core.Tool, error) {
-	return s.Client.Tools(ctx)
 }
 
 // Connect opens the session and reads what the server offers. Already
@@ -141,8 +127,7 @@ func (c *Client) refresh(ctx context.Context) error {
 
 	c.mu.Lock()
 	c.tools = tools
-	c.resources = toMCPResources(resources)
-	c.prompts = toMCPPrompts(prompts)
+	c.resourceCount, c.promptCount = len(resources), len(prompts)
 	c.mu.Unlock()
 	return nil
 }
@@ -151,7 +136,8 @@ func (c *Client) refresh(ctx context.Context) error {
 func (c *Client) Disconnect() error {
 	c.mu.Lock()
 	session := c.session
-	c.session, c.tools, c.resources, c.prompts = nil, nil, nil, nil
+	c.session, c.tools = nil, nil
+	c.resourceCount, c.promptCount = 0, 0
 	c.mu.Unlock()
 
 	if session == nil {
@@ -181,11 +167,7 @@ func (c *Client) GetCachedTools() []MCPTool {
 	out := make([]MCPTool, 0, len(c.tools))
 	for _, t := range c.tools {
 		schema := t.Schema()
-		tool := MCPTool{Name: schema.Name, Description: schema.Description}
-		if raw, err := json.Marshal(schema.Definition); err == nil {
-			tool.InputSchema = raw
-		}
-		out = append(out, tool)
+		out = append(out, MCPTool{Name: schema.Name, Description: schema.Description, InputSchema: schema.Definition})
 	}
 	return out
 }
@@ -245,22 +227,6 @@ func toolResultContent(content ai.Content) []ToolResultContent {
 	return out
 }
 
-func toMCPResources(in []sdkmcp.Resource) []MCPResource {
-	out := make([]MCPResource, 0, len(in))
-	for _, r := range in {
-		out = append(out, MCPResource{URI: r.URI, Name: r.Name, Description: r.Description, MimeType: r.MediaType})
-	}
-	return out
-}
-
-func toMCPPrompts(in []sdkmcp.Prompt) []MCPPrompt {
-	out := make([]MCPPrompt, 0, len(in))
-	for _, p := range in {
-		out = append(out, MCPPrompt{Name: p.Name, Description: p.Description})
-	}
-	return out
-}
-
 // SetOnToolsChanged installs the callback for a tool list that changed. Before
 // or after Connect both work.
 func (c *Client) SetOnToolsChanged(callback func()) {
@@ -294,18 +260,15 @@ func (c *Client) notifyToolsChanged() {
 func (c *Client) ToServer() Server {
 	c.mu.RLock()
 	status := c.statusLocked()
-	resources := make([]MCPResource, len(c.resources))
-	copy(resources, c.resources)
-	prompts := make([]MCPPrompt, len(c.prompts))
-	copy(prompts, c.prompts)
+	resources, prompts := c.resourceCount, c.promptCount
 	c.mu.RUnlock()
 
 	return Server{
-		Config:    c.config,
-		Status:    status,
-		Tools:     c.GetCachedTools(),
-		Resources: resources,
-		Prompts:   prompts,
+		Config:        c.config,
+		Status:        status,
+		Tools:         c.GetCachedTools(),
+		ResourceCount: resources,
+		PromptCount:   prompts,
 	}
 }
 

--- a/internal/mcp/config_test.go
+++ b/internal/mcp/config_test.go
@@ -220,8 +220,8 @@ func Test_parseMCPToolName(t *testing.T) {
 // survive connecting and be gone again after disconnecting.
 func TestMCP_ResourceListing(t *testing.T) {
 	client := NewClient(ServerConfig{Command: "echo"})
-	if got := client.ToServer().Resources; len(got) != 0 {
-		t.Errorf("a client that has not connected reports %d resources, want none", len(got))
+	if got := client.ToServer().ResourceCount; got != 0 {
+		t.Errorf("a client that has not connected reports %d resources, want none", got)
 	}
 
 	session := newFakeSession()
@@ -234,22 +234,15 @@ func TestMCP_ResourceListing(t *testing.T) {
 		t.Fatalf("Connect: %v", err)
 	}
 
-	cached := client.ToServer().Resources
-	if len(cached) != 2 {
-		t.Fatalf("cached resources = %d, want 2", len(cached))
-	}
-	if cached[0].URI != "file:///tmp/test.txt" || cached[0].Name != "test.txt" {
-		t.Errorf("first resource = %+v", cached[0])
-	}
-	if cached[1].MimeType != "application/json" {
-		t.Errorf("second resource media type = %q", cached[1].MimeType)
+	if got := client.ToServer().ResourceCount; got != 2 {
+		t.Fatalf("cached resources = %d, want 2", got)
 	}
 
 	if err := client.Disconnect(); err != nil {
 		t.Fatalf("Disconnect: %v", err)
 	}
-	if got := client.ToServer().Resources; len(got) != 0 {
-		t.Errorf("a disconnected client still reports %d resources", len(got))
+	if got := client.ToServer().ResourceCount; got != 0 {
+		t.Errorf("a disconnected client still reports %d resources", got)
 	}
 }
 

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -683,7 +683,7 @@ func (r *Registry) GetToolSchemas() []core.ToolSchema {
 			tools = append(tools, core.ToolSchema{
 				Name:        fmt.Sprintf("mcp__%s__%s", serverName, mcpTool.Name),
 				Description: mcpTool.Description,
-				Definition:  parseInputSchema(mcpTool.InputSchema),
+				Definition:  schemaOrEmpty(mcpTool.InputSchema),
 			})
 		}
 	}
@@ -691,16 +691,13 @@ func (r *Registry) GetToolSchemas() []core.ToolSchema {
 	return tools
 }
 
-// parseInputSchema parses the input schema or returns a default empty schema
-func parseInputSchema(raw json.RawMessage) any {
-	if len(raw) == 0 {
+// schemaOrEmpty is a tool's input schema, or the empty one for a tool that
+// states none.
+func schemaOrEmpty(def any) any {
+	if def == nil {
 		return emptySchema
 	}
-	var schema map[string]any
-	if err := json.Unmarshal(raw, &schema); err != nil {
-		return emptySchema
-	}
-	return schema
+	return def
 }
 
 // CallTool calls a tool on an MCP server

--- a/internal/mcp/session_test.go
+++ b/internal/mcp/session_test.go
@@ -21,12 +21,7 @@ type fakeSession struct {
 	// closeDelay is how long a teardown takes, for the tests about not
 	// blocking on one.
 	closeDelay time.Duration
-	// dead makes a session that connects and is immediately not alive, which
-	// is what the registry replaces.
-	dead bool
-
-	tools     []core.Tool
-	resources []sdkmcp.Resource
+	resources  []sdkmcp.Resource
 
 	mu         sync.Mutex
 	closed     bool
@@ -42,16 +37,13 @@ func newSlowSession(d time.Duration) *fakeSession {
 	return s
 }
 
-func (s *fakeSession) Tools(context.Context) ([]core.Tool, error) { return s.tools, nil }
+func (s *fakeSession) Tools(context.Context) ([]core.Tool, error) { return nil, nil }
 
 func (s *fakeSession) Resources(context.Context) ([]sdkmcp.Resource, error) { return s.resources, nil }
 
 func (s *fakeSession) Prompts(context.Context) ([]sdkmcp.Prompt, error) { return nil, nil }
 
 func (s *fakeSession) Alive() bool {
-	if s.dead {
-		return false
-	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return !s.closed

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -3,8 +3,6 @@
 // are sdk-go's — see client.go.
 package mcp
 
-import "encoding/json"
-
 // TransportType defines the type of MCP transport
 type TransportType string
 
@@ -62,23 +60,9 @@ type MCPConfig struct {
 
 // MCPTool represents a tool exposed by an MCP server
 type MCPTool struct {
-	Name        string          `json:"name"`
-	Description string          `json:"description,omitempty"`
-	InputSchema json.RawMessage `json:"inputSchema,omitempty"`
-}
-
-// MCPResource represents a resource exposed by an MCP server
-type MCPResource struct {
-	URI         string `json:"uri"`
-	Name        string `json:"name,omitempty"`
-	Description string `json:"description,omitempty"`
-	MimeType    string `json:"mimeType,omitempty"`
-}
-
-// MCPPrompt represents a prompt template exposed by an MCP server
-type MCPPrompt struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
+	InputSchema any    `json:"inputSchema,omitempty"`
 }
 
 // ToolResult represents the result of calling an MCP tool
@@ -108,10 +92,12 @@ const (
 
 // Server represents a connected MCP server with its current state
 type Server struct {
-	Config    ServerConfig  `json:"config"`
-	Status    ServerStatus  `json:"status"`
-	Error     string        `json:"error,omitempty"`
-	Tools     []MCPTool     `json:"tools,omitempty"`
-	Resources []MCPResource `json:"resources,omitempty"`
-	Prompts   []MCPPrompt   `json:"prompts,omitempty"`
+	Config ServerConfig `json:"config"`
+	Status ServerStatus `json:"status"`
+	Error  string       `json:"error,omitempty"`
+	Tools  []MCPTool    `json:"tools,omitempty"`
+	// What the server offers to read and to fill in, as counts: /mcp says how
+	// many, and nothing here reads one.
+	ResourceCount int `json:"resourceCount,omitempty"`
+	PromptCount   int `json:"promptCount,omitempty"`
 }

--- a/internal/selflearn/fork_test.go
+++ b/internal/selflearn/fork_test.go
@@ -1,35 +1,15 @@
 package selflearn
 
 import (
-	"iter"
-
 	"github.com/genai-io/sdk-go/pkg/ai"
 	"github.com/genai-io/sdk-go/pkg/ai/aitest"
 
 	"context"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/genai-io/san/internal/core"
 )
-
-// scripted answers with a queued sequence of responses, one per call, and
-// falls back to a refusal once the queue is dry. The driver keeps every request
-// it was handed, which is how these tests assert on the assembled prompt.
-func scripted(responses ...ai.Response) *aitest.Driver {
-	var mu sync.Mutex
-	queue := responses
-	return aitest.Always(func(ctx context.Context, req *ai.Request) iter.Seq2[ai.Delta, error] {
-		mu.Lock()
-		r := ai.Response{Content: ai.TextContent("Nothing to save."), StopReason: ai.StopEndTurn}
-		if len(queue) > 0 {
-			r, queue = queue[0], queue[1:]
-		}
-		mu.Unlock()
-		return aitest.Replies(r)(ctx, req)
-	})
-}
 
 // TestTrimTrailingPendingMessages guards against the "messages must
 // alternate" provider rejection: when the snapshot ends with a tool_result
@@ -123,13 +103,10 @@ func TestRunReviewWritesMemoryAndInheritsSystem(t *testing.T) {
 	store := newTestStore(t)
 	mgr := NewSkillManager("/work/project-x", AllowAllSkillActions())
 
-	llm := scripted([]ai.Response{
-		{
-			Content:    ai.Content{ai.ToolCallBlock(core.ToolCall{ID: "call-1", Name: "memory_write", Input: `{"action":"add","content":"the user prefers tabs"}`})},
-			StopReason: ai.StopToolUse,
-		},
-		{Content: ai.TextContent("Saved 1 memory entry."), StopReason: ai.StopEndTurn},
-	}...)
+	llm := aitest.New(
+		aitest.Asks(core.ToolCall{ID: "call-1", Name: "memory_write", Input: `{"action":"add","content":"the user prefers tabs"}`}),
+		aitest.Says("Saved 1 memory entry."),
+	)
 
 	parentSys := core.NewSystem()
 	parentSys.Use(core.Section{

--- a/tests/integration/loop/loop_test.go
+++ b/tests/integration/loop/loop_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAgent_SingleTurn_EndTurn(t *testing.T) {
-	ag, _ := testutil.NewTestAgent(t,
+	ag := testutil.NewTestAgent(t,
 		testutil.EndTurnResponse("hello world"),
 	)
 
@@ -38,7 +38,7 @@ func TestAgent_SingleTurn_EndTurn(t *testing.T) {
 func TestAgent_MultiTurn_ToolUse(t *testing.T) {
 	testutil.RegisterFakeTool(t, "MyTool", "tool output")
 
-	ag, _ := testutil.NewTestAgent(t,
+	ag := testutil.NewTestAgent(t,
 		testutil.ToolCallResponse("MyTool", "tc1", `{}`),
 		testutil.EndTurnResponse("done after tool"),
 	)
@@ -83,7 +83,7 @@ func TestAgent_MaxSteps(t *testing.T) {
 		responses[i] = testutil.ToolCallResponse("AlwaysTool", "tc", `{}`)
 	}
 
-	ag, _ := testutil.NewTestAgentWithMaxSteps(t, 3, responses...)
+	ag := testutil.NewTestAgentWithMaxSteps(t, 3, responses...)
 
 	result, err := testutil.RunAgent(context.Background(), ag, "go")
 	if err != nil {
@@ -99,7 +99,7 @@ func TestAgent_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
 
-	ag, _ := testutil.NewTestAgent(t,
+	ag := testutil.NewTestAgent(t,
 		testutil.EndTurnResponse("should not reach"),
 	)
 
@@ -110,7 +110,7 @@ func TestAgent_ContextCancellation(t *testing.T) {
 }
 
 func TestAgent_UnknownTool(t *testing.T) {
-	ag, _ := testutil.NewTestAgent(t,
+	ag := testutil.NewTestAgent(t,
 		testutil.ToolCallResponse("NonExistent", "tc1", `{}`),
 		testutil.EndTurnResponse("recovered"),
 	)
@@ -140,7 +140,7 @@ func TestAgent_MultipleToolCalls(t *testing.T) {
 	testutil.RegisterFakeTool(t, "ToolA", "result A")
 	testutil.RegisterFakeTool(t, "ToolB", "result B")
 
-	ag, _ := testutil.NewTestAgent(t,
+	ag := testutil.NewTestAgent(t,
 		testutil.MultiToolCallResponse(
 			core.ToolCall{ID: "tc1", Name: "ToolA", Input: `{}`},
 			core.ToolCall{ID: "tc2", Name: "ToolB", Input: `{}`},
@@ -171,7 +171,7 @@ func TestAgent_MultipleToolCalls(t *testing.T) {
 func TestAgent_TokenAccumulation(t *testing.T) {
 	testutil.RegisterFakeTool(t, "Tick", "ok")
 
-	ag, _ := testutil.NewTestAgent(t,
+	ag := testutil.NewTestAgent(t,
 		testutil.ToolCallResponse("Tick", "tc1", `{}`),
 		testutil.ToolCallResponse("Tick", "tc2", `{}`),
 		testutil.EndTurnResponseWithUsage("done", 20, 10),

--- a/tests/integration/mcp/mcp_test.go
+++ b/tests/integration/mcp/mcp_test.go
@@ -308,7 +308,7 @@ func TestRealMCP_Everything(t *testing.T) {
 			if tool.Description == "" {
 				t.Error("echo tool should have a description")
 			}
-			if len(tool.InputSchema) == 0 {
+			if tool.InputSchema == nil {
 				t.Error("echo tool should have an input schema")
 			}
 			break
@@ -349,16 +349,16 @@ func TestRealMCP_Everything(t *testing.T) {
 	}
 
 	// --- Resources ---
-	resources := client.ToServer().Resources
-	t.Logf("resources: %d", len(resources))
-	if len(resources) == 0 {
+	resources := client.ToServer().ResourceCount
+	t.Logf("resources: %d", resources)
+	if resources == 0 {
 		t.Error("expected at least 1 resource from server-everything")
 	}
 
 	// --- Prompts ---
-	prompts := client.ToServer().Prompts
-	t.Logf("prompts: %d", len(prompts))
-	if len(prompts) == 0 {
+	prompts := client.ToServer().PromptCount
+	t.Logf("prompts: %d", prompts)
+	if prompts == 0 {
 		t.Error("expected at least 1 prompt from server-everything")
 	}
 

--- a/tests/integration/permission/permission_test.go
+++ b/tests/integration/permission/permission_test.go
@@ -11,7 +11,7 @@ import (
 func TestPermission_PermitAll_AllowsWrite(t *testing.T) {
 	testutil.RegisterFakeTool(t, "Write", "written successfully")
 
-	ag, _ := testutil.NewTestAgentWithPermission(t, testutil.PermitAllPermission(),
+	ag := testutil.NewTestAgentWithPermission(t, testutil.PermitAllPermission(),
 		testutil.ToolCallResponse("Write", "tc1", `{"file_path": "/tmp/test"}`),
 		testutil.EndTurnResponse("done"),
 	)
@@ -34,7 +34,7 @@ func TestPermission_PermitAll_AllowsWrite(t *testing.T) {
 func TestPermission_ReadOnly_BlocksWrite(t *testing.T) {
 	testutil.RegisterFakeTool(t, "Write", "should not execute")
 
-	ag, _ := testutil.NewTestAgentWithPermission(t, testutil.ReadOnlyPermission(),
+	ag := testutil.NewTestAgentWithPermission(t, testutil.ReadOnlyPermission(),
 		testutil.ToolCallResponse("Write", "tc1", `{"file_path": "/tmp/test"}`),
 		testutil.EndTurnResponse("ok"),
 	)
@@ -59,7 +59,7 @@ func TestPermission_ReadOnly_BlocksWrite(t *testing.T) {
 func TestPermission_ReadOnly_AllowsRead(t *testing.T) {
 	testutil.RegisterFakeTool(t, "Read", "file contents")
 
-	ag, _ := testutil.NewTestAgentWithPermission(t, testutil.ReadOnlyPermission(),
+	ag := testutil.NewTestAgentWithPermission(t, testutil.ReadOnlyPermission(),
 		testutil.ToolCallResponse("Read", "tc1", `{"file_path": "/tmp/test"}`),
 		testutil.EndTurnResponse("done"),
 	)
@@ -79,7 +79,7 @@ func TestPermission_ReadOnly_AllowsRead(t *testing.T) {
 func TestPermission_DenyAll_BlocksNonSafeTools(t *testing.T) {
 	testutil.RegisterFakeTool(t, "Bash", "should not execute")
 
-	ag, _ := testutil.NewTestAgentWithPermission(t, testutil.DenyAllPermission(),
+	ag := testutil.NewTestAgentWithPermission(t, testutil.DenyAllPermission(),
 		testutil.ToolCallResponse("Bash", "tc1", `{"command":"echo hi"}`),
 		testutil.EndTurnResponse("done"),
 	)
@@ -104,7 +104,7 @@ func TestPermission_DenyAll_BlocksNonSafeTools(t *testing.T) {
 func TestPermission_SafeToolGoesThroughPermission(t *testing.T) {
 	testutil.RegisterFakeTool(t, "Read", "file contents")
 
-	ag, _ := testutil.NewTestAgentWithPermission(t, testutil.DenyAllPermission(),
+	ag := testutil.NewTestAgentWithPermission(t, testutil.DenyAllPermission(),
 		testutil.ToolCallResponse("Read", "tc1", `{}`),
 		testutil.EndTurnResponse("done"),
 	)

--- a/tests/integration/testutil/core_helpers.go
+++ b/tests/integration/testutil/core_helpers.go
@@ -57,7 +57,7 @@ func stubClient(d *aitest.Driver) func([]core.Message) (*ai.Client, error) {
 
 // NewTestAgent creates a core.Agent backed by a model with queued responses.
 // All globally registered tools (including dynamically registered fakes) are included.
-func NewTestAgent(t *testing.T, responses ...llm.CompletionResponse) (core.Agent, *aitest.Driver) {
+func NewTestAgent(t *testing.T, responses ...llm.CompletionResponse) core.Agent {
 	t.Helper()
 	fakeLLM := queued(responses)
 	cwd := t.TempDir()
@@ -68,7 +68,7 @@ func NewTestAgent(t *testing.T, responses ...llm.CompletionResponse) (core.Agent
 		Tools:  buildAllRegisteredTools(cwd),
 
 		MaxSteps: 100,
-	}), fakeLLM
+	})
 }
 
 // buildAllRegisteredTools creates a core.Tools wrapping ALL tools in the global registry,
@@ -90,7 +90,7 @@ func buildAllRegisteredTools(cwd string) core.Tools {
 }
 
 // NewTestAgentWithPermission creates a core.Agent with a permission function wrapping tools.
-func NewTestAgentWithPermission(t *testing.T, permFn perm.PermissionFunc, responses ...llm.CompletionResponse) (core.Agent, *aitest.Driver) {
+func NewTestAgentWithPermission(t *testing.T, permFn perm.PermissionFunc, responses ...llm.CompletionResponse) core.Agent {
 	t.Helper()
 	fakeLLM := queued(responses)
 	cwd := t.TempDir()
@@ -101,11 +101,11 @@ func NewTestAgentWithPermission(t *testing.T, permFn perm.PermissionFunc, respon
 		Tools:    buildAllRegisteredTools(cwd),
 		Gate:     tool.Permission(permFn),
 		MaxSteps: 100,
-	}), fakeLLM
+	})
 }
 
 // NewTestAgentWithMaxSteps creates a core.Agent with a specific max steps limit.
-func NewTestAgentWithMaxSteps(t *testing.T, maxSteps int, responses ...llm.CompletionResponse) (core.Agent, *aitest.Driver) {
+func NewTestAgentWithMaxSteps(t *testing.T, maxSteps int, responses ...llm.CompletionResponse) core.Agent {
 	t.Helper()
 	fakeLLM := queued(responses)
 	cwd := t.TempDir()
@@ -116,7 +116,7 @@ func NewTestAgentWithMaxSteps(t *testing.T, maxSteps int, responses ...llm.Compl
 		Tools:  buildAllRegisteredTools(cwd),
 
 		MaxSteps: maxSteps,
-	}), fakeLLM
+	})
 }
 
 // BuildTestTools adapts all globally registered tools into a core.Tools for use in tests.


### PR DESCRIPTION
A ponytail pass over #507's own diff. Net -98 lines, no behavior change: `/mcp`
prints the same counts, and the model sees the same schemas.

- **Resources and prompts are counts.** They were read, converted into
  `MCPResource`/`MCPPrompt`, copied under the lock — and every consumer in the
  repo, integration suite included, called `len()` on them. Two ints; the
  structs are gone.
- **A tool's schema is not a round trip.** It arrived as `any`, was marshalled
  to JSON in the client, and was unmarshalled straight back to `map[string]any`
  by its only reader in the registry. `parseInputSchema` goes with it, and
  `types.go` no longer imports `encoding/json`.
- **`sdkSession` was an identity wrapper.** `core.Tool` is an alias for
  `sdkagent.Tool`, so `*sdkmcp.Client` satisfies `conn` unaided. The nil guard
  around `OnToolsChanged` went too — `Connect` passes a method value.
- **The test queue is `aitest.New`.** `selflearn.scripted` and
  `llm.mockLLMProvider` each rebuilt it with a mutex or an index plus an
  invented answer for running off the end; neither call site ever reached that
  answer. `mockLLMProvider` also pinned the stop reason to `end_turn` and
  dropped the queued response's own — the defect the `FakeDeltas` removal fixed,
  in a double that outlived it.
- `fakeSession.dead` and `.tools` are assigned by nothing; `NewTestAgent` and
  its siblings returned a driver all twelve callers discard.

`make lint` (0 issues, layercheck clean), `make format-check`, and `go test
-race ./...` pass.